### PR TITLE
organizes dropletCreateImage MarshalJSON declaration

### DIFF
--- a/droplets.go
+++ b/droplets.go
@@ -147,6 +147,16 @@ type DropletCreateImage struct {
 	Slug string
 }
 
+// MarshalJSON returns either the slug or id of the image. It returns the id
+// if the slug is empty.
+func (d DropletCreateImage) MarshalJSON() ([]byte, error) {
+	if d.Slug != "" {
+		return json.Marshal(d.Slug)
+	}
+
+	return json.Marshal(d.ID)
+}
+
 // DropletCreateVolume identifies a volume to attach for the create request. It
 // prefers Name over ID,
 type DropletCreateVolume struct {
@@ -166,16 +176,6 @@ func (d DropletCreateVolume) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
 		ID string `json:"id"`
 	}{ID: d.ID})
-}
-
-// MarshalJSON returns either the slug or id of the image. It returns the id
-// if the slug is empty.
-func (d DropletCreateImage) MarshalJSON() ([]byte, error) {
-	if d.Slug != "" {
-		return json.Marshal(d.Slug)
-	}
-
-	return json.Marshal(d.ID)
 }
 
 // DropletCreateSSHKey identifies a SSH Key for the create request. It prefers fingerprint over ID.


### PR DESCRIPTION
Moves `dropletCreateImage` receiver's `MarshalJSON` to be under the `struct` definition for easier visual groking.

- [x] Code should be go fmt compliant.
- ~~Types, structs and funcs should be documented.~~ N/A, no code addition
- [x] Tests pass.