### PR TITLE
Omit an empty value for user data to serialize properly.

### DIFF
--- a/droplets.go
+++ b/droplets.go
@@ -99,7 +99,7 @@ type DropletCreateRequest struct {
 	Backups           bool                  `json:"backups"`
 	IPv6              bool                  `json:"ipv6"`
 	PrivateNetworking bool                  `json:"private_networking"`
-	UserData          string                `json:"user_data"`
+	UserData          string                `json:"user_data,omitempty"`
 }
 
 func (d DropletCreateRequest) String() string {

--- a/droplets_test.go
+++ b/droplets_test.go
@@ -37,8 +37,8 @@ func TestDroplets_ListDropletsMultiplePages(t *testing.T) {
 
 		dr := dropletsRoot{
 			Droplets: []Droplet{
-				Droplet{ID: 1},
-				Droplet{ID: 2},
+				{ID: 1},
+				{ID: 2},
 			},
 			Links: &Links{
 				Pages: &Pages{Next: "http://example.com/v2/droplets/?page=2"},
@@ -135,7 +135,6 @@ func TestDroplets_Create(t *testing.T) {
 			"backups":            false,
 			"ipv6":               false,
 			"private_networking": false,
-			"user_data":          "",
 		}
 
 		var v map[string]interface{}

--- a/godo_test.go
+++ b/godo_test.go
@@ -85,7 +85,35 @@ func TestNewRequest(t *testing.T) {
 	inBody, outBody := &DropletCreateRequest{Name: "l"},
 		`{"name":"l","region":"","size":"","image":0,`+
 			`"ssh_keys":null,"backups":false,"ipv6":false,`+
-			`"private_networking":false,"user_data":""}`+"\n"
+			`"private_networking":false}`+"\n"
+	req, _ := c.NewRequest("GET", inURL, inBody)
+
+	// test relative URL was expanded
+	if req.URL.String() != outURL {
+		t.Errorf("NewRequest(%v) URL = %v, expected %v", inURL, req.URL, outURL)
+	}
+
+	// test body was JSON encoded
+	body, _ := ioutil.ReadAll(req.Body)
+	if string(body) != outBody {
+		t.Errorf("NewRequest(%v)Body = %v, expected %v", inBody, string(body), outBody)
+	}
+
+	// test default user-agent is attached to the request
+	userAgent := req.Header.Get("User-Agent")
+	if c.UserAgent != userAgent {
+		t.Errorf("NewRequest() User-Agent = %v, expected %v", userAgent, c.UserAgent)
+	}
+}
+
+func TestNewRequest_withUserData(t *testing.T) {
+	c := NewClient(nil)
+
+	inURL, outURL := "/foo", defaultBaseURL+"foo"
+	inBody, outBody := &DropletCreateRequest{Name: "l", UserData: "u"},
+		`{"name":"l","region":"","size":"","image":0,`+
+			`"ssh_keys":null,"backups":false,"ipv6":false,`+
+			`"private_networking":false,"user_data":"u"}`+"\n"
 	req, _ := c.NewRequest("GET", inURL, inBody)
 
 	// test relative URL was expanded


### PR DESCRIPTION
#### What does this fix?
An issue with creating a droplet where the region does not support user data. Due to the string being empty and not sent as null it will cause the server to error out telling the user that the region does not support user data.

#### Source
Described in more detail by an issue created by me. #37 