### PR TITLE
Fix inability to list droplets with IPv6 addresses

### DIFF
--- a/droplets.go
+++ b/droplets.go
@@ -75,19 +75,31 @@ func (d DropletCreateRequest) String() string {
 
 // Networks represents the droplet's networks
 type Networks struct {
-	V4 []Network `json:"v4,omitempty"`
-	V6 []Network `json:"v6,omitempty"`
+	V4 []NetworkV4 `json:"v4,omitempty"`
+	V6 []NetworkV6 `json:"v6,omitempty"`
 }
 
-// Network represents a DigitalOcean Network
-type Network struct {
+// NetworkV4 represents a DigitalOcean IPv4 Network
+type NetworkV4 struct {
 	IPAddress string `json:"ip_address,omitempty"`
 	Netmask   string `json:"netmask,omitempty"`
 	Gateway   string `json:"gateway,omitempty"`
 	Type      string `json:"type,omitempty"`
 }
 
-func (n Network) String() string {
+func (n NetworkV4) String() string {
+	return Stringify(n)
+}
+
+// NetworkV6 represents a DigitalOcean IPv6 network.
+type NetworkV6 struct {
+	IPAddress string `json:"ip_address,omitempty"`
+	Netmask   int    `json:"netmask,omitempty"`
+	Gateway   string `json:"gateway,omitempty"`
+	Type      string `json:"type,omitempty"`
+}
+
+func (n NetworkV6) String() string {
 	return Stringify(n)
 }
 

--- a/droplets_test.go
+++ b/droplets_test.go
@@ -169,19 +169,32 @@ func TestDroplets_Destroy(t *testing.T) {
 	}
 }
 
-func TestNetwork_String(t *testing.T) {
-	network := &Network{
+func TestNetworkV4_String(t *testing.T) {
+	network := &NetworkV4{
 		IPAddress: "192.168.1.2",
 		Netmask:   "255.255.255.0",
 		Gateway:   "192.168.1.1",
 	}
 
 	stringified := network.String()
-	expected := `godo.Network{IPAddress:"192.168.1.2", Netmask:"255.255.255.0", Gateway:"192.168.1.1", Type:""}`
+	expected := `godo.NetworkV4{IPAddress:"192.168.1.2", Netmask:"255.255.255.0", Gateway:"192.168.1.1", Type:""}`
 	if expected != stringified {
-		t.Errorf("Distribution.String returned %+v, expected %+v", stringified, expected)
+		t.Errorf("NetworkV4.String returned %+v, expected %+v", stringified, expected)
 	}
 
+}
+
+func TestNetworkV6_String(t *testing.T) {
+	network := &NetworkV6{
+		IPAddress: "2604:A880:0800:0010:0000:0000:02DD:4001",
+		Netmask:   64,
+		Gateway:   "2604:A880:0800:0010:0000:0000:0000:0001",
+	}
+	stringified := network.String()
+	expected := `godo.NetworkV6{IPAddress:"2604:A880:0800:0010:0000:0000:02DD:4001", Netmask:64, Gateway:"2604:A880:0800:0010:0000:0000:0000:0001", Type:""}`
+	if expected != stringified {
+		t.Errorf("NetworkV6.String returned %+v, expected %+v", stringified, expected)
+	}
 }
 
 func TestDroplet_String(t *testing.T) {
@@ -208,13 +221,13 @@ func TestDroplet_String(t *testing.T) {
 		PriceHourly:  456,
 		Regions:      []string{"1", "2"},
 	}
-	network := &Network{
+	network := &NetworkV4{
 		IPAddress: "192.168.1.2",
 		Netmask:   "255.255.255.0",
 		Gateway:   "192.168.1.1",
 	}
 	networks := &Networks{
-		V4: []Network{*network},
+		V4: []NetworkV4{*network},
 	}
 
 	droplet := &Droplet{
@@ -235,7 +248,7 @@ func TestDroplet_String(t *testing.T) {
 	}
 
 	stringified := droplet.String()
-	expected := `godo.Droplet{ID:1, Name:"droplet", Memory:123, Vcpus:456, Disk:789, Region:godo.Region{Slug:"region", Name:"Region", Sizes:["1" "2"], Available:true}, Image:godo.Image{ID:1, Name:"Image", Distribution:"Ubuntu", Slug:"image", Public:true, Regions:["one" "two"]}, Size:godo.Size{Slug:"size", Memory:0, Vcpus:0, Disk:0, PriceMonthly:123, PriceHourly:456, Regions:["1" "2"]}, BackupIDs:[1], SnapshotIDs:[1], Locked:false, Status:"active", Networks:godo.Networks{V4:[godo.Network{IPAddress:"192.168.1.2", Netmask:"255.255.255.0", Gateway:"192.168.1.1", Type:""}]}, ActionIDs:[1], Created:""}`
+	expected := `godo.Droplet{ID:1, Name:"droplet", Memory:123, Vcpus:456, Disk:789, Region:godo.Region{Slug:"region", Name:"Region", Sizes:["1" "2"], Available:true}, Image:godo.Image{ID:1, Name:"Image", Distribution:"Ubuntu", Slug:"image", Public:true, Regions:["one" "two"]}, Size:godo.Size{Slug:"size", Memory:0, Vcpus:0, Disk:0, PriceMonthly:123, PriceHourly:456, Regions:["1" "2"]}, BackupIDs:[1], SnapshotIDs:[1], Locked:false, Status:"active", Networks:godo.Networks{V4:[godo.NetworkV4{IPAddress:"192.168.1.2", Netmask:"255.255.255.0", Gateway:"192.168.1.1", Type:""}]}, ActionIDs:[1], Created:""}`
 	if expected != stringified {
 		t.Errorf("Droplet.String returned %+v, expected %+v", stringified, expected)
 	}


### PR DESCRIPTION
This should fix #18 

The tl;dr of #18, is that the `Network.Netmask` field is a string, but depending on whether the interface is IPv4, or IPv6, the v2 API will return a different type for that field; (`string` for IPv4, `int` for IPv6). The reason for the splitting of the `Network` type into `NetworkV4` and `NetworkV6`, is so that everything unmarshals cleanly.

I have also added tests.