### PR TITLE
Standardize on returning objects, not the json roots.

### DIFF
--- a/account.go
+++ b/account.go
@@ -4,7 +4,7 @@ package godo
 // endpoints of the Digital Ocean API
 // See: https://developers.digitalocean.com/documentation/v2/#account
 type AccountService interface {
-	Get() (*AccountRoot, *Response, error)
+	Get() (*Account, *Response, error)
 }
 
 // AccountServiceOp handles communication with the Account related methods of
@@ -23,7 +23,7 @@ type Account struct {
 	EmailVerified bool   `json:"email_verified,omitempty"`
 }
 
-type AccountRoot struct {
+type accountRoot struct {
 	Account *Account `json:"account"`
 }
 
@@ -32,7 +32,7 @@ func (r Account) String() string {
 }
 
 // Get DigitalOcean account info
-func (s *AccountServiceOp) Get() (*AccountRoot, *Response, error) {
+func (s *AccountServiceOp) Get() (*Account, *Response, error) {
 	path := "v2/account"
 
 	req, err := s.client.NewRequest("GET", path, nil)
@@ -40,11 +40,11 @@ func (s *AccountServiceOp) Get() (*AccountRoot, *Response, error) {
 		return nil, nil, err
 	}
 
-	root := new(AccountRoot)
+	root := new(accountRoot)
 	resp, err := s.client.Do(req, root)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return root, resp, err
+	return root.Account, resp, err
 }

--- a/account_test.go
+++ b/account_test.go
@@ -31,8 +31,8 @@ func TestAccountGet(t *testing.T) {
 		t.Errorf("Account.Get returned error: %v", err)
 	}
 
-	expected := &AccountRoot{Account: &Account{DropletLimit: 25, Email: "sammy@digitalocean.com",
-		UUID: "b6fr89dbf6d9156cace5f3c78dc9851d957381ef", EmailVerified: true}}
+	expected := &Account{DropletLimit: 25, Email: "sammy@digitalocean.com",
+		UUID: "b6fr89dbf6d9156cace5f3c78dc9851d957381ef", EmailVerified: true}
 	if !reflect.DeepEqual(acct, expected) {
 		t.Errorf("Account.Get returned %+v, expected %+v", acct, expected)
 	}

--- a/domains.go
+++ b/domains.go
@@ -9,8 +9,8 @@ const domainsBasePath = "v2/domains"
 // https://developers.digitalocean.com/documentation/v2#domain-records
 type DomainsService interface {
 	List(*ListOptions) ([]Domain, *Response, error)
-	Get(string) (*DomainRoot, *Response, error)
-	Create(*DomainCreateRequest) (*DomainRoot, *Response, error)
+	Get(string) (*Domain, *Response, error)
+	Create(*DomainCreateRequest) (*Domain, *Response, error)
 	Delete(string) (*Response, error)
 
 	Records(string, *ListOptions) ([]DomainRecord, *Response, error)
@@ -35,8 +35,8 @@ type Domain struct {
 	ZoneFile string `json:"zone_file"`
 }
 
-// DomainRoot represents a response from the Digital Ocean API
-type DomainRoot struct {
+// domainRoot represents a response from the Digital Ocean API
+type domainRoot struct {
 	Domain *Domain `json:"domain"`
 }
 
@@ -52,12 +52,12 @@ type DomainCreateRequest struct {
 }
 
 // DomainRecordRoot is the root of an individual Domain Record response
-type DomainRecordRoot struct {
+type domainRecordRoot struct {
 	DomainRecord *DomainRecord `json:"domain_record"`
 }
 
 // DomainRecordsRoot is the root of a group of Domain Record responses
-type DomainRecordsRoot struct {
+type domainRecordsRoot struct {
 	DomainRecords []DomainRecord `json:"domain_records"`
 	Links         *Links         `json:"links"`
 }
@@ -113,7 +113,7 @@ func (s DomainsServiceOp) List(opt *ListOptions) ([]Domain, *Response, error) {
 }
 
 // Get individual domain
-func (s *DomainsServiceOp) Get(name string) (*DomainRoot, *Response, error) {
+func (s *DomainsServiceOp) Get(name string) (*Domain, *Response, error) {
 	path := fmt.Sprintf("%s/%s", domainsBasePath, name)
 
 	req, err := s.client.NewRequest("GET", path, nil)
@@ -121,31 +121,34 @@ func (s *DomainsServiceOp) Get(name string) (*DomainRoot, *Response, error) {
 		return nil, nil, err
 	}
 
-	root := new(DomainRoot)
+	root := new(domainRoot)
 	resp, err := s.client.Do(req, root)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return root, resp, err
+	return root.Domain, resp, err
 }
 
 // Create a new domain
-func (s *DomainsServiceOp) Create(createRequest *DomainCreateRequest) (*DomainRoot, *Response, error) {
+func (s *DomainsServiceOp) Create(createRequest *DomainCreateRequest) (*Domain, *Response, error) {
 	path := domainsBasePath
 
 	req, err := s.client.NewRequest("POST", path, createRequest)
 	if err != nil {
+		fmt.Printf("1Something bad happened: %+v", err)
 		return nil, nil, err
 	}
 
-	root := new(DomainRoot)
+	root := new(domainRoot)
 	resp, err := s.client.Do(req, root)
+	fmt.Printf("%+v\n", resp)
 	if err != nil {
+		fmt.Printf("2Something bad happened: %+v", err)
 		return nil, resp, err
 	}
-
-	return root, resp, err
+	fmt.Printf("%+v\n", root)
+	return root.Domain, resp, err
 }
 
 // Delete domain
@@ -185,7 +188,7 @@ func (s *DomainsServiceOp) Records(domain string, opt *ListOptions) ([]DomainRec
 		return nil, nil, err
 	}
 
-	root := new(DomainRecordsRoot)
+	root := new(domainRecordsRoot)
 	resp, err := s.client.Do(req, root)
 	if err != nil {
 		return nil, resp, err
@@ -206,7 +209,7 @@ func (s *DomainsServiceOp) Record(domain string, id int) (*DomainRecord, *Respon
 		return nil, nil, err
 	}
 
-	record := new(DomainRecordRoot)
+	record := new(domainRecordRoot)
 	resp, err := s.client.Do(req, record)
 	if err != nil {
 		return nil, resp, err
@@ -261,7 +264,7 @@ func (s *DomainsServiceOp) CreateRecord(
 		return nil, nil, err
 	}
 
-	d := new(DomainRecordRoot)
+	d := new(domainRecordRoot)
 	resp, err := s.client.Do(req, d)
 	if err != nil {
 		return nil, resp, err

--- a/domains_test.go
+++ b/domains_test.go
@@ -90,7 +90,7 @@ func TestDomains_GetDomain(t *testing.T) {
 		t.Errorf("domain.Get returned error: %v", err)
 	}
 
-	expected := &DomainRoot{Domain: &Domain{Name: "example.com"}}
+	expected := &Domain{Name: "example.com"}
 	if !reflect.DeepEqual(domains, expected) {
 		t.Errorf("domains.Get returned %+v, expected %+v", domains, expected)
 	}
@@ -117,13 +117,7 @@ func TestDomains_Create(t *testing.T) {
 			t.Errorf("Request body = %+v, expected %+v", v, createRequest)
 		}
 
-		dr := DomainRoot{&Domain{Name: v.Name}}
-		b, err := json.Marshal(dr)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		fmt.Fprint(w, string(b))
+		fmt.Fprint(w, `{"domain":{"name":"example.com"}}`)
 	})
 
 	domain, _, err := client.Domains.Create(createRequest)
@@ -131,7 +125,7 @@ func TestDomains_Create(t *testing.T) {
 		t.Errorf("Domains.Create returned error: %v", err)
 	}
 
-	expected := &DomainRoot{Domain: &Domain{Name: "example.com"}}
+	expected := &Domain{Name: "example.com"}
 	if !reflect.DeepEqual(domain, expected) {
 		t.Errorf("Domains.Create returned %+v, expected %+v", domain, expected)
 	}

--- a/droplet_actions.go
+++ b/droplet_actions.go
@@ -103,7 +103,7 @@ func (s *DropletActionsServiceOp) Rename(id int, name string) (*Action, *Respons
 	return s.doAction(id, request)
 }
 
-// Snapshot a Droplet
+// Snapshot a Droplet.
 func (s *DropletActionsServiceOp) Snapshot(id int, name string) (*Action, *Response, error) {
 	requestType := "snapshot"
 	request := &ActionRequest{
@@ -113,49 +113,49 @@ func (s *DropletActionsServiceOp) Snapshot(id int, name string) (*Action, *Respo
 	return s.doAction(id, request)
 }
 
-// Disable backups for a droplet
+// DisableBackups disables backups for a droplet.
 func (s *DropletActionsServiceOp) DisableBackups(id int) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "disable_backups"}
 	return s.doAction(id, request)
 }
 
-// Reset password for a droplet
+// PasswordReset resets the password for a droplet.
 func (s *DropletActionsServiceOp) PasswordReset(id int) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "password_reset"}
 	return s.doAction(id, request)
 }
 
-// Rebuild droplet from an image with a given id
+// RebuildByImageID rebuilds a droplet droplet from an image with a given id.
 func (s *DropletActionsServiceOp) RebuildByImageID(id, imageID int) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "rebuild", "image": imageID}
 	return s.doAction(id, request)
 }
 
-// Rebuild a droplet from an image with a given slug
+// RebuildByImageSlug rebuilds a droplet from an image with a given slug.
 func (s *DropletActionsServiceOp) RebuildByImageSlug(id int, slug string) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "rebuild", "image": slug}
 	return s.doAction(id, request)
 }
 
-// Change a droplet kernel
+// ChangeKernel changes the kernel for a droplet.
 func (s *DropletActionsServiceOp) ChangeKernel(id, kernelID int) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "change_kernel", "kernel": kernelID}
 	return s.doAction(id, request)
 }
 
-// Enable IPv6 on a droplet
+// EnableIPv6 enables IPv6 for a droplet.
 func (s *DropletActionsServiceOp) EnableIPv6(id int) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "enable_ipv6"}
 	return s.doAction(id, request)
 }
 
-// Enable private networking on a droplet
+// EnablePrivateNetworking enables private networking for a droplet.
 func (s *DropletActionsServiceOp) EnablePrivateNetworking(id int) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "enable_private_networking"}
 	return s.doAction(id, request)
 }
 
-// Upgrade a droplet
+// Upgrade a droplet.
 func (s *DropletActionsServiceOp) Upgrade(id int) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "upgrade"}
 	return s.doAction(id, request)

--- a/droplets.go
+++ b/droplets.go
@@ -12,8 +12,8 @@ const dropletBasePath = "v2/droplets"
 // See: https://developers.digitalocean.com/documentation/v2#droplets
 type DropletsService interface {
 	List(*ListOptions) ([]Droplet, *Response, error)
-	Get(int) (*DropletRoot, *Response, error)
-	Create(*DropletCreateRequest) (*DropletRoot, *Response, error)
+	Get(int) (*Droplet, *Response, error)
+	Create(*DropletCreateRequest) (*Droplet, *Response, error)
 	Delete(int) (*Response, error)
 	Kernels(int, *ListOptions) ([]Kernel, *Response, error)
 	Snapshots(int, *ListOptions) ([]Image, *Response, error)
@@ -64,7 +64,7 @@ func (d Droplet) String() string {
 }
 
 // DropletRoot represents a Droplet root
-type DropletRoot struct {
+type dropletRoot struct {
 	Droplet *Droplet `json:"droplet"`
 	Links   *Links   `json:"links,omitempty"`
 }
@@ -190,7 +190,7 @@ func (s *DropletsServiceOp) List(opt *ListOptions) ([]Droplet, *Response, error)
 }
 
 // Get individual droplet
-func (s *DropletsServiceOp) Get(dropletID int) (*DropletRoot, *Response, error) {
+func (s *DropletsServiceOp) Get(dropletID int) (*Droplet, *Response, error) {
 	path := fmt.Sprintf("%s/%d", dropletBasePath, dropletID)
 
 	req, err := s.client.NewRequest("GET", path, nil)
@@ -198,17 +198,17 @@ func (s *DropletsServiceOp) Get(dropletID int) (*DropletRoot, *Response, error) 
 		return nil, nil, err
 	}
 
-	root := new(DropletRoot)
+	root := new(dropletRoot)
 	resp, err := s.client.Do(req, root)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return root, resp, err
+	return root.Droplet, resp, err
 }
 
 // Create droplet
-func (s *DropletsServiceOp) Create(createRequest *DropletCreateRequest) (*DropletRoot, *Response, error) {
+func (s *DropletsServiceOp) Create(createRequest *DropletCreateRequest) (*Droplet, *Response, error) {
 	path := dropletBasePath
 
 	req, err := s.client.NewRequest("POST", path, createRequest)
@@ -216,7 +216,7 @@ func (s *DropletsServiceOp) Create(createRequest *DropletCreateRequest) (*Drople
 		return nil, nil, err
 	}
 
-	root := new(DropletRoot)
+	root := new(dropletRoot)
 	resp, err := s.client.Do(req, root)
 	if err != nil {
 		return nil, resp, err
@@ -225,7 +225,7 @@ func (s *DropletsServiceOp) Create(createRequest *DropletCreateRequest) (*Drople
 		resp.Links = l
 	}
 
-	return root, resp, err
+	return root.Droplet, resp, err
 }
 
 // Delete droplet

--- a/droplets.go
+++ b/droplets.go
@@ -95,12 +95,14 @@ type DropletCreateImage struct {
 	Slug string
 }
 
+// MarshalJSON returns either the slug or id of the image. It returns the id
+// if the slug is empty.
 func (d DropletCreateImage) MarshalJSON() ([]byte, error) {
 	if d.Slug != "" {
 		return json.Marshal(d.Slug)
-	} else {
-		return json.Marshal(d.ID)
 	}
+
+	return json.Marshal(d.ID)
 }
 
 // DropletCreateSSHKey identifies a SSH Key for the create request. It prefers fingerprint over ID.
@@ -109,12 +111,14 @@ type DropletCreateSSHKey struct {
 	Fingerprint string
 }
 
+// MarshalJSON returns either the fingerprint or id of the ssh key. It returns
+// the id if the fingerprint is empty.
 func (d DropletCreateSSHKey) MarshalJSON() ([]byte, error) {
 	if d.Fingerprint != "" {
 		return json.Marshal(d.Fingerprint)
-	} else {
-		return json.Marshal(d.ID)
 	}
+
+	return json.Marshal(d.ID)
 }
 
 // DropletCreateRequest represents a request to create a droplet.
@@ -242,7 +246,7 @@ func (s *DropletsServiceOp) Delete(dropletID int) (*Response, error) {
 	return resp, err
 }
 
-// List droplet available kernels
+// Kernels lists kernels available for a droplet.
 func (s *DropletsServiceOp) Kernels(dropletID int, opt *ListOptions) ([]Kernel, *Response, error) {
 	path := fmt.Sprintf("%s/%d/kernels", dropletBasePath, dropletID)
 	path, err := addOptions(path, opt)
@@ -264,7 +268,7 @@ func (s *DropletsServiceOp) Kernels(dropletID int, opt *ListOptions) ([]Kernel, 
 	return root.Kernels, resp, err
 }
 
-// List droplet actions
+// Actions lists the actions for a droplet.
 func (s *DropletsServiceOp) Actions(dropletID int, opt *ListOptions) ([]Action, *Response, error) {
 	path := fmt.Sprintf("%s/%d/actions", dropletBasePath, dropletID)
 	path, err := addOptions(path, opt)
@@ -289,7 +293,7 @@ func (s *DropletsServiceOp) Actions(dropletID int, opt *ListOptions) ([]Action, 
 	return root.Actions, resp, err
 }
 
-// List droplet backups
+// Backups lists the backups for a droplet.
 func (s *DropletsServiceOp) Backups(dropletID int, opt *ListOptions) ([]Image, *Response, error) {
 	path := fmt.Sprintf("%s/%d/backups", dropletBasePath, dropletID)
 	path, err := addOptions(path, opt)
@@ -314,7 +318,7 @@ func (s *DropletsServiceOp) Backups(dropletID int, opt *ListOptions) ([]Image, *
 	return root.Backups, resp, err
 }
 
-// List droplet snapshots
+// Snapshots lists the snapshots available for a droplet.
 func (s *DropletsServiceOp) Snapshots(dropletID int, opt *ListOptions) ([]Image, *Response, error) {
 	path := fmt.Sprintf("%s/%d/snapshots", dropletBasePath, dropletID)
 	path, err := addOptions(path, opt)
@@ -339,7 +343,7 @@ func (s *DropletsServiceOp) Snapshots(dropletID int, opt *ListOptions) ([]Image,
 	return root.Snapshots, resp, err
 }
 
-// List droplet neighbors
+// Neighbors lists the neighbors for a droplet.
 func (s *DropletsServiceOp) Neighbors(dropletID int) ([]Droplet, *Response, error) {
 	path := fmt.Sprintf("%s/%d/neighbors", dropletBasePath, dropletID)
 

--- a/droplets_test.go
+++ b/droplets_test.go
@@ -106,7 +106,7 @@ func TestDroplets_GetDroplet(t *testing.T) {
 		t.Errorf("Droplet.Get returned error: %v", err)
 	}
 
-	expected := &DropletRoot{Droplet: &Droplet{ID: 12345}}
+	expected := &Droplet{ID: 12345}
 	if !reflect.DeepEqual(droplets, expected) {
 		t.Errorf("Droplets.Get returned %+v, expected %+v", droplets, expected)
 	}
@@ -150,12 +150,12 @@ func TestDroplets_Create(t *testing.T) {
 		fmt.Fprintf(w, `{"droplet":{"id":1}, "links":{"actions": [{"id": 1, "href": "http://example.com", "rel": "create"}]}}`)
 	})
 
-	root, resp, err := client.Droplets.Create(createRequest)
+	droplet, resp, err := client.Droplets.Create(createRequest)
 	if err != nil {
 		t.Errorf("Droplets.Create returned error: %v", err)
 	}
 
-	if id := root.Droplet.ID; id != 1 {
+	if id := droplet.ID; id != 1 {
 		t.Errorf("expected id '%d', received '%d'", 1, id)
 	}
 

--- a/godo_test.go
+++ b/godo_test.go
@@ -430,24 +430,24 @@ func TestAddOptions(t *testing.T) {
 			continue
 		}
 
-		gotUrl, err := url.Parse(got)
+		gotURL, err := url.Parse(got)
 		if err != nil {
 			t.Errorf("%q unable to parse returned URL", c.name)
 			continue
 		}
 
-		expectedUrl, err := url.Parse(c.expected)
+		expectedURL, err := url.Parse(c.expected)
 		if err != nil {
 			t.Errorf("%q unable to parse expected URL", c.name)
 			continue
 		}
 
-		if g, e := gotUrl.Path, expectedUrl.Path; g != e {
-			t.Errorf("%q path = %q; expected %q", g, e)
+		if g, e := gotURL.Path, expectedURL.Path; g != e {
+			t.Errorf("%q path = %q; expected %q", c.name, g, e)
 			continue
 		}
 
-		if g, e := gotUrl.Query(), expectedUrl.Query(); !reflect.DeepEqual(g, e) {
+		if g, e := gotURL.Query(), expectedURL.Query(); !reflect.DeepEqual(g, e) {
 			t.Errorf("%q query = %#v; expected %#v", c.name, g, e)
 			continue
 		}

--- a/images.go
+++ b/images.go
@@ -61,40 +61,40 @@ func (i Image) String() string {
 	return Stringify(i)
 }
 
-// List all images
+// List lists all the images available.
 func (s *ImagesServiceOp) List(opt *ListOptions) ([]Image, *Response, error) {
 	return s.list(opt, nil)
 }
 
-// List distribution images
+// ListDistribution lists all the distribution images.
 func (s *ImagesServiceOp) ListDistribution(opt *ListOptions) ([]Image, *Response, error) {
 	listOpt := listImageOptions{Type: "distribution"}
 	return s.list(opt, &listOpt)
 }
 
-// List application images
+// ListApplication lists all the application images.
 func (s *ImagesServiceOp) ListApplication(opt *ListOptions) ([]Image, *Response, error) {
 	listOpt := listImageOptions{Type: "application"}
 	return s.list(opt, &listOpt)
 }
 
-// List user images
+// ListUser lists all the user images.
 func (s *ImagesServiceOp) ListUser(opt *ListOptions) ([]Image, *Response, error) {
 	listOpt := listImageOptions{Private: true}
 	return s.list(opt, &listOpt)
 }
 
-// Get individual image by id
+// GetByID retrieves an image by id.
 func (s *ImagesServiceOp) GetByID(imageID int) (*Image, *Response, error) {
 	return s.get(interface{}(imageID))
 }
 
-// Get individual image by slug
+// GetBySlug retrieves an image by slug.
 func (s *ImagesServiceOp) GetBySlug(slug string) (*Image, *Response, error) {
 	return s.get(interface{}(slug))
 }
 
-// Update an image name
+// Update an image name.
 func (s *ImagesServiceOp) Update(imageID int, updateRequest *ImageUpdateRequest) (*Image, *Response, error) {
 	path := fmt.Sprintf("%s/%d", imageBasePath, imageID)
 	req, err := s.client.NewRequest("PUT", path, updateRequest)
@@ -111,7 +111,7 @@ func (s *ImagesServiceOp) Update(imageID int, updateRequest *ImageUpdateRequest)
 	return &root.Image, resp, err
 }
 
-// Delete image
+// Delete an image.
 func (s *ImagesServiceOp) Delete(imageID int) (*Response, error) {
 	path := fmt.Sprintf("%s/%d", imageBasePath, imageID)
 

--- a/keys.go
+++ b/keys.go
@@ -127,7 +127,7 @@ func (s *KeysServiceOp) Create(createRequest *KeyCreateRequest) (*Key, *Response
 	return &root.SSHKey, resp, err
 }
 
-// Update a key name by ID
+// UpdateByID updates a key name by ID.
 func (s *KeysServiceOp) UpdateByID(keyID int, updateRequest *KeyUpdateRequest) (*Key, *Response, error) {
 	path := fmt.Sprintf("%s/%d", keysBasePath, keyID)
 	req, err := s.client.NewRequest("PUT", path, updateRequest)
@@ -144,7 +144,7 @@ func (s *KeysServiceOp) UpdateByID(keyID int, updateRequest *KeyUpdateRequest) (
 	return &root.SSHKey, resp, err
 }
 
-// Update a key name by fingerprint
+// UpdateByFingerprint updates a key name by fingerprint.
 func (s *KeysServiceOp) UpdateByFingerprint(fingerprint string, updateRequest *KeyUpdateRequest) (*Key, *Response, error) {
 	path := fmt.Sprintf("%s/%s", keysBasePath, fingerprint)
 	req, err := s.client.NewRequest("PUT", path, updateRequest)

--- a/links.go
+++ b/links.go
@@ -80,6 +80,7 @@ func pageForURL(urlText string) (int, error) {
 	return page, nil
 }
 
+// Get a link action by id.
 func (la *LinkAction) Get(client *Client) (*Action, *Response, error) {
 	return client.Actions.Get(la.ID)
 }


### PR DESCRIPTION
This standardizes the client responses to return objects, not json document roots. 
* We're inconsistent about this. We already return the object from DropletActionsService, ImageActionsService, DomainsService.CreateRecord, KeysService
* Implementers don't care about the root object, they care about the object. Even when the user needs access to the Links, that's accessible via the `resp` variable returned, as is shown in the example in the readme.

cc @aybabtme @macb @bryanl @nickvanw @jphines