### PR TITLE
Don't drop existing query keys

### DIFF
--- a/godo.go
+++ b/godo.go
@@ -113,18 +113,24 @@ func addOptions(s string, opt interface{}) (string, error) {
 		return s, nil
 	}
 
-	u, err := url.Parse(s)
+	origURL, err := url.Parse(s)
 	if err != nil {
 		return s, err
 	}
 
-	qv, err := query.Values(opt)
+	origValues := origURL.Query()
+
+	newValues, err := query.Values(opt)
 	if err != nil {
 		return s, err
 	}
 
-	u.RawQuery = qv.Encode()
-	return u.String(), nil
+	for k, v := range newValues {
+		origValues[k] = v
+	}
+
+	origURL.RawQuery = origValues.Encode()
+	return origURL.String(), nil
 }
 
 // NewClient returns a new Digital Ocean API client.

--- a/godo_test.go
+++ b/godo_test.go
@@ -393,3 +393,63 @@ func TestDo_completion_callback(t *testing.T) {
 		t.Errorf("expected response to contain %v, Response = %v", expected, completedResp)
 	}
 }
+
+func TestAddOptions(t *testing.T) {
+	cases := []struct {
+		name     string
+		path     string
+		expected string
+		opts     *ListOptions
+		isErr    bool
+	}{
+		{
+			name:     "add options",
+			path:     "/action",
+			expected: "/action?page=1",
+			opts:     &ListOptions{Page: 1},
+			isErr:    false,
+		},
+		{
+			name:     "add options with existing parameters",
+			path:     "/action?scope=all",
+			expected: "/action?page=1&scope=all",
+			opts:     &ListOptions{Page: 1},
+			isErr:    false,
+		},
+	}
+
+	for _, c := range cases {
+		got, err := addOptions(c.path, c.opts)
+		if c.isErr && err == nil {
+			t.Errorf("%q expected error but none was encountered", c.name)
+			continue
+		}
+
+		if !c.isErr && err != nil {
+			t.Errorf("%q unexpected error: %v", c.name, err)
+			continue
+		}
+
+		gotUrl, err := url.Parse(got)
+		if err != nil {
+			t.Errorf("%q unable to parse returned URL", c.name)
+			continue
+		}
+
+		expectedUrl, err := url.Parse(c.expected)
+		if err != nil {
+			t.Errorf("%q unable to parse expected URL", c.name)
+			continue
+		}
+
+		if g, e := gotUrl.Path, expectedUrl.Path; g != e {
+			t.Errorf("%q path = %q; expected %q", g, e)
+			continue
+		}
+
+		if g, e := gotUrl.Query(), expectedUrl.Query(); !reflect.DeepEqual(g, e) {
+			t.Errorf("%q query = %#v; expected %#v", c.name, g, e)
+			continue
+		}
+	}
+}


### PR DESCRIPTION
When adding options to a path, don't drop existing keys. This will enable image pagination when there is a type key to work. The bug was trying to addOptions to an existing path with query values. Previously if a path `/path?type=alpha` was passed, key `page=2` would be appeneded, but `type=alpha` would be dropped.