### PR TITLE
Add size slug to droplet

### DIFF
--- a/droplets.go
+++ b/droplets.go
@@ -41,6 +41,7 @@ type Droplet struct {
 	Region      *Region   `json:"region,omitempty"`
 	Image       *Image    `json:"image,omitempty"`
 	Size        *Size     `json:"size,omitempty"`
+	SizeSlug    string    `json:"size_slug,omitempty"`
 	BackupIDs   []int     `json:"backup_ids,omitempty"`
 	SnapshotIDs []int     `json:"snapshot_ids,omitempty"`
 	Locked      bool      `json:"locked,bool,omitempty"`

--- a/droplets_test.go
+++ b/droplets_test.go
@@ -360,10 +360,11 @@ func TestDroplet_String(t *testing.T) {
 		Locked:      false,
 		Status:      "active",
 		Networks:    networks,
+		SizeSlug:    "1gb",
 	}
 
 	stringified := droplet.String()
-	expected := `godo.Droplet{ID:1, Name:"droplet", Memory:123, Vcpus:456, Disk:789, Region:godo.Region{Slug:"region", Name:"Region", Sizes:["1" "2"], Available:true}, Image:godo.Image{ID:1, Name:"Image", Type:"snapshot", Distribution:"Ubuntu", Slug:"image", Public:true, Regions:["one" "two"], MinDiskSize:20}, Size:godo.Size{Slug:"size", Memory:0, Vcpus:0, Disk:0, PriceMonthly:123, PriceHourly:456, Regions:["1" "2"], Available:false, Transfer:0}, BackupIDs:[1], SnapshotIDs:[1], Locked:false, Status:"active", Networks:godo.Networks{V4:[godo.NetworkV4{IPAddress:"192.168.1.2", Netmask:"255.255.255.0", Gateway:"192.168.1.1", Type:""}]}, ActionIDs:[1], Created:""}`
+	expected := `godo.Droplet{ID:1, Name:"droplet", Memory:123, Vcpus:456, Disk:789, Region:godo.Region{Slug:"region", Name:"Region", Sizes:["1" "2"], Available:true}, Image:godo.Image{ID:1, Name:"Image", Type:"snapshot", Distribution:"Ubuntu", Slug:"image", Public:true, Regions:["one" "two"], MinDiskSize:20}, Size:godo.Size{Slug:"size", Memory:0, Vcpus:0, Disk:0, PriceMonthly:123, PriceHourly:456, Regions:["1" "2"], Available:false, Transfer:0}, SizeSlug:"1gb", BackupIDs:[1], SnapshotIDs:[1], Locked:false, Status:"active", Networks:godo.Networks{V4:[godo.NetworkV4{IPAddress:"192.168.1.2", Netmask:"255.255.255.0", Gateway:"192.168.1.1", Type:""}]}, ActionIDs:[1], Created:""}`
 	if expected != stringified {
 		t.Errorf("Droplet.String returned %+v, expected %+v", stringified, expected)
 	}


### PR DESCRIPTION
Adds missing size_slug to the Droplet struct.

Fixes #21