### PR TITLE
Remove unexported item from interface

### DIFF
--- a/droplet_actions.go
+++ b/droplet_actions.go
@@ -29,7 +29,6 @@ type DropletActionsService interface {
 	EnableIPv6(int) (*Action, *Response, error)
 	EnablePrivateNetworking(int) (*Action, *Response, error)
 	Upgrade(int) (*Action, *Response, error)
-	doAction(int, *ActionRequest) (*Action, *Response, error)
 	Get(int, int) (*Action, *Response, error)
 	GetByURI(string) (*Action, *Response, error)
 }


### PR DESCRIPTION
Removing unexported `doAction` from DropletActionsService interface because it makes DropletActionsService impossible to mock.