### PR TITLE
Add support for DropletActions.Snapshot.

### DIFF
--- a/droplet_actions.go
+++ b/droplet_actions.go
@@ -20,6 +20,7 @@ type DropletActionsService interface {
 	Restore(int, int) (*Action, *Response, error)
 	Resize(int, string) (*Action, *Response, error)
 	Rename(int, string) (*Action, *Response, error)
+	Snapshot(int, string) (*Action, *Response, error)
 	doAction(int, *ActionRequest) (*Action, *Response, error)
 	Get(int, int) (*Action, *Response, error)
 	GetByURI(string) (*Action, *Response, error)
@@ -84,6 +85,16 @@ func (s *DropletActionsServiceOp) Resize(id int, sizeSlug string) (*Action, *Res
 // Rename a Droplet
 func (s *DropletActionsServiceOp) Rename(id int, name string) (*Action, *Response, error) {
 	requestType := "rename"
+	request := &ActionRequest{
+		"type": requestType,
+		"name": name,
+	}
+	return s.doAction(id, request)
+}
+
+// Snapshot a Droplet
+func (s *DropletActionsServiceOp) Snapshot(id int, name string) (*Action, *Response, error) {
+	requestType := "snapshot"
 	request := &ActionRequest{
 		"type": requestType,
 		"name": name,

--- a/droplet_actions_test.go
+++ b/droplet_actions_test.go
@@ -291,3 +291,36 @@ func TestDropletActions_Get(t *testing.T) {
 		t.Errorf("DropletActions.Get returned %+v, expected %+v", action, expected)
 	}
 }
+
+func TestDropletAction_Snapshot(t *testing.T) {
+	setup()
+	defer teardown()
+
+	request := &ActionRequest{
+		"type": "snapshot",
+		"name": "Image-Name",
+	}
+
+	mux.HandleFunc("/v2/droplets/1/actions", func(w http.ResponseWriter, r *http.Request) {
+		v := new(ActionRequest)
+		json.NewDecoder(r.Body).Decode(v)
+
+		testMethod(t, r, "POST")
+
+		if !reflect.DeepEqual(v, request) {
+			t.Errorf("Request body = %+v, expected %+v", v, request)
+		}
+
+		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
+	})
+
+	action, _, err := client.DropletActions.Snapshot(1, "Image-Name")
+	if err != nil {
+		t.Errorf("DropletActions.Snapshot returned error: %v", err)
+	}
+
+	expected := &Action{Status: "in-progress"}
+	if !reflect.DeepEqual(action, expected) {
+		t.Errorf("DropletActions.Snapshot returned %+v, expected %+v", action, expected)
+	}
+}

--- a/droplet_actions_test.go
+++ b/droplet_actions_test.go
@@ -272,26 +272,6 @@ func TestDropletAction_PowerCycle(t *testing.T) {
 	}
 }
 
-func TestDropletActions_Get(t *testing.T) {
-	setup()
-	defer teardown()
-
-	mux.HandleFunc("/v2/droplets/123/actions/456", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
-	})
-
-	action, _, err := client.DropletActions.Get(123, 456)
-	if err != nil {
-		t.Errorf("DropletActions.Get returned error: %v", err)
-	}
-
-	expected := &Action{Status: "in-progress"}
-	if !reflect.DeepEqual(action, expected) {
-		t.Errorf("DropletActions.Get returned %+v, expected %+v", action, expected)
-	}
-}
-
 func TestDropletAction_Snapshot(t *testing.T) {
 	setup()
 	defer teardown()
@@ -322,5 +302,25 @@ func TestDropletAction_Snapshot(t *testing.T) {
 	expected := &Action{Status: "in-progress"}
 	if !reflect.DeepEqual(action, expected) {
 		t.Errorf("DropletActions.Snapshot returned %+v, expected %+v", action, expected)
+	}
+}
+
+func TestDropletActions_Get(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/droplets/123/actions/456", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
+	})
+
+	action, _, err := client.DropletActions.Get(123, 456)
+	if err != nil {
+		t.Errorf("DropletActions.Get returned error: %v", err)
+	}
+
+	expected := &Action{Status: "in-progress"}
+	if !reflect.DeepEqual(action, expected) {
+		t.Errorf("DropletActions.Get returned %+v, expected %+v", action, expected)
 	}
 }


### PR DESCRIPTION
This is an old branch I had laying around from when I was first looking at godo and Actions requiring parameters were broken, cleaned up and rebased on master. It add support for taking snapshots.