### PR TITLE
remove JSON invalid encoding test

### DIFF
--- a/godo_test.go
+++ b/godo_test.go
@@ -1,7 +1,6 @@
 package godo
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -132,22 +131,6 @@ func TestNewRequest_withUserData(t *testing.T) {
 	userAgent := req.Header.Get("User-Agent")
 	if c.UserAgent != userAgent {
 		t.Errorf("NewRequest() User-Agent = %v, expected %v", userAgent, c.UserAgent)
-	}
-}
-
-func TestNewRequest_invalidJSON(t *testing.T) {
-	c := NewClient(nil)
-
-	type T struct {
-		A map[int]interface{}
-	}
-	_, err := c.NewRequest("GET", "/", &T{})
-
-	if err == nil {
-		t.Error("Expected error to be returned.")
-	}
-	if err, ok := err.(*json.UnsupportedTypeError); !ok {
-		t.Errorf("Expected a JSON error; got %#v.", err)
 	}
 }
 


### PR DESCRIPTION
> Go 1.7 adds support for maps using keys with integer types: the
> encoding uses a quoted decimal representation as the JSON key.

in: https://tip.golang.org/doc/go1.7, under encoding/json