### PR TITLE
Fix droplet JSON to support VolumeIDs

### DIFF
--- a/droplets.go
+++ b/droplets.go
@@ -55,7 +55,7 @@ type Droplet struct {
 	Created     string    `json:"created_at,omitempty"`
 	Kernel      *Kernel   `json:"kernel,omitempty"`
 	Tags        []string  `json:"tags,ommitempty"`
-	VolumeIDs   []string  `json:"volumes"`
+	VolumeIDs   []string  `json:"volume_ids"`
 }
 
 // PublicIPv4 returns the public IPv4 address for the Droplet.

--- a/droplets.go
+++ b/droplets.go
@@ -54,7 +54,7 @@ type Droplet struct {
 	Networks    *Networks `json:"networks,omitempty"`
 	Created     string    `json:"created_at,omitempty"`
 	Kernel      *Kernel   `json:"kernel,omitempty"`
-	Tags        []string  `json:"tags,ommitempty"`
+	Tags        []string  `json:"tags,omitempty"`
 	VolumeIDs   []string  `json:"volume_ids"`
 }
 


### PR DESCRIPTION
Hey there! I'm @ UC Berkeley working on Quilt, a distributed application deployment engine, (https://github.com/NetSys/quilt/). I'm currently adding cloud provider support for DigitalOcean, which is how I found this bug.

The Droplet struct had the wrong JSON key for VolumeIDs, so volumes would not be reflected in a Droplet query.