### PR TITLE
Add Tags attribute to droplet create

### DIFF
--- a/droplets.go
+++ b/droplets.go
@@ -206,6 +206,7 @@ type DropletCreateRequest struct {
 	PrivateNetworking bool                  `json:"private_networking"`
 	UserData          string                `json:"user_data,omitempty"`
 	Volumes           []DropletCreateVolume `json:"volumes,omitempty"`
+	Tags              []string              `json:"tags"`
 }
 
 // DropletMultiCreateRequest is a request to create multiple droplets.
@@ -219,6 +220,7 @@ type DropletMultiCreateRequest struct {
 	IPv6              bool                  `json:"ipv6"`
 	PrivateNetworking bool                  `json:"private_networking"`
 	UserData          string                `json:"user_data,omitempty"`
+	Tags              []string              `json:"tags"`
 }
 
 func (d DropletCreateRequest) String() string {

--- a/droplets_test.go
+++ b/droplets_test.go
@@ -152,6 +152,7 @@ func TestDroplets_Create(t *testing.T) {
 			{ID: "hello-im-another-volume"},
 			{Name: "hello-im-still-a-volume", ID: "should be ignored due to Name"},
 		},
+		Tags: []string{"one", "two"},
 	}
 
 	mux.HandleFunc("/v2/droplets", func(w http.ResponseWriter, r *http.Request) {
@@ -169,6 +170,7 @@ func TestDroplets_Create(t *testing.T) {
 				map[string]interface{}{"id": "hello-im-another-volume"},
 				map[string]interface{}{"name": "hello-im-still-a-volume"},
 			},
+			"tags": []interface{}{"one", "two"},
 		}
 
 		var v map[string]interface{}
@@ -209,6 +211,7 @@ func TestDroplets_CreateMultiple(t *testing.T) {
 		Image: DropletCreateImage{
 			ID: 1,
 		},
+		Tags: []string{"one", "two"},
 	}
 
 	mux.HandleFunc("/v2/droplets", func(w http.ResponseWriter, r *http.Request) {
@@ -221,6 +224,7 @@ func TestDroplets_CreateMultiple(t *testing.T) {
 			"backups":            false,
 			"ipv6":               false,
 			"private_networking": false,
+			"tags":               []interface{}{"one", "two"},
 		}
 
 		var v map[string]interface{}

--- a/godo_test.go
+++ b/godo_test.go
@@ -133,7 +133,7 @@ func TestNewRequest(t *testing.T) {
 	inBody, outBody := &DropletCreateRequest{Name: "l"},
 		`{"name":"l","region":"","size":"","image":0,`+
 			`"ssh_keys":null,"backups":false,"ipv6":false,`+
-			`"private_networking":false}`+"\n"
+			`"private_networking":false,"tags":null}`+"\n"
 	req, _ := c.NewRequest("GET", inURL, inBody)
 
 	// test relative URL was expanded
@@ -161,7 +161,7 @@ func TestNewRequest_withUserData(t *testing.T) {
 	inBody, outBody := &DropletCreateRequest{Name: "l", UserData: "u"},
 		`{"name":"l","region":"","size":"","image":0,`+
 			`"ssh_keys":null,"backups":false,"ipv6":false,`+
-			`"private_networking":false,"user_data":"u"}`+"\n"
+			`"private_networking":false,"user_data":"u","tags":null}`+"\n"
 	req, _ := c.NewRequest("GET", inURL, inBody)
 
 	// test relative URL was expanded


### PR DESCRIPTION
This allows `tags` to be sent in droplet create requests.

https://developers.digitalocean.com/documentation/changelog/api-v2/tagging-in-droplet-create/

@daveworth @hugocorbucci 