### PR TITLE
Add Created attribute to Image

### DIFF
--- a/droplets_test.go
+++ b/droplets_test.go
@@ -328,6 +328,7 @@ func TestDroplet_String(t *testing.T) {
 		Public:       true,
 		Regions:      []string{"one", "two"},
 		MinDiskSize:  20,
+		Created:      "2013-11-27T09:24:55Z",
 	}
 
 	size := &Size{
@@ -364,7 +365,7 @@ func TestDroplet_String(t *testing.T) {
 	}
 
 	stringified := droplet.String()
-	expected := `godo.Droplet{ID:1, Name:"droplet", Memory:123, Vcpus:456, Disk:789, Region:godo.Region{Slug:"region", Name:"Region", Sizes:["1" "2"], Available:true}, Image:godo.Image{ID:1, Name:"Image", Type:"snapshot", Distribution:"Ubuntu", Slug:"image", Public:true, Regions:["one" "two"], MinDiskSize:20}, Size:godo.Size{Slug:"size", Memory:0, Vcpus:0, Disk:0, PriceMonthly:123, PriceHourly:456, Regions:["1" "2"], Available:false, Transfer:0}, SizeSlug:"1gb", BackupIDs:[1], SnapshotIDs:[1], Locked:false, Status:"active", Networks:godo.Networks{V4:[godo.NetworkV4{IPAddress:"192.168.1.2", Netmask:"255.255.255.0", Gateway:"192.168.1.1", Type:""}]}, ActionIDs:[1], Created:""}`
+	expected := `godo.Droplet{ID:1, Name:"droplet", Memory:123, Vcpus:456, Disk:789, Region:godo.Region{Slug:"region", Name:"Region", Sizes:["1" "2"], Available:true}, Image:godo.Image{ID:1, Name:"Image", Type:"snapshot", Distribution:"Ubuntu", Slug:"image", Public:true, Regions:["one" "two"], MinDiskSize:20, Created:"2013-11-27T09:24:55Z"}, Size:godo.Size{Slug:"size", Memory:0, Vcpus:0, Disk:0, PriceMonthly:123, PriceHourly:456, Regions:["1" "2"], Available:false, Transfer:0}, SizeSlug:"1gb", BackupIDs:[1], SnapshotIDs:[1], Locked:false, Status:"active", Networks:godo.Networks{V4:[godo.NetworkV4{IPAddress:"192.168.1.2", Netmask:"255.255.255.0", Gateway:"192.168.1.1", Type:""}]}, ActionIDs:[1], Created:""}`
 	if expected != stringified {
 		t.Errorf("Droplet.String returned %+v, expected %+v", stringified, expected)
 	}

--- a/images.go
+++ b/images.go
@@ -36,6 +36,7 @@ type Image struct {
 	Public       bool     `json:"public,omitempty"`
 	Regions      []string `json:"regions,omitempty"`
 	MinDiskSize  int      `json:"min_disk_size,omitempty"`
+	Created      string   `json:"created_at,omitempty"`
 }
 
 // ImageUpdateRequest represents a request to update an image.

--- a/images_test.go
+++ b/images_test.go
@@ -251,10 +251,11 @@ func TestImage_String(t *testing.T) {
 		Public:       true,
 		Regions:      []string{"one", "two"},
 		MinDiskSize:  20,
+		Created:      "2013-11-27T09:24:55Z",
 	}
 
 	stringified := image.String()
-	expected := `godo.Image{ID:1, Name:"Image", Type:"snapshot", Distribution:"Ubuntu", Slug:"image", Public:true, Regions:["one" "two"], MinDiskSize:20}`
+	expected := `godo.Image{ID:1, Name:"Image", Type:"snapshot", Distribution:"Ubuntu", Slug:"image", Public:true, Regions:["one" "two"], MinDiskSize:20, Created:"2013-11-27T09:24:55Z"}`
 	if expected != stringified {
 		t.Errorf("Image.String returned %+v, expected %+v", stringified, expected)
 	}


### PR DESCRIPTION
Add standard `created_at` attribute exposed from [Images API](https://developers.digitalocean.com/documentation/v2/#images).