### PR TITLE
Add example for WaitForActive()

### DIFF
--- a/util/droplet_test.go
+++ b/util/droplet_test.go
@@ -1,0 +1,26 @@
+package util
+
+import (
+	"code.google.com/p/goauth2/oauth"
+
+	"github.com/digitalocean/godo"
+)
+
+func ExampleWaitForActive() {
+	// build client
+	pat := "mytoken"
+	t := &oauth.Transport{
+		Token: &oauth.Token{AccessToken: pat},
+	}
+
+	client := godo.NewClient(t.Client())
+
+	// create your droplet and retrieve the create action uri
+	uri := "https://api.digitalocean.com/v2/actions/xxxxxxxx"
+
+	// block until until the action is complete
+	err := WaitForActive(client, uri)
+	if err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
WaitForActive can be used to block until a droplet comes up. Adding
an example of its usage.