### PR TITLE
Add List action for Floating IP Actions

### DIFF
--- a/floating_ips_actions.go
+++ b/floating_ips_actions.go
@@ -9,6 +9,7 @@ type FloatingIPActionsService interface {
 	Assign(ip string, dropletID int) (*Action, *Response, error)
 	Unassign(ip string) (*Action, *Response, error)
 	Get(ip string, actionID int) (*Action, *Response, error)
+	List(ip string) ([]Action, *Response, error)
 }
 
 // FloatingIPActionsServiceOp handles communication with the floating IPs
@@ -36,6 +37,12 @@ func (s *FloatingIPActionsServiceOp) Unassign(ip string) (*Action, *Response, er
 func (s *FloatingIPActionsServiceOp) Get(ip string, actionID int) (*Action, *Response, error) {
 	path := fmt.Sprintf("%s/%d", floatingIPActionPath(ip), actionID)
 	return s.get(path)
+}
+
+// List the actions for a particular floating IP.
+func (s *FloatingIPActionsServiceOp) List(ip string) ([]Action, *Response, error) {
+	path := floatingIPActionPath(ip)
+	return s.list(path)
 }
 
 func (s *FloatingIPActionsServiceOp) doAction(ip string, request *ActionRequest) (*Action, *Response, error) {
@@ -68,6 +75,21 @@ func (s *FloatingIPActionsServiceOp) get(path string) (*Action, *Response, error
 	}
 
 	return &root.Event, resp, err
+}
+
+func (s *FloatingIPActionsServiceOp) list(path string) ([]Action, *Response, error) {
+	req, err := s.client.NewRequest("GET", path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(actionsRoot)
+	resp, err := s.client.Do(req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Actions, resp, err
 }
 
 func floatingIPActionPath(ip string) string {

--- a/floating_ips_actions_test.go
+++ b/floating_ips_actions_test.go
@@ -97,3 +97,23 @@ func TestFloatingIPsActions_Get(t *testing.T) {
 		t.Errorf("FloatingIPsActions.Get returned %+v, expected %+v", action, expected)
 	}
 }
+
+func TestFloatingIPsActions_List(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/floating_ips/192.168.0.1/actions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprintf(w, `{"actions":[{"status":"in-progress"}]}`)
+	})
+
+	actions, _, err := client.FloatingIPActions.List("192.168.0.1")
+	if err != nil {
+		t.Errorf("FloatingIPsActions.List returned error: %v", err)
+	}
+
+	expected := []Action{Action{Status: "in-progress"}}
+	if !reflect.DeepEqual(actions, expected) {
+		t.Errorf("FloatingIPsActions.List returned %+v, expected %+v", actions, expected)
+	}
+}


### PR DESCRIPTION
Adds the missing `List` action for Floating IP Actions. This GET endpoint is also missing from the API docs (I opened feedback [here](https://digitalocean.uservoice.com/forums/136585-digitalocean/suggestions/10798782-the-get-action-on-floating-ip-ip-actions-should)) .

This is also blocking hashicorp/terraform#3748 , so an expedient review would be appreciated! Test is included.