### PR TITLE
add context.Context to all calls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 
 go:
-  - 1.3
-  - 1.4
+  - 1.7
   - tip

--- a/account.go
+++ b/account.go
@@ -1,10 +1,12 @@
 package godo
 
+import "context"
+
 // AccountService is an interface for interfacing with the Account
 // endpoints of the DigitalOcean API
 // See: https://developers.digitalocean.com/documentation/v2/#account
 type AccountService interface {
-	Get() (*Account, *Response, error)
+	Get(context.Context) (*Account, *Response, error)
 }
 
 // AccountServiceOp handles communication with the Account related methods of
@@ -35,10 +37,11 @@ func (r Account) String() string {
 }
 
 // Get DigitalOcean account info
-func (s *AccountServiceOp) Get() (*Account, *Response, error) {
+func (s *AccountServiceOp) Get(ctx context.Context) (*Account, *Response, error) {
+
 	path := "v2/account"
 
-	req, err := s.client.NewRequest("GET", path, nil)
+	req, err := s.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/account_test.go
+++ b/account_test.go
@@ -27,7 +27,7 @@ func TestAccountGet(t *testing.T) {
 		fmt.Fprint(w, response)
 	})
 
-	acct, _, err := client.Account.Get()
+	acct, _, err := client.Account.Get(ctx)
 	if err != nil {
 		t.Errorf("Account.Get returned error: %v", err)
 	}

--- a/action.go
+++ b/action.go
@@ -1,6 +1,9 @@
 package godo
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 const (
 	actionsBasePath = "v2/actions"
@@ -15,8 +18,8 @@ const (
 // ActionsService handles communction with action related methods of the
 // DigitalOcean API: https://developers.digitalocean.com/documentation/v2#actions
 type ActionsService interface {
-	List(*ListOptions) ([]Action, *Response, error)
-	Get(int) (*Action, *Response, error)
+	List(context.Context, *ListOptions) ([]Action, *Response, error)
+	Get(context.Context, int) (*Action, *Response, error)
 }
 
 // ActionsServiceOp handles communition with the image action related methods of the
@@ -50,14 +53,14 @@ type Action struct {
 }
 
 // List all actions
-func (s *ActionsServiceOp) List(opt *ListOptions) ([]Action, *Response, error) {
+func (s *ActionsServiceOp) List(ctx context.Context, opt *ListOptions) ([]Action, *Response, error) {
 	path := actionsBasePath
 	path, err := addOptions(path, opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", path, nil)
+	req, err := s.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -75,13 +78,13 @@ func (s *ActionsServiceOp) List(opt *ListOptions) ([]Action, *Response, error) {
 }
 
 // Get an action by ID.
-func (s *ActionsServiceOp) Get(id int) (*Action, *Response, error) {
+func (s *ActionsServiceOp) Get(ctx context.Context, id int) (*Action, *Response, error) {
 	if id < 1 {
 		return nil, nil, NewArgError("id", "cannot be less than 1")
 	}
 
 	path := fmt.Sprintf("%s/%d", actionsBasePath, id)
-	req, err := s.client.NewRequest("GET", path, nil)
+	req, err := s.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/action_test.go
+++ b/action_test.go
@@ -17,7 +17,7 @@ func TestAction_List(t *testing.T) {
 		testMethod(t, r, "GET")
 	})
 
-	actions, _, err := client.Actions.List(nil)
+	actions, _, err := client.Actions.List(ctx, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -37,7 +37,7 @@ func TestAction_ListActionMultiplePages(t *testing.T) {
 		testMethod(t, r, "GET")
 	})
 
-	_, resp, err := client.Actions.List(nil)
+	_, resp, err := client.Actions.List(ctx, nil)
 	if err != nil {
 		t.Fatal(nil)
 	}
@@ -68,7 +68,7 @@ func TestAction_RetrievePageByNumber(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	_, resp, err := client.Actions.List(opt)
+	_, resp, err := client.Actions.List(ctx, opt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +85,7 @@ func TestAction_Get(t *testing.T) {
 		testMethod(t, r, "GET")
 	})
 
-	action, _, err := client.Actions.Get(12345)
+	action, _, err := client.Actions.Get(ctx, 12345)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/certificates.go
+++ b/certificates.go
@@ -1,16 +1,19 @@
 package godo
 
-import "path"
+import (
+	"context"
+	"path"
+)
 
 const certificatesBasePath = "/v2/certificates"
 
 // CertificatesService is an interface for managing certificates with the DigitalOcean API.
 // See: https://developers.digitalocean.com/documentation/v2/#certificates
 type CertificatesService interface {
-	Get(cID string) (*Certificate, *Response, error)
-	List(opt *ListOptions) ([]Certificate, *Response, error)
-	Create(cr *CertificateRequest) (*Certificate, *Response, error)
-	Delete(cID string) (*Response, error)
+	Get(context.Context, string) (*Certificate, *Response, error)
+	List(context.Context, *ListOptions) ([]Certificate, *Response, error)
+	Create(context.Context, *CertificateRequest) (*Certificate, *Response, error)
+	Delete(context.Context, string) (*Response, error)
 }
 
 // Certificate represents a DigitalOcean certificate configuration.
@@ -47,10 +50,10 @@ type CertificatesServiceOp struct {
 var _ CertificatesService = &CertificatesServiceOp{}
 
 // Get an existing certificate by its identifier.
-func (c *CertificatesServiceOp) Get(cID string) (*Certificate, *Response, error) {
+func (c *CertificatesServiceOp) Get(ctx context.Context, cID string) (*Certificate, *Response, error) {
 	urlStr := path.Join(certificatesBasePath, cID)
 
-	req, err := c.client.NewRequest("GET", urlStr, nil)
+	req, err := c.client.NewRequest(ctx, "GET", urlStr, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -65,13 +68,13 @@ func (c *CertificatesServiceOp) Get(cID string) (*Certificate, *Response, error)
 }
 
 // List all certificates.
-func (c *CertificatesServiceOp) List(opt *ListOptions) ([]Certificate, *Response, error) {
+func (c *CertificatesServiceOp) List(ctx context.Context, opt *ListOptions) ([]Certificate, *Response, error) {
 	urlStr, err := addOptions(certificatesBasePath, opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := c.client.NewRequest("GET", urlStr, nil)
+	req, err := c.client.NewRequest(ctx, "GET", urlStr, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -89,8 +92,8 @@ func (c *CertificatesServiceOp) List(opt *ListOptions) ([]Certificate, *Response
 }
 
 // Create a new certificate with provided configuration.
-func (c *CertificatesServiceOp) Create(cr *CertificateRequest) (*Certificate, *Response, error) {
-	req, err := c.client.NewRequest("POST", certificatesBasePath, cr)
+func (c *CertificatesServiceOp) Create(ctx context.Context, cr *CertificateRequest) (*Certificate, *Response, error) {
+	req, err := c.client.NewRequest(ctx, "POST", certificatesBasePath, cr)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -105,10 +108,10 @@ func (c *CertificatesServiceOp) Create(cr *CertificateRequest) (*Certificate, *R
 }
 
 // Delete a certificate by its identifier.
-func (c *CertificatesServiceOp) Delete(cID string) (*Response, error) {
+func (c *CertificatesServiceOp) Delete(ctx context.Context, cID string) (*Response, error) {
 	urlStr := path.Join(certificatesBasePath, cID)
 
-	req, err := c.client.NewRequest("DELETE", urlStr, nil)
+	req, err := c.client.NewRequest(ctx, "DELETE", urlStr, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/certificates_test.go
+++ b/certificates_test.go
@@ -59,7 +59,7 @@ func TestCertificates_Get(t *testing.T) {
 		fmt.Fprint(w, certJSONResponse)
 	})
 
-	certificate, _, err := client.Certificates.Get(cID)
+	certificate, _, err := client.Certificates.Get(ctx, cID)
 	if err != nil {
 		t.Errorf("Certificates.Get returned error: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestCertificates_List(t *testing.T) {
 		fmt.Fprint(w, certsJSONResponse)
 	})
 
-	certificates, _, err := client.Certificates.List(nil)
+	certificates, _, err := client.Certificates.List(ctx, nil)
 
 	if err != nil {
 		t.Errorf("Certificates.List returned error: %v", err)
@@ -136,7 +136,7 @@ func TestCertificates_Create(t *testing.T) {
 		fmt.Fprint(w, certJSONResponse)
 	})
 
-	certificate, _, err := client.Certificates.Create(createRequest)
+	certificate, _, err := client.Certificates.Create(ctx, createRequest)
 	if err != nil {
 		t.Errorf("Certificates.Create returned error: %v", err)
 	}
@@ -163,7 +163,7 @@ func TestCertificates_Delete(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Certificates.Delete(cID)
+	_, err := client.Certificates.Delete(ctx, cID)
 
 	if err != nil {
 		t.Errorf("Certificates.Delete returned error: %v", err)

--- a/domains.go
+++ b/domains.go
@@ -1,6 +1,9 @@
 package godo
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 const domainsBasePath = "v2/domains"
 
@@ -8,16 +11,16 @@ const domainsBasePath = "v2/domains"
 // See: https://developers.digitalocean.com/documentation/v2#domains and
 // https://developers.digitalocean.com/documentation/v2#domain-records
 type DomainsService interface {
-	List(*ListOptions) ([]Domain, *Response, error)
-	Get(string) (*Domain, *Response, error)
-	Create(*DomainCreateRequest) (*Domain, *Response, error)
-	Delete(string) (*Response, error)
+	List(context.Context, *ListOptions) ([]Domain, *Response, error)
+	Get(context.Context, string) (*Domain, *Response, error)
+	Create(context.Context, *DomainCreateRequest) (*Domain, *Response, error)
+	Delete(context.Context, string) (*Response, error)
 
-	Records(string, *ListOptions) ([]DomainRecord, *Response, error)
-	Record(string, int) (*DomainRecord, *Response, error)
-	DeleteRecord(string, int) (*Response, error)
-	EditRecord(string, int, *DomainRecordEditRequest) (*DomainRecord, *Response, error)
-	CreateRecord(string, *DomainRecordEditRequest) (*DomainRecord, *Response, error)
+	Records(context.Context, string, *ListOptions) ([]DomainRecord, *Response, error)
+	Record(context.Context, string, int) (*DomainRecord, *Response, error)
+	DeleteRecord(context.Context, string, int) (*Response, error)
+	EditRecord(context.Context, string, int, *DomainRecordEditRequest) (*DomainRecord, *Response, error)
+	CreateRecord(context.Context, string, *DomainRecordEditRequest) (*DomainRecord, *Response, error)
 }
 
 // DomainsServiceOp handles communication with the domain related methods of the
@@ -88,14 +91,14 @@ func (d Domain) String() string {
 }
 
 // List all domains.
-func (s DomainsServiceOp) List(opt *ListOptions) ([]Domain, *Response, error) {
+func (s DomainsServiceOp) List(ctx context.Context, opt *ListOptions) ([]Domain, *Response, error) {
 	path := domainsBasePath
 	path, err := addOptions(path, opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", path, nil)
+	req, err := s.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -113,14 +116,14 @@ func (s DomainsServiceOp) List(opt *ListOptions) ([]Domain, *Response, error) {
 }
 
 // Get individual domain. It requires a non-empty domain name.
-func (s *DomainsServiceOp) Get(name string) (*Domain, *Response, error) {
+func (s *DomainsServiceOp) Get(ctx context.Context, name string) (*Domain, *Response, error) {
 	if len(name) < 1 {
 		return nil, nil, NewArgError("name", "cannot be an empty string")
 	}
 
 	path := fmt.Sprintf("%s/%s", domainsBasePath, name)
 
-	req, err := s.client.NewRequest("GET", path, nil)
+	req, err := s.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -135,14 +138,14 @@ func (s *DomainsServiceOp) Get(name string) (*Domain, *Response, error) {
 }
 
 // Create a new domain
-func (s *DomainsServiceOp) Create(createRequest *DomainCreateRequest) (*Domain, *Response, error) {
+func (s *DomainsServiceOp) Create(ctx context.Context, createRequest *DomainCreateRequest) (*Domain, *Response, error) {
 	if createRequest == nil {
 		return nil, nil, NewArgError("createRequest", "cannot be nil")
 	}
 
 	path := domainsBasePath
 
-	req, err := s.client.NewRequest("POST", path, createRequest)
+	req, err := s.client.NewRequest(ctx, "POST", path, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -156,14 +159,14 @@ func (s *DomainsServiceOp) Create(createRequest *DomainCreateRequest) (*Domain, 
 }
 
 // Delete domain
-func (s *DomainsServiceOp) Delete(name string) (*Response, error) {
+func (s *DomainsServiceOp) Delete(ctx context.Context, name string) (*Response, error) {
 	if len(name) < 1 {
 		return nil, NewArgError("name", "cannot be an empty string")
 	}
 
 	path := fmt.Sprintf("%s/%s", domainsBasePath, name)
 
-	req, err := s.client.NewRequest("DELETE", path, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -184,7 +187,7 @@ func (d DomainRecordEditRequest) String() string {
 }
 
 // Records returns a slice of DomainRecords for a domain
-func (s *DomainsServiceOp) Records(domain string, opt *ListOptions) ([]DomainRecord, *Response, error) {
+func (s *DomainsServiceOp) Records(ctx context.Context, domain string, opt *ListOptions) ([]DomainRecord, *Response, error) {
 	if len(domain) < 1 {
 		return nil, nil, NewArgError("domain", "cannot be an empty string")
 	}
@@ -195,7 +198,7 @@ func (s *DomainsServiceOp) Records(domain string, opt *ListOptions) ([]DomainRec
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", path, nil)
+	req, err := s.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -213,7 +216,7 @@ func (s *DomainsServiceOp) Records(domain string, opt *ListOptions) ([]DomainRec
 }
 
 // Record returns the record id from a domain
-func (s *DomainsServiceOp) Record(domain string, id int) (*DomainRecord, *Response, error) {
+func (s *DomainsServiceOp) Record(ctx context.Context, domain string, id int) (*DomainRecord, *Response, error) {
 	if len(domain) < 1 {
 		return nil, nil, NewArgError("domain", "cannot be an empty string")
 	}
@@ -224,7 +227,7 @@ func (s *DomainsServiceOp) Record(domain string, id int) (*DomainRecord, *Respon
 
 	path := fmt.Sprintf("%s/%s/records/%d", domainsBasePath, domain, id)
 
-	req, err := s.client.NewRequest("GET", path, nil)
+	req, err := s.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -239,7 +242,7 @@ func (s *DomainsServiceOp) Record(domain string, id int) (*DomainRecord, *Respon
 }
 
 // DeleteRecord deletes a record from a domain identified by id
-func (s *DomainsServiceOp) DeleteRecord(domain string, id int) (*Response, error) {
+func (s *DomainsServiceOp) DeleteRecord(ctx context.Context, domain string, id int) (*Response, error) {
 	if len(domain) < 1 {
 		return nil, NewArgError("domain", "cannot be an empty string")
 	}
@@ -250,7 +253,7 @@ func (s *DomainsServiceOp) DeleteRecord(domain string, id int) (*Response, error
 
 	path := fmt.Sprintf("%s/%s/records/%d", domainsBasePath, domain, id)
 
-	req, err := s.client.NewRequest("DELETE", path, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -261,7 +264,7 @@ func (s *DomainsServiceOp) DeleteRecord(domain string, id int) (*Response, error
 }
 
 // EditRecord edits a record using a DomainRecordEditRequest
-func (s *DomainsServiceOp) EditRecord(
+func (s *DomainsServiceOp) EditRecord(ctx context.Context,
 	domain string,
 	id int,
 	editRequest *DomainRecordEditRequest,
@@ -280,7 +283,7 @@ func (s *DomainsServiceOp) EditRecord(
 
 	path := fmt.Sprintf("%s/%s/records/%d", domainsBasePath, domain, id)
 
-	req, err := s.client.NewRequest("PUT", path, editRequest)
+	req, err := s.client.NewRequest(ctx, "PUT", path, editRequest)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -295,7 +298,7 @@ func (s *DomainsServiceOp) EditRecord(
 }
 
 // CreateRecord creates a record using a DomainRecordEditRequest
-func (s *DomainsServiceOp) CreateRecord(
+func (s *DomainsServiceOp) CreateRecord(ctx context.Context,
 	domain string,
 	createRequest *DomainRecordEditRequest) (*DomainRecord, *Response, error) {
 	if len(domain) < 1 {
@@ -307,7 +310,7 @@ func (s *DomainsServiceOp) CreateRecord(
 	}
 
 	path := fmt.Sprintf("%s/%s/records", domainsBasePath, domain)
-	req, err := s.client.NewRequest("POST", path, createRequest)
+	req, err := s.client.NewRequest(ctx, "POST", path, createRequest)
 
 	if err != nil {
 		return nil, nil, err

--- a/domains_test.go
+++ b/domains_test.go
@@ -17,7 +17,7 @@ func TestDomains_ListDomains(t *testing.T) {
 		fmt.Fprint(w, `{"domains": [{"name":"foo.com"},{"name":"bar.com"}]}`)
 	})
 
-	domains, _, err := client.Domains.List(nil)
+	domains, _, err := client.Domains.List(ctx, nil)
 	if err != nil {
 		t.Errorf("Domains.List returned error: %v", err)
 	}
@@ -37,7 +37,7 @@ func TestDomains_ListDomainsMultiplePages(t *testing.T) {
 		fmt.Fprint(w, `{"domains": [{"id":1},{"id":2}], "links":{"pages":{"next":"http://example.com/v2/domains/?page=2"}}}`)
 	})
 
-	_, resp, err := client.Domains.List(nil)
+	_, resp, err := client.Domains.List(ctx, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,7 +68,7 @@ func TestDomains_RetrievePageByNumber(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	_, resp, err := client.Domains.List(opt)
+	_, resp, err := client.Domains.List(ctx, opt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +85,7 @@ func TestDomains_GetDomain(t *testing.T) {
 		fmt.Fprint(w, `{"domain":{"name":"example.com"}}`)
 	})
 
-	domains, _, err := client.Domains.Get("example.com")
+	domains, _, err := client.Domains.Get(ctx, "example.com")
 	if err != nil {
 		t.Errorf("domain.Get returned error: %v", err)
 	}
@@ -120,7 +120,7 @@ func TestDomains_Create(t *testing.T) {
 		fmt.Fprint(w, `{"domain":{"name":"example.com"}}`)
 	})
 
-	domain, _, err := client.Domains.Create(createRequest)
+	domain, _, err := client.Domains.Create(ctx, createRequest)
 	if err != nil {
 		t.Errorf("Domains.Create returned error: %v", err)
 	}
@@ -139,7 +139,7 @@ func TestDomains_Destroy(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Domains.Delete("example.com")
+	_, err := client.Domains.Delete(ctx, "example.com")
 	if err != nil {
 		t.Errorf("Domains.Delete returned error: %v", err)
 	}
@@ -154,7 +154,7 @@ func TestDomains_AllRecordsForDomainName(t *testing.T) {
 		fmt.Fprint(w, `{"domain_records":[{"id":1},{"id":2}]}`)
 	})
 
-	records, _, err := client.Domains.Records("example.com", nil)
+	records, _, err := client.Domains.Records(ctx, "example.com", nil)
 	if err != nil {
 		t.Errorf("Domains.List returned error: %v", err)
 	}
@@ -179,7 +179,7 @@ func TestDomains_AllRecordsForDomainName_PerPage(t *testing.T) {
 	})
 
 	dro := &ListOptions{PerPage: 2}
-	records, _, err := client.Domains.Records("example.com", dro)
+	records, _, err := client.Domains.Records(ctx, "example.com", dro)
 	if err != nil {
 		t.Errorf("Domains.List returned error: %v", err)
 	}
@@ -199,7 +199,7 @@ func TestDomains_GetRecordforDomainName(t *testing.T) {
 		fmt.Fprint(w, `{"domain_record":{"id":1}}`)
 	})
 
-	record, _, err := client.Domains.Record("example.com", 1)
+	record, _, err := client.Domains.Record(ctx, "example.com", 1)
 	if err != nil {
 		t.Errorf("Domains.GetRecord returned error: %v", err)
 	}
@@ -218,7 +218,7 @@ func TestDomains_DeleteRecordForDomainName(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Domains.DeleteRecord("example.com", 1)
+	_, err := client.Domains.DeleteRecord(ctx, "example.com", 1)
 	if err != nil {
 		t.Errorf("Domains.RecordDelete returned error: %v", err)
 	}
@@ -254,7 +254,7 @@ func TestDomains_CreateRecordForDomainName(t *testing.T) {
 			fmt.Fprintf(w, `{"domain_record": {"id":1}}`)
 		})
 
-	record, _, err := client.Domains.CreateRecord("example.com", createRequest)
+	record, _, err := client.Domains.CreateRecord(ctx, "example.com", createRequest)
 	if err != nil {
 		t.Errorf("Domains.CreateRecord returned error: %v", err)
 	}
@@ -293,7 +293,7 @@ func TestDomains_EditRecordForDomainName(t *testing.T) {
 		fmt.Fprintf(w, `{"id":1}`)
 	})
 
-	record, _, err := client.Domains.EditRecord("example.com", 1, editRequest)
+	record, _, err := client.Domains.EditRecord(ctx, "example.com", 1, editRequest)
 	if err != nil {
 		t.Errorf("Domains.EditRecord returned error: %v", err)
 	}

--- a/droplet_actions.go
+++ b/droplet_actions.go
@@ -1,6 +1,7 @@
 package godo
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 )
@@ -12,35 +13,35 @@ type ActionRequest map[string]interface{}
 // endpoints of the DigitalOcean API
 // See: https://developers.digitalocean.com/documentation/v2#droplet-actions
 type DropletActionsService interface {
-	Shutdown(int) (*Action, *Response, error)
-	ShutdownByTag(string) (*Action, *Response, error)
-	PowerOff(int) (*Action, *Response, error)
-	PowerOffByTag(string) (*Action, *Response, error)
-	PowerOn(int) (*Action, *Response, error)
-	PowerOnByTag(string) (*Action, *Response, error)
-	PowerCycle(int) (*Action, *Response, error)
-	PowerCycleByTag(string) (*Action, *Response, error)
-	Reboot(int) (*Action, *Response, error)
-	Restore(int, int) (*Action, *Response, error)
-	Resize(int, string, bool) (*Action, *Response, error)
-	Rename(int, string) (*Action, *Response, error)
-	Snapshot(int, string) (*Action, *Response, error)
-	SnapshotByTag(string, string) (*Action, *Response, error)
-	EnableBackups(int) (*Action, *Response, error)
-	EnableBackupsByTag(string) (*Action, *Response, error)
-	DisableBackups(int) (*Action, *Response, error)
-	DisableBackupsByTag(string) (*Action, *Response, error)
-	PasswordReset(int) (*Action, *Response, error)
-	RebuildByImageID(int, int) (*Action, *Response, error)
-	RebuildByImageSlug(int, string) (*Action, *Response, error)
-	ChangeKernel(int, int) (*Action, *Response, error)
-	EnableIPv6(int) (*Action, *Response, error)
-	EnableIPv6ByTag(string) (*Action, *Response, error)
-	EnablePrivateNetworking(int) (*Action, *Response, error)
-	EnablePrivateNetworkingByTag(string) (*Action, *Response, error)
-	Upgrade(int) (*Action, *Response, error)
-	Get(int, int) (*Action, *Response, error)
-	GetByURI(string) (*Action, *Response, error)
+	Shutdown(context.Context, int) (*Action, *Response, error)
+	ShutdownByTag(context.Context, string) (*Action, *Response, error)
+	PowerOff(context.Context, int) (*Action, *Response, error)
+	PowerOffByTag(context.Context, string) (*Action, *Response, error)
+	PowerOn(context.Context, int) (*Action, *Response, error)
+	PowerOnByTag(context.Context, string) (*Action, *Response, error)
+	PowerCycle(context.Context, int) (*Action, *Response, error)
+	PowerCycleByTag(context.Context, string) (*Action, *Response, error)
+	Reboot(context.Context, int) (*Action, *Response, error)
+	Restore(context.Context, int, int) (*Action, *Response, error)
+	Resize(context.Context, int, string, bool) (*Action, *Response, error)
+	Rename(context.Context, int, string) (*Action, *Response, error)
+	Snapshot(context.Context, int, string) (*Action, *Response, error)
+	SnapshotByTag(context.Context, string, string) (*Action, *Response, error)
+	EnableBackups(context.Context, int) (*Action, *Response, error)
+	EnableBackupsByTag(context.Context, string) (*Action, *Response, error)
+	DisableBackups(context.Context, int) (*Action, *Response, error)
+	DisableBackupsByTag(context.Context, string) (*Action, *Response, error)
+	PasswordReset(context.Context, int) (*Action, *Response, error)
+	RebuildByImageID(context.Context, int, int) (*Action, *Response, error)
+	RebuildByImageSlug(context.Context, int, string) (*Action, *Response, error)
+	ChangeKernel(context.Context, int, int) (*Action, *Response, error)
+	EnableIPv6(context.Context, int) (*Action, *Response, error)
+	EnableIPv6ByTag(context.Context, string) (*Action, *Response, error)
+	EnablePrivateNetworking(context.Context, int) (*Action, *Response, error)
+	EnablePrivateNetworkingByTag(context.Context, string) (*Action, *Response, error)
+	Upgrade(context.Context, int) (*Action, *Response, error)
+	Get(context.Context, int, int) (*Action, *Response, error)
+	GetByURI(context.Context, string) (*Action, *Response, error)
 }
 
 // DropletActionsServiceOp handles communication with the Droplet action related
@@ -52,189 +53,189 @@ type DropletActionsServiceOp struct {
 var _ DropletActionsService = &DropletActionsServiceOp{}
 
 // Shutdown a Droplet
-func (s *DropletActionsServiceOp) Shutdown(id int) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) Shutdown(ctx context.Context, id int) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "shutdown"}
-	return s.doAction(id, request)
+	return s.doAction(ctx, id, request)
 }
 
 // ShutdownByTag shuts down Droplets matched by a Tag.
-func (s *DropletActionsServiceOp) ShutdownByTag(tag string) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) ShutdownByTag(ctx context.Context, tag string) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "shutdown"}
-	return s.doActionByTag(tag, request)
+	return s.doActionByTag(ctx, tag, request)
 }
 
 // PowerOff a Droplet
-func (s *DropletActionsServiceOp) PowerOff(id int) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) PowerOff(ctx context.Context, id int) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "power_off"}
-	return s.doAction(id, request)
+	return s.doAction(ctx, id, request)
 }
 
 // PowerOffByTag powers off Droplets matched by a Tag.
-func (s *DropletActionsServiceOp) PowerOffByTag(tag string) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) PowerOffByTag(ctx context.Context, tag string) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "power_off"}
-	return s.doActionByTag(tag, request)
+	return s.doActionByTag(ctx, tag, request)
 }
 
 // PowerOn a Droplet
-func (s *DropletActionsServiceOp) PowerOn(id int) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) PowerOn(ctx context.Context, id int) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "power_on"}
-	return s.doAction(id, request)
+	return s.doAction(ctx, id, request)
 }
 
 // PowerOnByTag powers on Droplets matched by a Tag.
-func (s *DropletActionsServiceOp) PowerOnByTag(tag string) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) PowerOnByTag(ctx context.Context, tag string) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "power_on"}
-	return s.doActionByTag(tag, request)
+	return s.doActionByTag(ctx, tag, request)
 }
 
 // PowerCycle a Droplet
-func (s *DropletActionsServiceOp) PowerCycle(id int) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) PowerCycle(ctx context.Context, id int) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "power_cycle"}
-	return s.doAction(id, request)
+	return s.doAction(ctx, id, request)
 }
 
 // PowerCycleByTag power cycles Droplets matched by a Tag.
-func (s *DropletActionsServiceOp) PowerCycleByTag(tag string) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) PowerCycleByTag(ctx context.Context, tag string) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "power_cycle"}
-	return s.doActionByTag(tag, request)
+	return s.doActionByTag(ctx, tag, request)
 }
 
 // Reboot a Droplet
-func (s *DropletActionsServiceOp) Reboot(id int) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) Reboot(ctx context.Context, id int) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "reboot"}
-	return s.doAction(id, request)
+	return s.doAction(ctx, id, request)
 }
 
 // Restore an image to a Droplet
-func (s *DropletActionsServiceOp) Restore(id, imageID int) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) Restore(ctx context.Context, id, imageID int) (*Action, *Response, error) {
 	requestType := "restore"
 	request := &ActionRequest{
 		"type":  requestType,
 		"image": float64(imageID),
 	}
-	return s.doAction(id, request)
+	return s.doAction(ctx, id, request)
 }
 
 // Resize a Droplet
-func (s *DropletActionsServiceOp) Resize(id int, sizeSlug string, resizeDisk bool) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) Resize(ctx context.Context, id int, sizeSlug string, resizeDisk bool) (*Action, *Response, error) {
 	requestType := "resize"
 	request := &ActionRequest{
 		"type": requestType,
 		"size": sizeSlug,
 		"disk": resizeDisk,
 	}
-	return s.doAction(id, request)
+	return s.doAction(ctx, id, request)
 }
 
 // Rename a Droplet
-func (s *DropletActionsServiceOp) Rename(id int, name string) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) Rename(ctx context.Context, id int, name string) (*Action, *Response, error) {
 	requestType := "rename"
 	request := &ActionRequest{
 		"type": requestType,
 		"name": name,
 	}
-	return s.doAction(id, request)
+	return s.doAction(ctx, id, request)
 }
 
 // Snapshot a Droplet.
-func (s *DropletActionsServiceOp) Snapshot(id int, name string) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) Snapshot(ctx context.Context, id int, name string) (*Action, *Response, error) {
 	requestType := "snapshot"
 	request := &ActionRequest{
 		"type": requestType,
 		"name": name,
 	}
-	return s.doAction(id, request)
+	return s.doAction(ctx, id, request)
 }
 
 // SnapshotByTag snapshots Droplets matched by a Tag.
-func (s *DropletActionsServiceOp) SnapshotByTag(tag string, name string) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) SnapshotByTag(ctx context.Context, tag string, name string) (*Action, *Response, error) {
 	requestType := "snapshot"
 	request := &ActionRequest{
 		"type": requestType,
 		"name": name,
 	}
-	return s.doActionByTag(tag, request)
+	return s.doActionByTag(ctx, tag, request)
 }
 
 // EnableBackups enables backups for a Droplet.
-func (s *DropletActionsServiceOp) EnableBackups(id int) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) EnableBackups(ctx context.Context, id int) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "enable_backups"}
-	return s.doAction(id, request)
+	return s.doAction(ctx, id, request)
 }
 
 // EnableBackupsByTag enables backups for Droplets matched by a Tag.
-func (s *DropletActionsServiceOp) EnableBackupsByTag(tag string) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) EnableBackupsByTag(ctx context.Context, tag string) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "enable_backups"}
-	return s.doActionByTag(tag, request)
+	return s.doActionByTag(ctx, tag, request)
 }
 
 // DisableBackups disables backups for a Droplet.
-func (s *DropletActionsServiceOp) DisableBackups(id int) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) DisableBackups(ctx context.Context, id int) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "disable_backups"}
-	return s.doAction(id, request)
+	return s.doAction(ctx, id, request)
 }
 
 // DisableBackupsByTag disables backups for Droplet matched by a Tag.
-func (s *DropletActionsServiceOp) DisableBackupsByTag(tag string) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) DisableBackupsByTag(ctx context.Context, tag string) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "disable_backups"}
-	return s.doActionByTag(tag, request)
+	return s.doActionByTag(ctx, tag, request)
 }
 
 // PasswordReset resets the password for a Droplet.
-func (s *DropletActionsServiceOp) PasswordReset(id int) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) PasswordReset(ctx context.Context, id int) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "password_reset"}
-	return s.doAction(id, request)
+	return s.doAction(ctx, id, request)
 }
 
 // RebuildByImageID rebuilds a Droplet from an image with a given id.
-func (s *DropletActionsServiceOp) RebuildByImageID(id, imageID int) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) RebuildByImageID(ctx context.Context, id, imageID int) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "rebuild", "image": imageID}
-	return s.doAction(id, request)
+	return s.doAction(ctx, id, request)
 }
 
 // RebuildByImageSlug rebuilds a Droplet from an Image matched by a given Slug.
-func (s *DropletActionsServiceOp) RebuildByImageSlug(id int, slug string) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) RebuildByImageSlug(ctx context.Context, id int, slug string) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "rebuild", "image": slug}
-	return s.doAction(id, request)
+	return s.doAction(ctx, id, request)
 }
 
 // ChangeKernel changes the kernel for a Droplet.
-func (s *DropletActionsServiceOp) ChangeKernel(id, kernelID int) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) ChangeKernel(ctx context.Context, id, kernelID int) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "change_kernel", "kernel": kernelID}
-	return s.doAction(id, request)
+	return s.doAction(ctx, id, request)
 }
 
 // EnableIPv6 enables IPv6 for a Droplet.
-func (s *DropletActionsServiceOp) EnableIPv6(id int) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) EnableIPv6(ctx context.Context, id int) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "enable_ipv6"}
-	return s.doAction(id, request)
+	return s.doAction(ctx, id, request)
 }
 
 // EnableIPv6ByTag enables IPv6 for Droplets matched by a Tag.
-func (s *DropletActionsServiceOp) EnableIPv6ByTag(tag string) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) EnableIPv6ByTag(ctx context.Context, tag string) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "enable_ipv6"}
-	return s.doActionByTag(tag, request)
+	return s.doActionByTag(ctx, tag, request)
 }
 
 // EnablePrivateNetworking enables private networking for a Droplet.
-func (s *DropletActionsServiceOp) EnablePrivateNetworking(id int) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) EnablePrivateNetworking(ctx context.Context, id int) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "enable_private_networking"}
-	return s.doAction(id, request)
+	return s.doAction(ctx, id, request)
 }
 
 // EnablePrivateNetworkingByTag enables private networking for Droplets matched by a Tag.
-func (s *DropletActionsServiceOp) EnablePrivateNetworkingByTag(tag string) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) EnablePrivateNetworkingByTag(ctx context.Context, tag string) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "enable_private_networking"}
-	return s.doActionByTag(tag, request)
+	return s.doActionByTag(ctx, tag, request)
 }
 
 // Upgrade a Droplet.
-func (s *DropletActionsServiceOp) Upgrade(id int) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) Upgrade(ctx context.Context, id int) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "upgrade"}
-	return s.doAction(id, request)
+	return s.doAction(ctx, id, request)
 }
 
-func (s *DropletActionsServiceOp) doAction(id int, request *ActionRequest) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) doAction(ctx context.Context, id int, request *ActionRequest) (*Action, *Response, error) {
 	if id < 1 {
 		return nil, nil, NewArgError("id", "cannot be less than 1")
 	}
@@ -245,7 +246,7 @@ func (s *DropletActionsServiceOp) doAction(id int, request *ActionRequest) (*Act
 
 	path := dropletActionPath(id)
 
-	req, err := s.client.NewRequest("POST", path, request)
+	req, err := s.client.NewRequest(ctx, "POST", path, request)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -259,7 +260,7 @@ func (s *DropletActionsServiceOp) doAction(id int, request *ActionRequest) (*Act
 	return root.Event, resp, err
 }
 
-func (s *DropletActionsServiceOp) doActionByTag(tag string, request *ActionRequest) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) doActionByTag(ctx context.Context, tag string, request *ActionRequest) (*Action, *Response, error) {
 	if tag == "" {
 		return nil, nil, NewArgError("tag", "cannot be empty")
 	}
@@ -270,7 +271,7 @@ func (s *DropletActionsServiceOp) doActionByTag(tag string, request *ActionReque
 
 	path := dropletActionPathByTag(tag)
 
-	req, err := s.client.NewRequest("POST", path, request)
+	req, err := s.client.NewRequest(ctx, "POST", path, request)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -285,7 +286,7 @@ func (s *DropletActionsServiceOp) doActionByTag(tag string, request *ActionReque
 }
 
 // Get an action for a particular Droplet by id.
-func (s *DropletActionsServiceOp) Get(dropletID, actionID int) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) Get(ctx context.Context, dropletID, actionID int) (*Action, *Response, error) {
 	if dropletID < 1 {
 		return nil, nil, NewArgError("dropletID", "cannot be less than 1")
 	}
@@ -295,22 +296,22 @@ func (s *DropletActionsServiceOp) Get(dropletID, actionID int) (*Action, *Respon
 	}
 
 	path := fmt.Sprintf("%s/%d", dropletActionPath(dropletID), actionID)
-	return s.get(path)
+	return s.get(ctx, path)
 }
 
 // GetByURI gets an action for a particular Droplet by id.
-func (s *DropletActionsServiceOp) GetByURI(rawurl string) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) GetByURI(ctx context.Context, rawurl string) (*Action, *Response, error) {
 	u, err := url.Parse(rawurl)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return s.get(u.Path)
+	return s.get(ctx, u.Path)
 
 }
 
-func (s *DropletActionsServiceOp) get(path string) (*Action, *Response, error) {
-	req, err := s.client.NewRequest("GET", path, nil)
+func (s *DropletActionsServiceOp) get(ctx context.Context, path string) (*Action, *Response, error) {
+	req, err := s.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/droplet_actions_test.go
+++ b/droplet_actions_test.go
@@ -31,7 +31,7 @@ func TestDropletActions_Shutdown(t *testing.T) {
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
-	action, _, err := client.DropletActions.Shutdown(1)
+	action, _, err := client.DropletActions.Shutdown(ctx, 1)
 	if err != nil {
 		t.Errorf("DropletActions.Shutdown returned error: %v", err)
 	}
@@ -69,7 +69,7 @@ func TestDropletActions_ShutdownByTag(t *testing.T) {
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
-	action, _, err := client.DropletActions.ShutdownByTag("testing-1")
+	action, _, err := client.DropletActions.ShutdownByTag(ctx, "testing-1")
 	if err != nil {
 		t.Errorf("DropletActions.ShutdownByTag returned error: %v", err)
 	}
@@ -103,7 +103,7 @@ func TestDropletAction_PowerOff(t *testing.T) {
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
-	action, _, err := client.DropletActions.PowerOff(1)
+	action, _, err := client.DropletActions.PowerOff(ctx, 1)
 	if err != nil {
 		t.Errorf("DropletActions.PowerOff returned error: %v", err)
 	}
@@ -141,7 +141,7 @@ func TestDropletAction_PowerOffByTag(t *testing.T) {
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
-	action, _, err := client.DropletActions.PowerOffByTag("testing-1")
+	action, _, err := client.DropletActions.PowerOffByTag(ctx, "testing-1")
 	if err != nil {
 		t.Errorf("DropletActions.PowerOffByTag returned error: %v", err)
 	}
@@ -175,7 +175,7 @@ func TestDropletAction_PowerOn(t *testing.T) {
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
-	action, _, err := client.DropletActions.PowerOn(1)
+	action, _, err := client.DropletActions.PowerOn(ctx, 1)
 	if err != nil {
 		t.Errorf("DropletActions.PowerOn returned error: %v", err)
 	}
@@ -213,7 +213,7 @@ func TestDropletAction_PowerOnByTag(t *testing.T) {
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
-	action, _, err := client.DropletActions.PowerOnByTag("testing-1")
+	action, _, err := client.DropletActions.PowerOnByTag(ctx, "testing-1")
 	if err != nil {
 		t.Errorf("DropletActions.PowerOnByTag returned error: %v", err)
 	}
@@ -247,7 +247,7 @@ func TestDropletAction_Reboot(t *testing.T) {
 
 	})
 
-	action, _, err := client.DropletActions.Reboot(1)
+	action, _, err := client.DropletActions.Reboot(ctx, 1)
 	if err != nil {
 		t.Errorf("DropletActions.Reboot returned error: %v", err)
 	}
@@ -284,7 +284,7 @@ func TestDropletAction_Restore(t *testing.T) {
 
 	})
 
-	action, _, err := client.DropletActions.Restore(1, 1)
+	action, _, err := client.DropletActions.Restore(ctx, 1, 1)
 	if err != nil {
 		t.Errorf("DropletActions.Restore returned error: %v", err)
 	}
@@ -322,7 +322,7 @@ func TestDropletAction_Resize(t *testing.T) {
 
 	})
 
-	action, _, err := client.DropletActions.Resize(1, "1024mb", true)
+	action, _, err := client.DropletActions.Resize(ctx, 1, "1024mb", true)
 	if err != nil {
 		t.Errorf("DropletActions.Resize returned error: %v", err)
 	}
@@ -358,7 +358,7 @@ func TestDropletAction_Rename(t *testing.T) {
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
-	action, _, err := client.DropletActions.Rename(1, "Droplet-Name")
+	action, _, err := client.DropletActions.Rename(ctx, 1, "Droplet-Name")
 	if err != nil {
 		t.Errorf("DropletActions.Rename returned error: %v", err)
 	}
@@ -393,7 +393,7 @@ func TestDropletAction_PowerCycle(t *testing.T) {
 
 	})
 
-	action, _, err := client.DropletActions.PowerCycle(1)
+	action, _, err := client.DropletActions.PowerCycle(ctx, 1)
 	if err != nil {
 		t.Errorf("DropletActions.PowerCycle returned error: %v", err)
 	}
@@ -432,7 +432,7 @@ func TestDropletAction_PowerCycleByTag(t *testing.T) {
 
 	})
 
-	action, _, err := client.DropletActions.PowerCycleByTag("testing-1")
+	action, _, err := client.DropletActions.PowerCycleByTag(ctx, "testing-1")
 	if err != nil {
 		t.Errorf("DropletActions.PowerCycleByTag returned error: %v", err)
 	}
@@ -468,7 +468,7 @@ func TestDropletAction_Snapshot(t *testing.T) {
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
-	action, _, err := client.DropletActions.Snapshot(1, "Image-Name")
+	action, _, err := client.DropletActions.Snapshot(ctx, 1, "Image-Name")
 	if err != nil {
 		t.Errorf("DropletActions.Snapshot returned error: %v", err)
 	}
@@ -508,7 +508,7 @@ func TestDropletAction_SnapshotByTag(t *testing.T) {
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
-	action, _, err := client.DropletActions.SnapshotByTag("testing-1", "Image-Name")
+	action, _, err := client.DropletActions.SnapshotByTag(ctx, "testing-1", "Image-Name")
 	if err != nil {
 		t.Errorf("DropletActions.SnapshotByTag returned error: %v", err)
 	}
@@ -543,7 +543,7 @@ func TestDropletAction_EnableBackups(t *testing.T) {
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
-	action, _, err := client.DropletActions.EnableBackups(1)
+	action, _, err := client.DropletActions.EnableBackups(ctx, 1)
 	if err != nil {
 		t.Errorf("DropletActions.EnableBackups returned error: %v", err)
 	}
@@ -582,7 +582,7 @@ func TestDropletAction_EnableBackupsByTag(t *testing.T) {
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
-	action, _, err := client.DropletActions.EnableBackupsByTag("testing-1")
+	action, _, err := client.DropletActions.EnableBackupsByTag(ctx, "testing-1")
 	if err != nil {
 		t.Errorf("DropletActions.EnableBackupsByTag returned error: %v", err)
 	}
@@ -617,7 +617,7 @@ func TestDropletAction_DisableBackups(t *testing.T) {
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
-	action, _, err := client.DropletActions.DisableBackups(1)
+	action, _, err := client.DropletActions.DisableBackups(ctx, 1)
 	if err != nil {
 		t.Errorf("DropletActions.DisableBackups returned error: %v", err)
 	}
@@ -656,7 +656,7 @@ func TestDropletAction_DisableBackupsByTag(t *testing.T) {
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
-	action, _, err := client.DropletActions.DisableBackupsByTag("testing-1")
+	action, _, err := client.DropletActions.DisableBackupsByTag(ctx, "testing-1")
 	if err != nil {
 		t.Errorf("DropletActions.DisableBackupsByTag returned error: %v", err)
 	}
@@ -691,7 +691,7 @@ func TestDropletAction_PasswordReset(t *testing.T) {
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
-	action, _, err := client.DropletActions.PasswordReset(1)
+	action, _, err := client.DropletActions.PasswordReset(ctx, 1)
 	if err != nil {
 		t.Errorf("DropletActions.PasswordReset returned error: %v", err)
 	}
@@ -727,7 +727,7 @@ func TestDropletAction_RebuildByImageID(t *testing.T) {
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
-	action, _, err := client.DropletActions.RebuildByImageID(1, 2)
+	action, _, err := client.DropletActions.RebuildByImageID(ctx, 1, 2)
 	if err != nil {
 		t.Errorf("DropletActions.RebuildByImageID returned error: %v", err)
 	}
@@ -763,7 +763,7 @@ func TestDropletAction_RebuildByImageSlug(t *testing.T) {
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
-	action, _, err := client.DropletActions.RebuildByImageSlug(1, "Image-Name")
+	action, _, err := client.DropletActions.RebuildByImageSlug(ctx, 1, "Image-Name")
 	if err != nil {
 		t.Errorf("DropletActions.RebuildByImageSlug returned error: %v", err)
 	}
@@ -799,7 +799,7 @@ func TestDropletAction_ChangeKernel(t *testing.T) {
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
-	action, _, err := client.DropletActions.ChangeKernel(1, 2)
+	action, _, err := client.DropletActions.ChangeKernel(ctx, 1, 2)
 	if err != nil {
 		t.Errorf("DropletActions.ChangeKernel returned error: %v", err)
 	}
@@ -834,7 +834,7 @@ func TestDropletAction_EnableIPv6(t *testing.T) {
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
-	action, _, err := client.DropletActions.EnableIPv6(1)
+	action, _, err := client.DropletActions.EnableIPv6(ctx, 1)
 	if err != nil {
 		t.Errorf("DropletActions.EnableIPv6 returned error: %v", err)
 	}
@@ -873,7 +873,7 @@ func TestDropletAction_EnableIPv6ByTag(t *testing.T) {
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
-	action, _, err := client.DropletActions.EnableIPv6ByTag("testing-1")
+	action, _, err := client.DropletActions.EnableIPv6ByTag(ctx, "testing-1")
 	if err != nil {
 		t.Errorf("DropletActions.EnableIPv6ByTag returned error: %v", err)
 	}
@@ -908,7 +908,7 @@ func TestDropletAction_EnablePrivateNetworking(t *testing.T) {
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
-	action, _, err := client.DropletActions.EnablePrivateNetworking(1)
+	action, _, err := client.DropletActions.EnablePrivateNetworking(ctx, 1)
 	if err != nil {
 		t.Errorf("DropletActions.EnablePrivateNetworking returned error: %v", err)
 	}
@@ -947,7 +947,7 @@ func TestDropletAction_EnablePrivateNetworkingByTag(t *testing.T) {
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
-	action, _, err := client.DropletActions.EnablePrivateNetworkingByTag("testing-1")
+	action, _, err := client.DropletActions.EnablePrivateNetworkingByTag(ctx, "testing-1")
 	if err != nil {
 		t.Errorf("DropletActions.EnablePrivateNetworkingByTag returned error: %v", err)
 	}
@@ -982,7 +982,7 @@ func TestDropletAction_Upgrade(t *testing.T) {
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
-	action, _, err := client.DropletActions.Upgrade(1)
+	action, _, err := client.DropletActions.Upgrade(ctx, 1)
 	if err != nil {
 		t.Errorf("DropletActions.Upgrade returned error: %v", err)
 	}
@@ -1002,7 +1002,7 @@ func TestDropletActions_Get(t *testing.T) {
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
-	action, _, err := client.DropletActions.Get(123, 456)
+	action, _, err := client.DropletActions.Get(ctx, 123, 456)
 	if err != nil {
 		t.Errorf("DropletActions.Get returned error: %v", err)
 	}

--- a/droplets.go
+++ b/droplets.go
@@ -1,6 +1,7 @@
 package godo
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,18 +15,18 @@ var errNoNetworks = errors.New("no networks have been defined")
 // endpoints of the DigitalOcean API
 // See: https://developers.digitalocean.com/documentation/v2#droplets
 type DropletsService interface {
-	List(*ListOptions) ([]Droplet, *Response, error)
-	ListByTag(string, *ListOptions) ([]Droplet, *Response, error)
-	Get(int) (*Droplet, *Response, error)
-	Create(*DropletCreateRequest) (*Droplet, *Response, error)
-	CreateMultiple(*DropletMultiCreateRequest) ([]Droplet, *Response, error)
-	Delete(int) (*Response, error)
-	DeleteByTag(string) (*Response, error)
-	Kernels(int, *ListOptions) ([]Kernel, *Response, error)
-	Snapshots(int, *ListOptions) ([]Image, *Response, error)
-	Backups(int, *ListOptions) ([]Image, *Response, error)
-	Actions(int, *ListOptions) ([]Action, *Response, error)
-	Neighbors(int) ([]Droplet, *Response, error)
+	List(context.Context, *ListOptions) ([]Droplet, *Response, error)
+	ListByTag(context.Context, string, *ListOptions) ([]Droplet, *Response, error)
+	Get(context.Context, int) (*Droplet, *Response, error)
+	Create(context.Context, *DropletCreateRequest) (*Droplet, *Response, error)
+	CreateMultiple(context.Context, *DropletMultiCreateRequest) ([]Droplet, *Response, error)
+	Delete(context.Context, int) (*Response, error)
+	DeleteByTag(context.Context, string) (*Response, error)
+	Kernels(context.Context, int, *ListOptions) ([]Kernel, *Response, error)
+	Snapshots(context.Context, int, *ListOptions) ([]Image, *Response, error)
+	Backups(context.Context, int, *ListOptions) ([]Image, *Response, error)
+	Actions(context.Context, int, *ListOptions) ([]Action, *Response, error)
+	Neighbors(context.Context, int) ([]Droplet, *Response, error)
 }
 
 // DropletsServiceOp handles communication with the Droplet related methods of the
@@ -272,8 +273,8 @@ func (n NetworkV6) String() string {
 }
 
 // Performs a list request given a path.
-func (s *DropletsServiceOp) list(path string) ([]Droplet, *Response, error) {
-	req, err := s.client.NewRequest("GET", path, nil)
+func (s *DropletsServiceOp) list(ctx context.Context, path string) ([]Droplet, *Response, error) {
+	req, err := s.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -291,36 +292,36 @@ func (s *DropletsServiceOp) list(path string) ([]Droplet, *Response, error) {
 }
 
 // List all Droplets.
-func (s *DropletsServiceOp) List(opt *ListOptions) ([]Droplet, *Response, error) {
+func (s *DropletsServiceOp) List(ctx context.Context, opt *ListOptions) ([]Droplet, *Response, error) {
 	path := dropletBasePath
 	path, err := addOptions(path, opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return s.list(path)
+	return s.list(ctx, path)
 }
 
 // ListByTag lists all Droplets matched by a Tag.
-func (s *DropletsServiceOp) ListByTag(tag string, opt *ListOptions) ([]Droplet, *Response, error) {
+func (s *DropletsServiceOp) ListByTag(ctx context.Context, tag string, opt *ListOptions) ([]Droplet, *Response, error) {
 	path := fmt.Sprintf("%s?tag_name=%s", dropletBasePath, tag)
 	path, err := addOptions(path, opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return s.list(path)
+	return s.list(ctx, path)
 }
 
 // Get individual Droplet.
-func (s *DropletsServiceOp) Get(dropletID int) (*Droplet, *Response, error) {
+func (s *DropletsServiceOp) Get(ctx context.Context, dropletID int) (*Droplet, *Response, error) {
 	if dropletID < 1 {
 		return nil, nil, NewArgError("dropletID", "cannot be less than 1")
 	}
 
 	path := fmt.Sprintf("%s/%d", dropletBasePath, dropletID)
 
-	req, err := s.client.NewRequest("GET", path, nil)
+	req, err := s.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -335,14 +336,14 @@ func (s *DropletsServiceOp) Get(dropletID int) (*Droplet, *Response, error) {
 }
 
 // Create Droplet
-func (s *DropletsServiceOp) Create(createRequest *DropletCreateRequest) (*Droplet, *Response, error) {
+func (s *DropletsServiceOp) Create(ctx context.Context, createRequest *DropletCreateRequest) (*Droplet, *Response, error) {
 	if createRequest == nil {
 		return nil, nil, NewArgError("createRequest", "cannot be nil")
 	}
 
 	path := dropletBasePath
 
-	req, err := s.client.NewRequest("POST", path, createRequest)
+	req, err := s.client.NewRequest(ctx, "POST", path, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -360,14 +361,14 @@ func (s *DropletsServiceOp) Create(createRequest *DropletCreateRequest) (*Drople
 }
 
 // CreateMultiple creates multiple Droplets.
-func (s *DropletsServiceOp) CreateMultiple(createRequest *DropletMultiCreateRequest) ([]Droplet, *Response, error) {
+func (s *DropletsServiceOp) CreateMultiple(ctx context.Context, createRequest *DropletMultiCreateRequest) ([]Droplet, *Response, error) {
 	if createRequest == nil {
 		return nil, nil, NewArgError("createRequest", "cannot be nil")
 	}
 
 	path := dropletBasePath
 
-	req, err := s.client.NewRequest("POST", path, createRequest)
+	req, err := s.client.NewRequest(ctx, "POST", path, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -385,8 +386,8 @@ func (s *DropletsServiceOp) CreateMultiple(createRequest *DropletMultiCreateRequ
 }
 
 // Performs a delete request given a path
-func (s *DropletsServiceOp) delete(path string) (*Response, error) {
-	req, err := s.client.NewRequest("DELETE", path, nil)
+func (s *DropletsServiceOp) delete(ctx context.Context, path string) (*Response, error) {
+	req, err := s.client.NewRequest(ctx, "DELETE", path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -397,29 +398,29 @@ func (s *DropletsServiceOp) delete(path string) (*Response, error) {
 }
 
 // Delete Droplet.
-func (s *DropletsServiceOp) Delete(dropletID int) (*Response, error) {
+func (s *DropletsServiceOp) Delete(ctx context.Context, dropletID int) (*Response, error) {
 	if dropletID < 1 {
 		return nil, NewArgError("dropletID", "cannot be less than 1")
 	}
 
 	path := fmt.Sprintf("%s/%d", dropletBasePath, dropletID)
 
-	return s.delete(path)
+	return s.delete(ctx, path)
 }
 
 // DeleteByTag deletes Droplets matched by a Tag.
-func (s *DropletsServiceOp) DeleteByTag(tag string) (*Response, error) {
+func (s *DropletsServiceOp) DeleteByTag(ctx context.Context, tag string) (*Response, error) {
 	if tag == "" {
 		return nil, NewArgError("tag", "cannot be empty")
 	}
 
 	path := fmt.Sprintf("%s?tag_name=%s", dropletBasePath, tag)
 
-	return s.delete(path)
+	return s.delete(ctx, path)
 }
 
 // Kernels lists kernels available for a Droplet.
-func (s *DropletsServiceOp) Kernels(dropletID int, opt *ListOptions) ([]Kernel, *Response, error) {
+func (s *DropletsServiceOp) Kernels(ctx context.Context, dropletID int, opt *ListOptions) ([]Kernel, *Response, error) {
 	if dropletID < 1 {
 		return nil, nil, NewArgError("dropletID", "cannot be less than 1")
 	}
@@ -430,7 +431,7 @@ func (s *DropletsServiceOp) Kernels(dropletID int, opt *ListOptions) ([]Kernel, 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", path, nil)
+	req, err := s.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -445,7 +446,7 @@ func (s *DropletsServiceOp) Kernels(dropletID int, opt *ListOptions) ([]Kernel, 
 }
 
 // Actions lists the actions for a Droplet.
-func (s *DropletsServiceOp) Actions(dropletID int, opt *ListOptions) ([]Action, *Response, error) {
+func (s *DropletsServiceOp) Actions(ctx context.Context, dropletID int, opt *ListOptions) ([]Action, *Response, error) {
 	if dropletID < 1 {
 		return nil, nil, NewArgError("dropletID", "cannot be less than 1")
 	}
@@ -456,7 +457,7 @@ func (s *DropletsServiceOp) Actions(dropletID int, opt *ListOptions) ([]Action, 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", path, nil)
+	req, err := s.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -474,7 +475,7 @@ func (s *DropletsServiceOp) Actions(dropletID int, opt *ListOptions) ([]Action, 
 }
 
 // Backups lists the backups for a Droplet.
-func (s *DropletsServiceOp) Backups(dropletID int, opt *ListOptions) ([]Image, *Response, error) {
+func (s *DropletsServiceOp) Backups(ctx context.Context, dropletID int, opt *ListOptions) ([]Image, *Response, error) {
 	if dropletID < 1 {
 		return nil, nil, NewArgError("dropletID", "cannot be less than 1")
 	}
@@ -485,7 +486,7 @@ func (s *DropletsServiceOp) Backups(dropletID int, opt *ListOptions) ([]Image, *
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", path, nil)
+	req, err := s.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -503,7 +504,7 @@ func (s *DropletsServiceOp) Backups(dropletID int, opt *ListOptions) ([]Image, *
 }
 
 // Snapshots lists the snapshots available for a Droplet.
-func (s *DropletsServiceOp) Snapshots(dropletID int, opt *ListOptions) ([]Image, *Response, error) {
+func (s *DropletsServiceOp) Snapshots(ctx context.Context, dropletID int, opt *ListOptions) ([]Image, *Response, error) {
 	if dropletID < 1 {
 		return nil, nil, NewArgError("dropletID", "cannot be less than 1")
 	}
@@ -514,7 +515,7 @@ func (s *DropletsServiceOp) Snapshots(dropletID int, opt *ListOptions) ([]Image,
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", path, nil)
+	req, err := s.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -532,14 +533,14 @@ func (s *DropletsServiceOp) Snapshots(dropletID int, opt *ListOptions) ([]Image,
 }
 
 // Neighbors lists the neighbors for a Droplet.
-func (s *DropletsServiceOp) Neighbors(dropletID int) ([]Droplet, *Response, error) {
+func (s *DropletsServiceOp) Neighbors(ctx context.Context, dropletID int) ([]Droplet, *Response, error) {
 	if dropletID < 1 {
 		return nil, nil, NewArgError("dropletID", "cannot be less than 1")
 	}
 
 	path := fmt.Sprintf("%s/%d/neighbors", dropletBasePath, dropletID)
 
-	req, err := s.client.NewRequest("GET", path, nil)
+	req, err := s.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -553,8 +554,8 @@ func (s *DropletsServiceOp) Neighbors(dropletID int) ([]Droplet, *Response, erro
 	return root.Droplets, resp, err
 }
 
-func (s *DropletsServiceOp) dropletActionStatus(uri string) (string, error) {
-	action, _, err := s.client.DropletActions.GetByURI(uri)
+func (s *DropletsServiceOp) dropletActionStatus(ctx context.Context, uri string) (string, error) {
+	action, _, err := s.client.DropletActions.GetByURI(ctx, uri)
 
 	if err != nil {
 		return "", err

--- a/droplets_test.go
+++ b/droplets_test.go
@@ -17,7 +17,7 @@ func TestDroplets_ListDroplets(t *testing.T) {
 		fmt.Fprint(w, `{"droplets": [{"id":1},{"id":2}]}`)
 	})
 
-	droplets, _, err := client.Droplets.List(nil)
+	droplets, _, err := client.Droplets.List(ctx, nil)
 	if err != nil {
 		t.Errorf("Droplets.List returned error: %v", err)
 	}
@@ -41,7 +41,7 @@ func TestDroplets_ListDropletsByTag(t *testing.T) {
 		fmt.Fprint(w, `{"droplets": [{"id":1},{"id":2}]}`)
 	})
 
-	droplets, _, err := client.Droplets.ListByTag("testing-1", nil)
+	droplets, _, err := client.Droplets.ListByTag(ctx, "testing-1", nil)
 	if err != nil {
 		t.Errorf("Droplets.ListByTag returned error: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestDroplets_ListDropletsMultiplePages(t *testing.T) {
 		fmt.Fprint(w, string(b))
 	})
 
-	_, resp, err := client.Droplets.List(nil)
+	_, resp, err := client.Droplets.List(ctx, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,7 +108,7 @@ func TestDroplets_RetrievePageByNumber(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	_, resp, err := client.Droplets.List(opt)
+	_, resp, err := client.Droplets.List(ctx, opt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,7 +125,7 @@ func TestDroplets_GetDroplet(t *testing.T) {
 		fmt.Fprint(w, `{"droplet":{"id":12345}}`)
 	})
 
-	droplets, _, err := client.Droplets.Get(12345)
+	droplets, _, err := client.Droplets.Get(ctx, 12345)
 	if err != nil {
 		t.Errorf("Droplet.Get returned error: %v", err)
 	}
@@ -187,7 +187,7 @@ func TestDroplets_Create(t *testing.T) {
 		fmt.Fprintf(w, `{"droplet":{"id":1}, "links":{"actions": [{"id": 1, "href": "http://example.com", "rel": "create"}]}}`)
 	})
 
-	droplet, resp, err := client.Droplets.Create(createRequest)
+	droplet, resp, err := client.Droplets.Create(ctx, createRequest)
 	if err != nil {
 		t.Errorf("Droplets.Create returned error: %v", err)
 	}
@@ -242,7 +242,7 @@ func TestDroplets_CreateMultiple(t *testing.T) {
 		fmt.Fprintf(w, `{"droplets":[{"id":1},{"id":2}], "links":{"actions": [{"id": 1, "href": "http://example.com", "rel": "multiple_create"}]}}`)
 	})
 
-	droplets, resp, err := client.Droplets.CreateMultiple(createRequest)
+	droplets, resp, err := client.Droplets.CreateMultiple(ctx, createRequest)
 	if err != nil {
 		t.Errorf("Droplets.CreateMultiple returned error: %v", err)
 	}
@@ -268,7 +268,7 @@ func TestDroplets_Destroy(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Droplets.Delete(12345)
+	_, err := client.Droplets.Delete(ctx, 12345)
 	if err != nil {
 		t.Errorf("Droplet.Delete returned error: %v", err)
 	}
@@ -286,7 +286,7 @@ func TestDroplets_DestroyByTag(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Droplets.DeleteByTag("testing-1")
+	_, err := client.Droplets.DeleteByTag(ctx, "testing-1")
 	if err != nil {
 		t.Errorf("Droplet.Delete returned error: %v", err)
 	}
@@ -302,7 +302,7 @@ func TestDroplets_Kernels(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	kernels, _, err := client.Droplets.Kernels(12345, opt)
+	kernels, _, err := client.Droplets.Kernels(ctx, 12345, opt)
 	if err != nil {
 		t.Errorf("Droplets.Kernels returned error: %v", err)
 	}
@@ -323,7 +323,7 @@ func TestDroplets_Snapshots(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	snapshots, _, err := client.Droplets.Snapshots(12345, opt)
+	snapshots, _, err := client.Droplets.Snapshots(ctx, 12345, opt)
 	if err != nil {
 		t.Errorf("Droplets.Snapshots returned error: %v", err)
 	}
@@ -344,7 +344,7 @@ func TestDroplets_Backups(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	backups, _, err := client.Droplets.Backups(12345, opt)
+	backups, _, err := client.Droplets.Backups(ctx, 12345, opt)
 	if err != nil {
 		t.Errorf("Droplets.Backups returned error: %v", err)
 	}
@@ -365,7 +365,7 @@ func TestDroplets_Actions(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	actions, _, err := client.Droplets.Actions(12345, opt)
+	actions, _, err := client.Droplets.Actions(ctx, 12345, opt)
 	if err != nil {
 		t.Errorf("Droplets.Actions returned error: %v", err)
 	}
@@ -385,7 +385,7 @@ func TestDroplets_Neighbors(t *testing.T) {
 		fmt.Fprint(w, `{"droplets": [{"id":1},{"id":2}]}`)
 	})
 
-	neighbors, _, err := client.Droplets.Neighbors(12345)
+	neighbors, _, err := client.Droplets.Neighbors(ctx, 12345)
 	if err != nil {
 		t.Errorf("Droplets.Neighbors returned error: %v", err)
 	}

--- a/floating_ips.go
+++ b/floating_ips.go
@@ -1,6 +1,9 @@
 package godo
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 const floatingBasePath = "v2/floating_ips"
 
@@ -8,10 +11,10 @@ const floatingBasePath = "v2/floating_ips"
 // endpoints of the Digital Ocean API.
 // See: https://developers.digitalocean.com/documentation/v2#floating-ips
 type FloatingIPsService interface {
-	List(*ListOptions) ([]FloatingIP, *Response, error)
-	Get(string) (*FloatingIP, *Response, error)
-	Create(*FloatingIPCreateRequest) (*FloatingIP, *Response, error)
-	Delete(string) (*Response, error)
+	List(context.Context, *ListOptions) ([]FloatingIP, *Response, error)
+	Get(context.Context, string) (*FloatingIP, *Response, error)
+	Create(context.Context, *FloatingIPCreateRequest) (*FloatingIP, *Response, error)
+	Delete(context.Context, string) (*Response, error)
 }
 
 // FloatingIPsServiceOp handles communication with the floating IPs related methods of the
@@ -52,14 +55,14 @@ type FloatingIPCreateRequest struct {
 }
 
 // List all floating IPs.
-func (f *FloatingIPsServiceOp) List(opt *ListOptions) ([]FloatingIP, *Response, error) {
+func (f *FloatingIPsServiceOp) List(ctx context.Context, opt *ListOptions) ([]FloatingIP, *Response, error) {
 	path := floatingBasePath
 	path, err := addOptions(path, opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := f.client.NewRequest("GET", path, nil)
+	req, err := f.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -77,10 +80,10 @@ func (f *FloatingIPsServiceOp) List(opt *ListOptions) ([]FloatingIP, *Response, 
 }
 
 // Get an individual floating IP.
-func (f *FloatingIPsServiceOp) Get(ip string) (*FloatingIP, *Response, error) {
+func (f *FloatingIPsServiceOp) Get(ctx context.Context, ip string) (*FloatingIP, *Response, error) {
 	path := fmt.Sprintf("%s/%s", floatingBasePath, ip)
 
-	req, err := f.client.NewRequest("GET", path, nil)
+	req, err := f.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -96,10 +99,10 @@ func (f *FloatingIPsServiceOp) Get(ip string) (*FloatingIP, *Response, error) {
 
 // Create a floating IP. If the DropletID field of the request is not empty,
 // the floating IP will also be assigned to the droplet.
-func (f *FloatingIPsServiceOp) Create(createRequest *FloatingIPCreateRequest) (*FloatingIP, *Response, error) {
+func (f *FloatingIPsServiceOp) Create(ctx context.Context, createRequest *FloatingIPCreateRequest) (*FloatingIP, *Response, error) {
 	path := floatingBasePath
 
-	req, err := f.client.NewRequest("POST", path, createRequest)
+	req, err := f.client.NewRequest(ctx, "POST", path, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -117,10 +120,10 @@ func (f *FloatingIPsServiceOp) Create(createRequest *FloatingIPCreateRequest) (*
 }
 
 // Delete a floating IP.
-func (f *FloatingIPsServiceOp) Delete(ip string) (*Response, error) {
+func (f *FloatingIPsServiceOp) Delete(ctx context.Context, ip string) (*Response, error) {
 	path := fmt.Sprintf("%s/%s", floatingBasePath, ip)
 
-	req, err := f.client.NewRequest("DELETE", path, nil)
+	req, err := f.client.NewRequest(ctx, "DELETE", path, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/floating_ips_actions.go
+++ b/floating_ips_actions.go
@@ -1,15 +1,18 @@
 package godo
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // FloatingIPActionsService is an interface for interfacing with the
 // floating IPs actions endpoints of the Digital Ocean API.
 // See: https://developers.digitalocean.com/documentation/v2#floating-ips-action
 type FloatingIPActionsService interface {
-	Assign(ip string, dropletID int) (*Action, *Response, error)
-	Unassign(ip string) (*Action, *Response, error)
-	Get(ip string, actionID int) (*Action, *Response, error)
-	List(ip string, opt *ListOptions) ([]Action, *Response, error)
+	Assign(ctx context.Context, ip string, dropletID int) (*Action, *Response, error)
+	Unassign(ctx context.Context, ip string) (*Action, *Response, error)
+	Get(ctx context.Context, ip string, actionID int) (*Action, *Response, error)
+	List(ctx context.Context, ip string, opt *ListOptions) ([]Action, *Response, error)
 }
 
 // FloatingIPActionsServiceOp handles communication with the floating IPs
@@ -19,41 +22,41 @@ type FloatingIPActionsServiceOp struct {
 }
 
 // Assign a floating IP to a droplet.
-func (s *FloatingIPActionsServiceOp) Assign(ip string, dropletID int) (*Action, *Response, error) {
+func (s *FloatingIPActionsServiceOp) Assign(ctx context.Context, ip string, dropletID int) (*Action, *Response, error) {
 	request := &ActionRequest{
 		"type":       "assign",
 		"droplet_id": dropletID,
 	}
-	return s.doAction(ip, request)
+	return s.doAction(ctx, ip, request)
 }
 
 // Unassign a floating IP from the droplet it is currently assigned to.
-func (s *FloatingIPActionsServiceOp) Unassign(ip string) (*Action, *Response, error) {
+func (s *FloatingIPActionsServiceOp) Unassign(ctx context.Context, ip string) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "unassign"}
-	return s.doAction(ip, request)
+	return s.doAction(ctx, ip, request)
 }
 
 // Get an action for a particular floating IP by id.
-func (s *FloatingIPActionsServiceOp) Get(ip string, actionID int) (*Action, *Response, error) {
+func (s *FloatingIPActionsServiceOp) Get(ctx context.Context, ip string, actionID int) (*Action, *Response, error) {
 	path := fmt.Sprintf("%s/%d", floatingIPActionPath(ip), actionID)
-	return s.get(path)
+	return s.get(ctx, path)
 }
 
 // List the actions for a particular floating IP.
-func (s *FloatingIPActionsServiceOp) List(ip string, opt *ListOptions) ([]Action, *Response, error) {
+func (s *FloatingIPActionsServiceOp) List(ctx context.Context, ip string, opt *ListOptions) ([]Action, *Response, error) {
 	path := floatingIPActionPath(ip)
 	path, err := addOptions(path, opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return s.list(path)
+	return s.list(ctx, path)
 }
 
-func (s *FloatingIPActionsServiceOp) doAction(ip string, request *ActionRequest) (*Action, *Response, error) {
+func (s *FloatingIPActionsServiceOp) doAction(ctx context.Context, ip string, request *ActionRequest) (*Action, *Response, error) {
 	path := floatingIPActionPath(ip)
 
-	req, err := s.client.NewRequest("POST", path, request)
+	req, err := s.client.NewRequest(ctx, "POST", path, request)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -67,8 +70,8 @@ func (s *FloatingIPActionsServiceOp) doAction(ip string, request *ActionRequest)
 	return root.Event, resp, err
 }
 
-func (s *FloatingIPActionsServiceOp) get(path string) (*Action, *Response, error) {
-	req, err := s.client.NewRequest("GET", path, nil)
+func (s *FloatingIPActionsServiceOp) get(ctx context.Context, path string) (*Action, *Response, error) {
+	req, err := s.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -82,8 +85,8 @@ func (s *FloatingIPActionsServiceOp) get(path string) (*Action, *Response, error
 	return root.Event, resp, err
 }
 
-func (s *FloatingIPActionsServiceOp) list(path string) ([]Action, *Response, error) {
-	req, err := s.client.NewRequest("GET", path, nil)
+func (s *FloatingIPActionsServiceOp) list(ctx context.Context, path string) ([]Action, *Response, error) {
+	req, err := s.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/floating_ips_actions_test.go
+++ b/floating_ips_actions_test.go
@@ -33,7 +33,7 @@ func TestFloatingIPsActions_Assign(t *testing.T) {
 
 	})
 
-	assign, _, err := client.FloatingIPActions.Assign("192.168.0.1", 12345)
+	assign, _, err := client.FloatingIPActions.Assign(ctx, "192.168.0.1", 12345)
 	if err != nil {
 		t.Errorf("FloatingIPsActions.Assign returned error: %v", err)
 	}
@@ -67,7 +67,7 @@ func TestFloatingIPsActions_Unassign(t *testing.T) {
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
-	action, _, err := client.FloatingIPActions.Unassign("192.168.0.1")
+	action, _, err := client.FloatingIPActions.Unassign(ctx, "192.168.0.1")
 	if err != nil {
 		t.Errorf("FloatingIPsActions.Get returned error: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestFloatingIPsActions_Get(t *testing.T) {
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
-	action, _, err := client.FloatingIPActions.Get("192.168.0.1", 456)
+	action, _, err := client.FloatingIPActions.Get(ctx, "192.168.0.1", 456)
 	if err != nil {
 		t.Errorf("FloatingIPsActions.Get returned error: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestFloatingIPsActions_List(t *testing.T) {
 		fmt.Fprintf(w, `{"actions":[{"status":"in-progress"}]}`)
 	})
 
-	actions, _, err := client.FloatingIPActions.List("192.168.0.1", nil)
+	actions, _, err := client.FloatingIPActions.List(ctx, "192.168.0.1", nil)
 	if err != nil {
 		t.Errorf("FloatingIPsActions.List returned error: %v", err)
 	}
@@ -127,7 +127,7 @@ func TestFloatingIPsActions_ListMultiplePages(t *testing.T) {
 		fmt.Fprint(w, `{"actions":[{"status":"in-progress"}], "links":{"pages":{"next":"http://example.com/v2/floating_ips/192.168.0.1/actions?page=2"}}}`)
 	})
 
-	_, resp, err := client.FloatingIPActions.List("192.168.0.1", nil)
+	_, resp, err := client.FloatingIPActions.List(ctx, "192.168.0.1", nil)
 	if err != nil {
 		t.Errorf("FloatingIPsActions.List returned error: %v", err)
 	}
@@ -158,7 +158,7 @@ func TestFloatingIPsActions_ListPageByNumber(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	_, resp, err := client.FloatingIPActions.List("192.168.0.1", opt)
+	_, resp, err := client.FloatingIPActions.List(ctx, "192.168.0.1", opt)
 	if err != nil {
 		t.Errorf("FloatingIPsActions.List returned error: %v", err)
 	}

--- a/floating_ips_test.go
+++ b/floating_ips_test.go
@@ -17,7 +17,7 @@ func TestFloatingIPs_ListFloatingIPs(t *testing.T) {
 		fmt.Fprint(w, `{"floating_ips": [{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1"},{"region":{"slug":"nyc3"},"droplet":{"id":2},"ip":"192.168.0.2"}]}`)
 	})
 
-	floatingIPs, _, err := client.FloatingIPs.List(nil)
+	floatingIPs, _, err := client.FloatingIPs.List(ctx, nil)
 	if err != nil {
 		t.Errorf("FloatingIPs.List returned error: %v", err)
 	}
@@ -40,7 +40,7 @@ func TestFloatingIPs_ListFloatingIPsMultiplePages(t *testing.T) {
 		fmt.Fprint(w, `{"floating_ips": [{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1"},{"region":{"slug":"nyc3"},"droplet":{"id":2},"ip":"192.168.0.2"}], "links":{"pages":{"next":"http://example.com/v2/floating_ips/?page=2"}}}`)
 	})
 
-	_, resp, err := client.FloatingIPs.List(nil)
+	_, resp, err := client.FloatingIPs.List(ctx, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +71,7 @@ func TestFloatingIPs_RetrievePageByNumber(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	_, resp, err := client.FloatingIPs.List(opt)
+	_, resp, err := client.FloatingIPs.List(ctx, opt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,7 +88,7 @@ func TestFloatingIPs_Get(t *testing.T) {
 		fmt.Fprint(w, `{"floating_ip":{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1"}}`)
 	})
 
-	floatingIP, _, err := client.FloatingIPs.Get("192.168.0.1")
+	floatingIP, _, err := client.FloatingIPs.Get(ctx, "192.168.0.1")
 	if err != nil {
 		t.Errorf("domain.Get returned error: %v", err)
 	}
@@ -123,7 +123,7 @@ func TestFloatingIPs_Create(t *testing.T) {
 		fmt.Fprint(w, `{"floating_ip":{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1"}}`)
 	})
 
-	floatingIP, _, err := client.FloatingIPs.Create(createRequest)
+	floatingIP, _, err := client.FloatingIPs.Create(ctx, createRequest)
 	if err != nil {
 		t.Errorf("FloatingIPs.Create returned error: %v", err)
 	}
@@ -142,7 +142,7 @@ func TestFloatingIPs_Destroy(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.FloatingIPs.Delete("192.168.0.1")
+	_, err := client.FloatingIPs.Delete(ctx, "192.168.0.1")
 	if err != nil {
 		t.Errorf("FloatingIPs.Delete returned error: %v", err)
 	}

--- a/godo.go
+++ b/godo.go
@@ -2,6 +2,7 @@ package godo
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -214,7 +215,7 @@ func SetUserAgent(ua string) ClientOpt {
 // NewRequest creates an API request. A relative URL can be provided in urlStr, which will be resolved to the
 // BaseURL of the Client. Relative URLS should always be specified without a preceding slash. If specified, the
 // value pointed to by body is JSON encoded and included in as the request body.
-func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Request, error) {
+func (c *Client) NewRequest(ctx context.Context, method, urlStr string, body interface{}) (*http.Request, error) {
 	rel, err := url.Parse(urlStr)
 	if err != nil {
 		return nil, err
@@ -235,6 +236,7 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 		return nil, err
 	}
 
+	req = req.WithContext(ctx)
 	req.Header.Add("Content-Type", mediaType)
 	req.Header.Add("Accept", mediaType)
 	req.Header.Add("User-Agent", c.UserAgent)

--- a/godo_test.go
+++ b/godo_test.go
@@ -1,6 +1,7 @@
 package godo
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -15,6 +16,8 @@ import (
 
 var (
 	mux *http.ServeMux
+
+	ctx = context.TODO()
 
 	client *Client
 
@@ -134,7 +137,7 @@ func TestNewRequest(t *testing.T) {
 		`{"name":"l","region":"","size":"","image":0,`+
 			`"ssh_keys":null,"backups":false,"ipv6":false,`+
 			`"private_networking":false,"monitoring":false,"tags":null}`+"\n"
-	req, _ := c.NewRequest("GET", inURL, inBody)
+	req, _ := c.NewRequest(ctx, "GET", inURL, inBody)
 
 	// test relative URL was expanded
 	if req.URL.String() != outURL {
@@ -162,7 +165,7 @@ func TestNewRequest_withUserData(t *testing.T) {
 		`{"name":"l","region":"","size":"","image":0,`+
 			`"ssh_keys":null,"backups":false,"ipv6":false,`+
 			`"private_networking":false,"monitoring":false,"user_data":"u","tags":null}`+"\n"
-	req, _ := c.NewRequest("GET", inURL, inBody)
+	req, _ := c.NewRequest(ctx, "GET", inURL, inBody)
 
 	// test relative URL was expanded
 	if req.URL.String() != outURL {
@@ -184,7 +187,7 @@ func TestNewRequest_withUserData(t *testing.T) {
 
 func TestNewRequest_badURL(t *testing.T) {
 	c := NewClient(nil)
-	_, err := c.NewRequest("GET", ":", nil)
+	_, err := c.NewRequest(ctx, "GET", ":", nil)
 	testURLParseError(t, err)
 }
 
@@ -196,7 +199,7 @@ func TestNewRequest_withCustomUserAgent(t *testing.T) {
 		t.Fatalf("New() unexpected error: %v", err)
 	}
 
-	req, _ := c.NewRequest("GET", "/foo", nil)
+	req, _ := c.NewRequest(ctx, "GET", "/foo", nil)
 
 	expected := fmt.Sprintf("%s+%s", ua, userAgent)
 	if got := req.Header.Get("User-Agent"); got != expected {
@@ -219,7 +222,7 @@ func TestDo(t *testing.T) {
 		fmt.Fprint(w, `{"A":"a"}`)
 	})
 
-	req, _ := client.NewRequest("GET", "/", nil)
+	req, _ := client.NewRequest(ctx, "GET", "/", nil)
 	body := new(foo)
 	_, err := client.Do(req, body)
 	if err != nil {
@@ -240,7 +243,7 @@ func TestDo_httpError(t *testing.T) {
 		http.Error(w, "Bad Request", 400)
 	})
 
-	req, _ := client.NewRequest("GET", "/", nil)
+	req, _ := client.NewRequest(ctx, "GET", "/", nil)
 	_, err := client.Do(req, nil)
 
 	if err == nil {
@@ -258,7 +261,7 @@ func TestDo_redirectLoop(t *testing.T) {
 		http.Redirect(w, r, "/", http.StatusFound)
 	})
 
-	req, _ := client.NewRequest("GET", "/", nil)
+	req, _ := client.NewRequest(ctx, "GET", "/", nil)
 	_, err := client.Do(req, nil)
 
 	if err == nil {
@@ -343,7 +346,7 @@ func TestDo_rateLimit(t *testing.T) {
 		t.Errorf("Client rate reset not initialized to zero value")
 	}
 
-	req, _ := client.NewRequest("GET", "/", nil)
+	req, _ := client.NewRequest(ctx, "GET", "/", nil)
 	_, err := client.Do(req, nil)
 	if err != nil {
 		t.Fatalf("Do(): %v", err)
@@ -374,7 +377,7 @@ func TestDo_rateLimit_errorResponse(t *testing.T) {
 
 	var expected int
 
-	req, _ := client.NewRequest("GET", "/", nil)
+	req, _ := client.NewRequest(ctx, "GET", "/", nil)
 	_, _ = client.Do(req, nil)
 
 	if expected = 60; client.Rate.Limit != expected {
@@ -416,7 +419,7 @@ func TestDo_completion_callback(t *testing.T) {
 		fmt.Fprint(w, `{"A":"a"}`)
 	})
 
-	req, _ := client.NewRequest("GET", "/", nil)
+	req, _ := client.NewRequest(ctx, "GET", "/", nil)
 	body := new(foo)
 	var completedReq *http.Request
 	var completedResp string

--- a/image_actions.go
+++ b/image_actions.go
@@ -1,13 +1,16 @@
 package godo
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // ImageActionsService is an interface for interfacing with the image actions
 // endpoints of the DigitalOcean API
 // See: https://developers.digitalocean.com/documentation/v2#image-actions
 type ImageActionsService interface {
-	Get(int, int) (*Action, *Response, error)
-	Transfer(int, *ActionRequest) (*Action, *Response, error)
+	Get(context.Context, int, int) (*Action, *Response, error)
+	Transfer(context.Context, int, *ActionRequest) (*Action, *Response, error)
 }
 
 // ImageActionsServiceOp handles communition with the image action related methods of the
@@ -19,7 +22,7 @@ type ImageActionsServiceOp struct {
 var _ ImageActionsService = &ImageActionsServiceOp{}
 
 // Transfer an image
-func (i *ImageActionsServiceOp) Transfer(imageID int, transferRequest *ActionRequest) (*Action, *Response, error) {
+func (i *ImageActionsServiceOp) Transfer(ctx context.Context, imageID int, transferRequest *ActionRequest) (*Action, *Response, error) {
 	if imageID < 1 {
 		return nil, nil, NewArgError("imageID", "cannot be less than 1")
 	}
@@ -30,7 +33,7 @@ func (i *ImageActionsServiceOp) Transfer(imageID int, transferRequest *ActionReq
 
 	path := fmt.Sprintf("v2/images/%d/actions", imageID)
 
-	req, err := i.client.NewRequest("POST", path, transferRequest)
+	req, err := i.client.NewRequest(ctx, "POST", path, transferRequest)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -45,7 +48,7 @@ func (i *ImageActionsServiceOp) Transfer(imageID int, transferRequest *ActionReq
 }
 
 // Get an action for a particular image by id.
-func (i *ImageActionsServiceOp) Get(imageID, actionID int) (*Action, *Response, error) {
+func (i *ImageActionsServiceOp) Get(ctx context.Context, imageID, actionID int) (*Action, *Response, error) {
 	if imageID < 1 {
 		return nil, nil, NewArgError("imageID", "cannot be less than 1")
 	}
@@ -56,7 +59,7 @@ func (i *ImageActionsServiceOp) Get(imageID, actionID int) (*Action, *Response, 
 
 	path := fmt.Sprintf("v2/images/%d/actions/%d", imageID, actionID)
 
-	req, err := i.client.NewRequest("GET", path, nil)
+	req, err := i.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/image_actions_test.go
+++ b/image_actions_test.go
@@ -30,7 +30,7 @@ func TestImageActions_Transfer(t *testing.T) {
 
 	})
 
-	transfer, _, err := client.ImageActions.Transfer(12345, transferRequest)
+	transfer, _, err := client.ImageActions.Transfer(ctx, 12345, transferRequest)
 	if err != nil {
 		t.Errorf("ImageActions.Transfer returned error: %v", err)
 	}
@@ -50,7 +50,7 @@ func TestImageActions_Get(t *testing.T) {
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
-	action, _, err := client.ImageActions.Get(123, 456)
+	action, _, err := client.ImageActions.Get(ctx, 123, 456)
 	if err != nil {
 		t.Errorf("ImageActions.Get returned error: %v", err)
 	}

--- a/images.go
+++ b/images.go
@@ -1,6 +1,9 @@
 package godo
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 const imageBasePath = "v2/images"
 
@@ -8,14 +11,14 @@ const imageBasePath = "v2/images"
 // endpoints of the DigitalOcean API
 // See: https://developers.digitalocean.com/documentation/v2#images
 type ImagesService interface {
-	List(*ListOptions) ([]Image, *Response, error)
-	ListDistribution(opt *ListOptions) ([]Image, *Response, error)
-	ListApplication(opt *ListOptions) ([]Image, *Response, error)
-	ListUser(opt *ListOptions) ([]Image, *Response, error)
-	GetByID(int) (*Image, *Response, error)
-	GetBySlug(string) (*Image, *Response, error)
-	Update(int, *ImageUpdateRequest) (*Image, *Response, error)
-	Delete(int) (*Response, error)
+	List(context.Context, *ListOptions) ([]Image, *Response, error)
+	ListDistribution(ctx context.Context, opt *ListOptions) ([]Image, *Response, error)
+	ListApplication(ctx context.Context, opt *ListOptions) ([]Image, *Response, error)
+	ListUser(ctx context.Context, opt *ListOptions) ([]Image, *Response, error)
+	GetByID(context.Context, int) (*Image, *Response, error)
+	GetBySlug(context.Context, string) (*Image, *Response, error)
+	Update(context.Context, int, *ImageUpdateRequest) (*Image, *Response, error)
+	Delete(context.Context, int) (*Response, error)
 }
 
 // ImagesServiceOp handles communication with the image related methods of the
@@ -63,48 +66,48 @@ func (i Image) String() string {
 }
 
 // List lists all the images available.
-func (s *ImagesServiceOp) List(opt *ListOptions) ([]Image, *Response, error) {
-	return s.list(opt, nil)
+func (s *ImagesServiceOp) List(ctx context.Context, opt *ListOptions) ([]Image, *Response, error) {
+	return s.list(ctx, opt, nil)
 }
 
 // ListDistribution lists all the distribution images.
-func (s *ImagesServiceOp) ListDistribution(opt *ListOptions) ([]Image, *Response, error) {
+func (s *ImagesServiceOp) ListDistribution(ctx context.Context, opt *ListOptions) ([]Image, *Response, error) {
 	listOpt := listImageOptions{Type: "distribution"}
-	return s.list(opt, &listOpt)
+	return s.list(ctx, opt, &listOpt)
 }
 
 // ListApplication lists all the application images.
-func (s *ImagesServiceOp) ListApplication(opt *ListOptions) ([]Image, *Response, error) {
+func (s *ImagesServiceOp) ListApplication(ctx context.Context, opt *ListOptions) ([]Image, *Response, error) {
 	listOpt := listImageOptions{Type: "application"}
-	return s.list(opt, &listOpt)
+	return s.list(ctx, opt, &listOpt)
 }
 
 // ListUser lists all the user images.
-func (s *ImagesServiceOp) ListUser(opt *ListOptions) ([]Image, *Response, error) {
+func (s *ImagesServiceOp) ListUser(ctx context.Context, opt *ListOptions) ([]Image, *Response, error) {
 	listOpt := listImageOptions{Private: true}
-	return s.list(opt, &listOpt)
+	return s.list(ctx, opt, &listOpt)
 }
 
 // GetByID retrieves an image by id.
-func (s *ImagesServiceOp) GetByID(imageID int) (*Image, *Response, error) {
+func (s *ImagesServiceOp) GetByID(ctx context.Context, imageID int) (*Image, *Response, error) {
 	if imageID < 1 {
 		return nil, nil, NewArgError("imageID", "cannot be less than 1")
 	}
 
-	return s.get(interface{}(imageID))
+	return s.get(ctx, interface{}(imageID))
 }
 
 // GetBySlug retrieves an image by slug.
-func (s *ImagesServiceOp) GetBySlug(slug string) (*Image, *Response, error) {
+func (s *ImagesServiceOp) GetBySlug(ctx context.Context, slug string) (*Image, *Response, error) {
 	if len(slug) < 1 {
 		return nil, nil, NewArgError("slug", "cannot be blank")
 	}
 
-	return s.get(interface{}(slug))
+	return s.get(ctx, interface{}(slug))
 }
 
 // Update an image name.
-func (s *ImagesServiceOp) Update(imageID int, updateRequest *ImageUpdateRequest) (*Image, *Response, error) {
+func (s *ImagesServiceOp) Update(ctx context.Context, imageID int, updateRequest *ImageUpdateRequest) (*Image, *Response, error) {
 	if imageID < 1 {
 		return nil, nil, NewArgError("imageID", "cannot be less than 1")
 	}
@@ -114,7 +117,7 @@ func (s *ImagesServiceOp) Update(imageID int, updateRequest *ImageUpdateRequest)
 	}
 
 	path := fmt.Sprintf("%s/%d", imageBasePath, imageID)
-	req, err := s.client.NewRequest("PUT", path, updateRequest)
+	req, err := s.client.NewRequest(ctx, "PUT", path, updateRequest)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -129,14 +132,14 @@ func (s *ImagesServiceOp) Update(imageID int, updateRequest *ImageUpdateRequest)
 }
 
 // Delete an image.
-func (s *ImagesServiceOp) Delete(imageID int) (*Response, error) {
+func (s *ImagesServiceOp) Delete(ctx context.Context, imageID int) (*Response, error) {
 	if imageID < 1 {
 		return nil, NewArgError("imageID", "cannot be less than 1")
 	}
 
 	path := fmt.Sprintf("%s/%d", imageBasePath, imageID)
 
-	req, err := s.client.NewRequest("DELETE", path, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -147,10 +150,10 @@ func (s *ImagesServiceOp) Delete(imageID int) (*Response, error) {
 }
 
 // Helper method for getting an individual image
-func (s *ImagesServiceOp) get(ID interface{}) (*Image, *Response, error) {
+func (s *ImagesServiceOp) get(ctx context.Context, ID interface{}) (*Image, *Response, error) {
 	path := fmt.Sprintf("%s/%v", imageBasePath, ID)
 
-	req, err := s.client.NewRequest("GET", path, nil)
+	req, err := s.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -165,7 +168,7 @@ func (s *ImagesServiceOp) get(ID interface{}) (*Image, *Response, error) {
 }
 
 // Helper method for listing images
-func (s *ImagesServiceOp) list(opt *ListOptions, listOpt *listImageOptions) ([]Image, *Response, error) {
+func (s *ImagesServiceOp) list(ctx context.Context, opt *ListOptions, listOpt *listImageOptions) ([]Image, *Response, error) {
 	path := imageBasePath
 	path, err := addOptions(path, opt)
 	if err != nil {
@@ -176,7 +179,7 @@ func (s *ImagesServiceOp) list(opt *ListOptions, listOpt *listImageOptions) ([]I
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", path, nil)
+	req, err := s.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/images_test.go
+++ b/images_test.go
@@ -17,7 +17,7 @@ func TestImages_List(t *testing.T) {
 		fmt.Fprint(w, `{"images":[{"id":1},{"id":2}]}`)
 	})
 
-	images, _, err := client.Images.List(nil)
+	images, _, err := client.Images.List(ctx, nil)
 	if err != nil {
 		t.Errorf("Images.List returned error: %v", err)
 	}
@@ -42,7 +42,7 @@ func TestImages_ListDistribution(t *testing.T) {
 		fmt.Fprint(w, `{"images":[{"id":1},{"id":2}]}`)
 	})
 
-	images, _, err := client.Images.ListDistribution(nil)
+	images, _, err := client.Images.ListDistribution(ctx, nil)
 	if err != nil {
 		t.Errorf("Images.ListDistribution returned error: %v", err)
 	}
@@ -67,7 +67,7 @@ func TestImages_ListApplication(t *testing.T) {
 		fmt.Fprint(w, `{"images":[{"id":1},{"id":2}]}`)
 	})
 
-	images, _, err := client.Images.ListApplication(nil)
+	images, _, err := client.Images.ListApplication(ctx, nil)
 	if err != nil {
 		t.Errorf("Images.ListApplication returned error: %v", err)
 	}
@@ -93,7 +93,7 @@ func TestImages_ListUser(t *testing.T) {
 		fmt.Fprint(w, `{"images":[{"id":1},{"id":2}]}`)
 	})
 
-	images, _, err := client.Images.ListUser(nil)
+	images, _, err := client.Images.ListUser(ctx, nil)
 	if err != nil {
 		t.Errorf("Images.ListUser returned error: %v", err)
 	}
@@ -113,7 +113,7 @@ func TestImages_ListImagesMultiplePages(t *testing.T) {
 		fmt.Fprint(w, `{"images": [{"id":1},{"id":2}], "links":{"pages":{"next":"http://example.com/v2/images/?page=2"}}}`)
 	})
 
-	_, resp, err := client.Images.List(&ListOptions{Page: 2})
+	_, resp, err := client.Images.List(ctx, &ListOptions{Page: 2})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -143,7 +143,7 @@ func TestImages_RetrievePageByNumber(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	_, resp, err := client.Images.List(opt)
+	_, resp, err := client.Images.List(ctx, opt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -160,7 +160,7 @@ func TestImages_GetImageByID(t *testing.T) {
 		fmt.Fprint(w, `{"image":{"id":12345}}`)
 	})
 
-	images, _, err := client.Images.GetByID(12345)
+	images, _, err := client.Images.GetByID(ctx, 12345)
 	if err != nil {
 		t.Errorf("Image.GetByID returned error: %v", err)
 	}
@@ -180,7 +180,7 @@ func TestImages_GetImageBySlug(t *testing.T) {
 		fmt.Fprint(w, `{"image":{"id":12345}}`)
 	})
 
-	images, _, err := client.Images.GetBySlug("ubuntu")
+	images, _, err := client.Images.GetBySlug(ctx, "ubuntu")
 	if err != nil {
 		t.Errorf("Image.GetBySlug returned error: %v", err)
 	}
@@ -217,7 +217,7 @@ func TestImages_Update(t *testing.T) {
 		fmt.Fprintf(w, `{"image":{"id":1}}`)
 	})
 
-	image, _, err := client.Images.Update(12345, updateRequest)
+	image, _, err := client.Images.Update(ctx, 12345, updateRequest)
 	if err != nil {
 		t.Errorf("Images.Update returned error: %v", err)
 	} else {
@@ -235,7 +235,7 @@ func TestImages_Destroy(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Images.Delete(12345)
+	_, err := client.Images.Delete(ctx, 12345)
 	if err != nil {
 		t.Errorf("Image.Delete returned error: %v", err)
 	}

--- a/keys.go
+++ b/keys.go
@@ -1,6 +1,9 @@
 package godo
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 const keysBasePath = "v2/account/keys"
 
@@ -8,14 +11,14 @@ const keysBasePath = "v2/account/keys"
 // endpoints of the DigitalOcean API
 // See: https://developers.digitalocean.com/documentation/v2#keys
 type KeysService interface {
-	List(*ListOptions) ([]Key, *Response, error)
-	GetByID(int) (*Key, *Response, error)
-	GetByFingerprint(string) (*Key, *Response, error)
-	Create(*KeyCreateRequest) (*Key, *Response, error)
-	UpdateByID(int, *KeyUpdateRequest) (*Key, *Response, error)
-	UpdateByFingerprint(string, *KeyUpdateRequest) (*Key, *Response, error)
-	DeleteByID(int) (*Response, error)
-	DeleteByFingerprint(string) (*Response, error)
+	List(context.Context, *ListOptions) ([]Key, *Response, error)
+	GetByID(context.Context, int) (*Key, *Response, error)
+	GetByFingerprint(context.Context, string) (*Key, *Response, error)
+	Create(context.Context, *KeyCreateRequest) (*Key, *Response, error)
+	UpdateByID(context.Context, int, *KeyUpdateRequest) (*Key, *Response, error)
+	UpdateByFingerprint(context.Context, string, *KeyUpdateRequest) (*Key, *Response, error)
+	DeleteByID(context.Context, int) (*Response, error)
+	DeleteByFingerprint(context.Context, string) (*Response, error)
 }
 
 // KeysServiceOp handles communication with key related method of the
@@ -59,14 +62,14 @@ type KeyCreateRequest struct {
 }
 
 // List all keys
-func (s *KeysServiceOp) List(opt *ListOptions) ([]Key, *Response, error) {
+func (s *KeysServiceOp) List(ctx context.Context, opt *ListOptions) ([]Key, *Response, error) {
 	path := keysBasePath
 	path, err := addOptions(path, opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", path, nil)
+	req, err := s.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -84,8 +87,8 @@ func (s *KeysServiceOp) List(opt *ListOptions) ([]Key, *Response, error) {
 }
 
 // Performs a get given a path
-func (s *KeysServiceOp) get(path string) (*Key, *Response, error) {
-	req, err := s.client.NewRequest("GET", path, nil)
+func (s *KeysServiceOp) get(ctx context.Context, path string) (*Key, *Response, error) {
+	req, err := s.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -100,32 +103,32 @@ func (s *KeysServiceOp) get(path string) (*Key, *Response, error) {
 }
 
 // GetByID gets a Key by id
-func (s *KeysServiceOp) GetByID(keyID int) (*Key, *Response, error) {
+func (s *KeysServiceOp) GetByID(ctx context.Context, keyID int) (*Key, *Response, error) {
 	if keyID < 1 {
 		return nil, nil, NewArgError("keyID", "cannot be less than 1")
 	}
 
 	path := fmt.Sprintf("%s/%d", keysBasePath, keyID)
-	return s.get(path)
+	return s.get(ctx, path)
 }
 
 // GetByFingerprint gets a Key by by fingerprint
-func (s *KeysServiceOp) GetByFingerprint(fingerprint string) (*Key, *Response, error) {
+func (s *KeysServiceOp) GetByFingerprint(ctx context.Context, fingerprint string) (*Key, *Response, error) {
 	if len(fingerprint) < 1 {
 		return nil, nil, NewArgError("fingerprint", "cannot not be empty")
 	}
 
 	path := fmt.Sprintf("%s/%s", keysBasePath, fingerprint)
-	return s.get(path)
+	return s.get(ctx, path)
 }
 
 // Create a key using a KeyCreateRequest
-func (s *KeysServiceOp) Create(createRequest *KeyCreateRequest) (*Key, *Response, error) {
+func (s *KeysServiceOp) Create(ctx context.Context, createRequest *KeyCreateRequest) (*Key, *Response, error) {
 	if createRequest == nil {
 		return nil, nil, NewArgError("createRequest", "cannot be nil")
 	}
 
-	req, err := s.client.NewRequest("POST", keysBasePath, createRequest)
+	req, err := s.client.NewRequest(ctx, "POST", keysBasePath, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -140,7 +143,7 @@ func (s *KeysServiceOp) Create(createRequest *KeyCreateRequest) (*Key, *Response
 }
 
 // UpdateByID updates a key name by ID.
-func (s *KeysServiceOp) UpdateByID(keyID int, updateRequest *KeyUpdateRequest) (*Key, *Response, error) {
+func (s *KeysServiceOp) UpdateByID(ctx context.Context, keyID int, updateRequest *KeyUpdateRequest) (*Key, *Response, error) {
 	if keyID < 1 {
 		return nil, nil, NewArgError("keyID", "cannot be less than 1")
 	}
@@ -150,7 +153,7 @@ func (s *KeysServiceOp) UpdateByID(keyID int, updateRequest *KeyUpdateRequest) (
 	}
 
 	path := fmt.Sprintf("%s/%d", keysBasePath, keyID)
-	req, err := s.client.NewRequest("PUT", path, updateRequest)
+	req, err := s.client.NewRequest(ctx, "PUT", path, updateRequest)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -165,7 +168,7 @@ func (s *KeysServiceOp) UpdateByID(keyID int, updateRequest *KeyUpdateRequest) (
 }
 
 // UpdateByFingerprint updates a key name by fingerprint.
-func (s *KeysServiceOp) UpdateByFingerprint(fingerprint string, updateRequest *KeyUpdateRequest) (*Key, *Response, error) {
+func (s *KeysServiceOp) UpdateByFingerprint(ctx context.Context, fingerprint string, updateRequest *KeyUpdateRequest) (*Key, *Response, error) {
 	if len(fingerprint) < 1 {
 		return nil, nil, NewArgError("fingerprint", "cannot be empty")
 	}
@@ -175,7 +178,7 @@ func (s *KeysServiceOp) UpdateByFingerprint(fingerprint string, updateRequest *K
 	}
 
 	path := fmt.Sprintf("%s/%s", keysBasePath, fingerprint)
-	req, err := s.client.NewRequest("PUT", path, updateRequest)
+	req, err := s.client.NewRequest(ctx, "PUT", path, updateRequest)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -190,8 +193,8 @@ func (s *KeysServiceOp) UpdateByFingerprint(fingerprint string, updateRequest *K
 }
 
 // Delete key using a path
-func (s *KeysServiceOp) delete(path string) (*Response, error) {
-	req, err := s.client.NewRequest("DELETE", path, nil)
+func (s *KeysServiceOp) delete(ctx context.Context, path string) (*Response, error) {
+	req, err := s.client.NewRequest(ctx, "DELETE", path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -202,21 +205,21 @@ func (s *KeysServiceOp) delete(path string) (*Response, error) {
 }
 
 // DeleteByID deletes a key by its id
-func (s *KeysServiceOp) DeleteByID(keyID int) (*Response, error) {
+func (s *KeysServiceOp) DeleteByID(ctx context.Context, keyID int) (*Response, error) {
 	if keyID < 1 {
 		return nil, NewArgError("keyID", "cannot be less than 1")
 	}
 
 	path := fmt.Sprintf("%s/%d", keysBasePath, keyID)
-	return s.delete(path)
+	return s.delete(ctx, path)
 }
 
 // DeleteByFingerprint deletes a key by its fingerprint
-func (s *KeysServiceOp) DeleteByFingerprint(fingerprint string) (*Response, error) {
+func (s *KeysServiceOp) DeleteByFingerprint(ctx context.Context, fingerprint string) (*Response, error) {
 	if len(fingerprint) < 1 {
 		return nil, NewArgError("fingerprint", "cannot be empty")
 	}
 
 	path := fmt.Sprintf("%s/%s", keysBasePath, fingerprint)
-	return s.delete(path)
+	return s.delete(ctx, path)
 }

--- a/keys_test.go
+++ b/keys_test.go
@@ -17,7 +17,7 @@ func TestKeys_List(t *testing.T) {
 		fmt.Fprint(w, `{"ssh_keys":[{"id":1},{"id":2}]}`)
 	})
 
-	keys, _, err := client.Keys.List(nil)
+	keys, _, err := client.Keys.List(ctx, nil)
 	if err != nil {
 		t.Errorf("Keys.List returned error: %v", err)
 	}
@@ -37,7 +37,7 @@ func TestKeys_ListKeysMultiplePages(t *testing.T) {
 		fmt.Fprint(w, `{"droplets": [{"id":1},{"id":2}], "links":{"pages":{"next":"http://example.com/v2/account/keys/?page=2"}}}`)
 	})
 
-	_, resp, err := client.Keys.List(nil)
+	_, resp, err := client.Keys.List(ctx, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,7 +67,7 @@ func TestKeys_RetrievePageByNumber(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	_, resp, err := client.Keys.List(opt)
+	_, resp, err := client.Keys.List(ctx, opt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,7 +83,7 @@ func TestKeys_GetByID(t *testing.T) {
 		fmt.Fprint(w, `{"ssh_key": {"id":12345}}`)
 	})
 
-	keys, _, err := client.Keys.GetByID(12345)
+	keys, _, err := client.Keys.GetByID(ctx, 12345)
 	if err != nil {
 		t.Errorf("Keys.GetByID returned error: %v", err)
 	}
@@ -103,7 +103,7 @@ func TestKeys_GetByFingerprint(t *testing.T) {
 		fmt.Fprint(w, `{"ssh_key": {"fingerprint":"aa:bb:cc"}}`)
 	})
 
-	keys, _, err := client.Keys.GetByFingerprint("aa:bb:cc")
+	keys, _, err := client.Keys.GetByFingerprint(ctx, "aa:bb:cc")
 	if err != nil {
 		t.Errorf("Keys.GetByFingerprint returned error: %v", err)
 	}
@@ -138,7 +138,7 @@ func TestKeys_Create(t *testing.T) {
 		fmt.Fprintf(w, `{"ssh_key":{"id":1}}`)
 	})
 
-	key, _, err := client.Keys.Create(createRequest)
+	key, _, err := client.Keys.Create(ctx, createRequest)
 	if err != nil {
 		t.Errorf("Keys.Create returned error: %v", err)
 	}
@@ -175,7 +175,7 @@ func TestKeys_UpdateByID(t *testing.T) {
 		fmt.Fprintf(w, `{"ssh_key":{"id":1}}`)
 	})
 
-	key, _, err := client.Keys.UpdateByID(12345, updateRequest)
+	key, _, err := client.Keys.UpdateByID(ctx, 12345, updateRequest)
 	if err != nil {
 		t.Errorf("Keys.Update returned error: %v", err)
 	} else {
@@ -211,7 +211,7 @@ func TestKeys_UpdateByFingerprint(t *testing.T) {
 		fmt.Fprintf(w, `{"ssh_key":{"id":1}}`)
 	})
 
-	key, _, err := client.Keys.UpdateByFingerprint("3b:16:bf:e4:8b:00:8b:b8:59:8c:a9:d3:f0:19:45:fa", updateRequest)
+	key, _, err := client.Keys.UpdateByFingerprint(ctx, "3b:16:bf:e4:8b:00:8b:b8:59:8c:a9:d3:f0:19:45:fa", updateRequest)
 	if err != nil {
 		t.Errorf("Keys.Update returned error: %v", err)
 	} else {
@@ -229,7 +229,7 @@ func TestKeys_DestroyByID(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Keys.DeleteByID(12345)
+	_, err := client.Keys.DeleteByID(ctx, 12345)
 	if err != nil {
 		t.Errorf("Keys.Delete returned error: %v", err)
 	}
@@ -243,7 +243,7 @@ func TestKeys_DestroyByFingerprint(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Keys.DeleteByFingerprint("aa:bb:cc")
+	_, err := client.Keys.DeleteByFingerprint(ctx, "aa:bb:cc")
 	if err != nil {
 		t.Errorf("Keys.Delete returned error: %v", err)
 	}

--- a/links.go
+++ b/links.go
@@ -1,6 +1,7 @@
 package godo
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 )
@@ -77,6 +78,6 @@ func pageForURL(urlText string) (int, error) {
 }
 
 // Get a link action by id.
-func (la *LinkAction) Get(client *Client) (*Action, *Response, error) {
-	return client.Actions.Get(la.ID)
+func (la *LinkAction) Get(ctx context.Context, client *Client) (*Action, *Response, error) {
+	return client.Actions.Get(ctx, la.ID)
 }

--- a/load_balancers.go
+++ b/load_balancers.go
@@ -1,6 +1,7 @@
 package godo
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -11,15 +12,15 @@ const dropletsPath = "droplets"
 // LoadBalancersService is an interface for managing load balancers with the DigitalOcean API.
 // See: https://developers.digitalocean.com/documentation/v2#load-balancers
 type LoadBalancersService interface {
-	Get(lbID string) (*LoadBalancer, *Response, error)
-	List(opt *ListOptions) ([]LoadBalancer, *Response, error)
-	Create(lbr *LoadBalancerRequest) (*LoadBalancer, *Response, error)
-	Update(lbID string, lbr *LoadBalancerRequest) (*LoadBalancer, *Response, error)
-	Delete(lbID string) (*Response, error)
-	AddDroplets(lbID string, dropletIDs ...int) (*Response, error)
-	RemoveDroplets(lbID string, dropletIDs ...int) (*Response, error)
-	AddForwardingRules(lbID string, rules ...ForwardingRule) (*Response, error)
-	RemoveForwardingRules(lbID string, rules ...ForwardingRule) (*Response, error)
+	Get(context.Context, string) (*LoadBalancer, *Response, error)
+	List(context.Context, *ListOptions) ([]LoadBalancer, *Response, error)
+	Create(context.Context, *LoadBalancerRequest) (*LoadBalancer, *Response, error)
+	Update(ctx context.Context, lbID string, lbr *LoadBalancerRequest) (*LoadBalancer, *Response, error)
+	Delete(ctx context.Context, lbID string) (*Response, error)
+	AddDroplets(ctx context.Context, lbID string, dropletIDs ...int) (*Response, error)
+	RemoveDroplets(ctx context.Context, lbID string, dropletIDs ...int) (*Response, error)
+	AddForwardingRules(ctx context.Context, lbID string, rules ...ForwardingRule) (*Response, error)
+	RemoveForwardingRules(ctx context.Context, lbID string, rules ...ForwardingRule) (*Response, error)
 }
 
 // LoadBalancer represents a DigitalOcean load balancer configuration.
@@ -138,10 +139,10 @@ type LoadBalancersServiceOp struct {
 var _ LoadBalancersService = &LoadBalancersServiceOp{}
 
 // Get an existing load balancer by its identifier.
-func (l *LoadBalancersServiceOp) Get(lbID string) (*LoadBalancer, *Response, error) {
+func (l *LoadBalancersServiceOp) Get(ctx context.Context, lbID string) (*LoadBalancer, *Response, error) {
 	path := fmt.Sprintf("%s/%s", loadBalancersBasePath, lbID)
 
-	req, err := l.client.NewRequest("GET", path, nil)
+	req, err := l.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -156,13 +157,13 @@ func (l *LoadBalancersServiceOp) Get(lbID string) (*LoadBalancer, *Response, err
 }
 
 // List load balancers, with optional pagination.
-func (l *LoadBalancersServiceOp) List(opt *ListOptions) ([]LoadBalancer, *Response, error) {
+func (l *LoadBalancersServiceOp) List(ctx context.Context, opt *ListOptions) ([]LoadBalancer, *Response, error) {
 	path, err := addOptions(loadBalancersBasePath, opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := l.client.NewRequest("GET", path, nil)
+	req, err := l.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -180,8 +181,8 @@ func (l *LoadBalancersServiceOp) List(opt *ListOptions) ([]LoadBalancer, *Respon
 }
 
 // Create a new load balancer with a given configuration.
-func (l *LoadBalancersServiceOp) Create(lbr *LoadBalancerRequest) (*LoadBalancer, *Response, error) {
-	req, err := l.client.NewRequest("POST", loadBalancersBasePath, lbr)
+func (l *LoadBalancersServiceOp) Create(ctx context.Context, lbr *LoadBalancerRequest) (*LoadBalancer, *Response, error) {
+	req, err := l.client.NewRequest(ctx, "POST", loadBalancersBasePath, lbr)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -196,10 +197,10 @@ func (l *LoadBalancersServiceOp) Create(lbr *LoadBalancerRequest) (*LoadBalancer
 }
 
 // Update an existing load balancer with new configuration.
-func (l *LoadBalancersServiceOp) Update(lbID string, lbr *LoadBalancerRequest) (*LoadBalancer, *Response, error) {
+func (l *LoadBalancersServiceOp) Update(ctx context.Context, lbID string, lbr *LoadBalancerRequest) (*LoadBalancer, *Response, error) {
 	path := fmt.Sprintf("%s/%s", loadBalancersBasePath, lbID)
 
-	req, err := l.client.NewRequest("PUT", path, lbr)
+	req, err := l.client.NewRequest(ctx, "PUT", path, lbr)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -214,10 +215,10 @@ func (l *LoadBalancersServiceOp) Update(lbID string, lbr *LoadBalancerRequest) (
 }
 
 // Delete a load balancer by its identifier.
-func (l *LoadBalancersServiceOp) Delete(ldID string) (*Response, error) {
+func (l *LoadBalancersServiceOp) Delete(ctx context.Context, ldID string) (*Response, error) {
 	path := fmt.Sprintf("%s/%s", loadBalancersBasePath, ldID)
 
-	req, err := l.client.NewRequest("DELETE", path, nil)
+	req, err := l.client.NewRequest(ctx, "DELETE", path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -226,10 +227,10 @@ func (l *LoadBalancersServiceOp) Delete(ldID string) (*Response, error) {
 }
 
 // AddDroplets adds droplets to a load balancer.
-func (l *LoadBalancersServiceOp) AddDroplets(lbID string, dropletIDs ...int) (*Response, error) {
+func (l *LoadBalancersServiceOp) AddDroplets(ctx context.Context, lbID string, dropletIDs ...int) (*Response, error) {
 	path := fmt.Sprintf("%s/%s/%s", loadBalancersBasePath, lbID, dropletsPath)
 
-	req, err := l.client.NewRequest("POST", path, &dropletIDsRequest{IDs: dropletIDs})
+	req, err := l.client.NewRequest(ctx, "POST", path, &dropletIDsRequest{IDs: dropletIDs})
 	if err != nil {
 		return nil, err
 	}
@@ -238,10 +239,10 @@ func (l *LoadBalancersServiceOp) AddDroplets(lbID string, dropletIDs ...int) (*R
 }
 
 // RemoveDroplets removes droplets from a load balancer.
-func (l *LoadBalancersServiceOp) RemoveDroplets(lbID string, dropletIDs ...int) (*Response, error) {
+func (l *LoadBalancersServiceOp) RemoveDroplets(ctx context.Context, lbID string, dropletIDs ...int) (*Response, error) {
 	path := fmt.Sprintf("%s/%s/%s", loadBalancersBasePath, lbID, dropletsPath)
 
-	req, err := l.client.NewRequest("DELETE", path, &dropletIDsRequest{IDs: dropletIDs})
+	req, err := l.client.NewRequest(ctx, "DELETE", path, &dropletIDsRequest{IDs: dropletIDs})
 	if err != nil {
 		return nil, err
 	}
@@ -250,10 +251,10 @@ func (l *LoadBalancersServiceOp) RemoveDroplets(lbID string, dropletIDs ...int) 
 }
 
 // AddForwardingRules adds forwarding rules to a load balancer.
-func (l *LoadBalancersServiceOp) AddForwardingRules(lbID string, rules ...ForwardingRule) (*Response, error) {
+func (l *LoadBalancersServiceOp) AddForwardingRules(ctx context.Context, lbID string, rules ...ForwardingRule) (*Response, error) {
 	path := fmt.Sprintf("%s/%s/%s", loadBalancersBasePath, lbID, forwardingRulesPath)
 
-	req, err := l.client.NewRequest("POST", path, &forwardingRulesRequest{Rules: rules})
+	req, err := l.client.NewRequest(ctx, "POST", path, &forwardingRulesRequest{Rules: rules})
 	if err != nil {
 		return nil, err
 	}
@@ -262,10 +263,10 @@ func (l *LoadBalancersServiceOp) AddForwardingRules(lbID string, rules ...Forwar
 }
 
 // RemoveForwardingRules removes forwarding rules from a load balancer.
-func (l *LoadBalancersServiceOp) RemoveForwardingRules(lbID string, rules ...ForwardingRule) (*Response, error) {
+func (l *LoadBalancersServiceOp) RemoveForwardingRules(ctx context.Context, lbID string, rules ...ForwardingRule) (*Response, error) {
 	path := fmt.Sprintf("%s/%s/%s", loadBalancersBasePath, lbID, forwardingRulesPath)
 
-	req, err := l.client.NewRequest("DELETE", path, &forwardingRulesRequest{Rules: rules})
+	req, err := l.client.NewRequest(ctx, "DELETE", path, &forwardingRulesRequest{Rules: rules})
 	if err != nil {
 		return nil, err
 	}

--- a/load_balancers_test.go
+++ b/load_balancers_test.go
@@ -284,7 +284,7 @@ func TestLoadBlanacers_Get(t *testing.T) {
 		fmt.Fprint(w, lbGetJSONResponse)
 	})
 
-	loadBalancer, _, err := client.LoadBalancers.Get(loadBalancerId)
+	loadBalancer, _, err := client.LoadBalancers.Get(ctx, loadBalancerId)
 	if err != nil {
 		t.Errorf("LoadBalancers.Get returned error: %v", err)
 	}
@@ -383,7 +383,7 @@ func TestLoadBlanacers_Create(t *testing.T) {
 		fmt.Fprint(w, lbCreateJSONResponse)
 	})
 
-	loadBalancer, _, err := client.LoadBalancers.Create(createRequest)
+	loadBalancer, _, err := client.LoadBalancers.Create(ctx, createRequest)
 	if err != nil {
 		t.Errorf("LoadBalancers.Create returned error: %v", err)
 	}
@@ -495,7 +495,7 @@ func TestLoadBlanacers_Update(t *testing.T) {
 		fmt.Fprint(w, lbUpdateJSONResponse)
 	})
 
-	loadBalancer, _, err := client.LoadBalancers.Update(loadBalancerId, updateRequest)
+	loadBalancer, _, err := client.LoadBalancers.Update(ctx, loadBalancerId, updateRequest)
 	if err != nil {
 		t.Errorf("LoadBalancers.Update returned error: %v", err)
 	}
@@ -557,7 +557,7 @@ func TestLoadBlanacers_List(t *testing.T) {
 		fmt.Fprint(w, lbListJSONResponse)
 	})
 
-	loadBalancers, _, err := client.LoadBalancers.List(nil)
+	loadBalancers, _, err := client.LoadBalancers.List(ctx, nil)
 
 	if err != nil {
 		t.Errorf("LoadBalancers.List returned error: %v", err)
@@ -620,7 +620,7 @@ func TestLoadBlanacers_List_Pagination(t *testing.T) {
 	})
 
 	opts := &ListOptions{Page: 2}
-	_, resp, err := client.LoadBalancers.List(opts)
+	_, resp, err := client.LoadBalancers.List(ctx, opts)
 
 	if err != nil {
 		t.Errorf("LoadBalancers.List returned error: %v", err)
@@ -641,7 +641,7 @@ func TestLoadBlanacers_Delete(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.LoadBalancers.Delete(lbID)
+	_, err := client.LoadBalancers.Delete(ctx, lbID)
 
 	if err != nil {
 		t.Errorf("LoadBalancers.Delete returned error: %v", err)
@@ -671,7 +671,7 @@ func TestLoadBlanacers_AddDroplets(t *testing.T) {
 		fmt.Fprint(w, nil)
 	})
 
-	_, err := client.LoadBalancers.AddDroplets(lbID, dropletIdsRequest.IDs...)
+	_, err := client.LoadBalancers.AddDroplets(ctx, lbID, dropletIdsRequest.IDs...)
 
 	if err != nil {
 		t.Errorf("LoadBalancers.AddDroplets returned error: %v", err)
@@ -701,7 +701,7 @@ func TestLoadBlanacers_RemoveDroplets(t *testing.T) {
 		fmt.Fprint(w, nil)
 	})
 
-	_, err := client.LoadBalancers.RemoveDroplets(lbID, dropletIdsRequest.IDs...)
+	_, err := client.LoadBalancers.RemoveDroplets(ctx, lbID, dropletIdsRequest.IDs...)
 
 	if err != nil {
 		t.Errorf("LoadBalancers.RemoveDroplets returned error: %v", err)
@@ -745,7 +745,7 @@ func TestLoadBlanacers_AddForwardingRules(t *testing.T) {
 		fmt.Fprint(w, nil)
 	})
 
-	_, err := client.LoadBalancers.AddForwardingRules(lbID, frr.Rules...)
+	_, err := client.LoadBalancers.AddForwardingRules(ctx, lbID, frr.Rules...)
 
 	if err != nil {
 		t.Errorf("LoadBalancers.AddForwardingRules returned error: %v", err)
@@ -788,7 +788,7 @@ func TestLoadBlanacers_RemoveForwardingRules(t *testing.T) {
 		fmt.Fprint(w, nil)
 	})
 
-	_, err := client.LoadBalancers.RemoveForwardingRules(lbID, frr.Rules...)
+	_, err := client.LoadBalancers.RemoveForwardingRules(ctx, lbID, frr.Rules...)
 
 	if err != nil {
 		t.Errorf("LoadBalancers.RemoveForwardingRules returned error: %v", err)

--- a/regions.go
+++ b/regions.go
@@ -1,10 +1,12 @@
 package godo
 
+import "context"
+
 // RegionsService is an interface for interfacing with the regions
 // endpoints of the DigitalOcean API
 // See: https://developers.digitalocean.com/documentation/v2#regions
 type RegionsService interface {
-	List(*ListOptions) ([]Region, *Response, error)
+	List(context.Context, *ListOptions) ([]Region, *Response, error)
 }
 
 // RegionsServiceOp handles communication with the region related methods of the
@@ -34,14 +36,14 @@ func (r Region) String() string {
 }
 
 // List all regions
-func (s *RegionsServiceOp) List(opt *ListOptions) ([]Region, *Response, error) {
+func (s *RegionsServiceOp) List(ctx context.Context, opt *ListOptions) ([]Region, *Response, error) {
 	path := "v2/regions"
 	path, err := addOptions(path, opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", path, nil)
+	req, err := s.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/regions_test.go
+++ b/regions_test.go
@@ -16,7 +16,7 @@ func TestRegions_List(t *testing.T) {
 		fmt.Fprint(w, `{"regions":[{"slug":"1"},{"slug":"2"}]}`)
 	})
 
-	regions, _, err := client.Regions.List(nil)
+	regions, _, err := client.Regions.List(ctx, nil)
 	if err != nil {
 		t.Errorf("Regions.List returned error: %v", err)
 	}
@@ -36,7 +36,7 @@ func TestRegions_ListRegionsMultiplePages(t *testing.T) {
 		fmt.Fprint(w, `{"regions": [{"id":1},{"id":2}], "links":{"pages":{"next":"http://example.com/v2/regions/?page=2"}}}`)
 	})
 
-	_, resp, err := client.Regions.List(nil)
+	_, resp, err := client.Regions.List(ctx, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,7 +67,7 @@ func TestRegions_RetrievePageByNumber(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	_, resp, err := client.Regions.List(opt)
+	_, resp, err := client.Regions.List(ctx, opt)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sizes.go
+++ b/sizes.go
@@ -1,10 +1,12 @@
 package godo
 
+import "context"
+
 // SizesService is an interface for interfacing with the size
 // endpoints of the DigitalOcean API
 // See: https://developers.digitalocean.com/documentation/v2#sizes
 type SizesService interface {
-	List(*ListOptions) ([]Size, *Response, error)
+	List(context.Context, *ListOptions) ([]Size, *Response, error)
 }
 
 // SizesServiceOp handles communication with the size related methods of the
@@ -38,14 +40,14 @@ type sizesRoot struct {
 }
 
 // List all images
-func (s *SizesServiceOp) List(opt *ListOptions) ([]Size, *Response, error) {
+func (s *SizesServiceOp) List(ctx context.Context, opt *ListOptions) ([]Size, *Response, error) {
 	path := "v2/sizes"
 	path, err := addOptions(path, opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", path, nil)
+	req, err := s.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sizes_test.go
+++ b/sizes_test.go
@@ -16,7 +16,7 @@ func TestSizes_List(t *testing.T) {
 		fmt.Fprint(w, `{"sizes":[{"slug":"1"},{"slug":"2"}]}`)
 	})
 
-	sizes, _, err := client.Sizes.List(nil)
+	sizes, _, err := client.Sizes.List(ctx, nil)
 	if err != nil {
 		t.Errorf("Sizes.List returned error: %v", err)
 	}
@@ -36,7 +36,7 @@ func TestSizes_ListSizesMultiplePages(t *testing.T) {
 		fmt.Fprint(w, `{"sizes": [{"id":1},{"id":2}], "links":{"pages":{"next":"http://example.com/v2/sizes/?page=2"}}}`)
 	})
 
-	_, resp, err := client.Sizes.List(nil)
+	_, resp, err := client.Sizes.List(ctx, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,7 +67,7 @@ func TestSizes_RetrievePageByNumber(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 2}
-	_, resp, err := client.Sizes.List(opt)
+	_, resp, err := client.Sizes.List(ctx, opt)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/snapshots.go
+++ b/snapshots.go
@@ -1,6 +1,9 @@
 package godo
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 const snapshotBasePath = "v2/snapshots"
 
@@ -8,11 +11,11 @@ const snapshotBasePath = "v2/snapshots"
 // endpoints of the DigitalOcean API
 // See: https://developers.digitalocean.com/documentation/v2#snapshots
 type SnapshotsService interface {
-	List(*ListOptions) ([]Snapshot, *Response, error)
-	ListVolume(*ListOptions) ([]Snapshot, *Response, error)
-	ListDroplet(*ListOptions) ([]Snapshot, *Response, error)
-	Get(string) (*Snapshot, *Response, error)
-	Delete(string) (*Response, error)
+	List(context.Context, *ListOptions) ([]Snapshot, *Response, error)
+	ListVolume(context.Context, *ListOptions) ([]Snapshot, *Response, error)
+	ListDroplet(context.Context, *ListOptions) ([]Snapshot, *Response, error)
+	Get(context.Context, string) (*Snapshot, *Response, error)
+	Delete(context.Context, string) (*Response, error)
 }
 
 // SnapshotsServiceOp handles communication with the snapshot related methods of the
@@ -53,32 +56,32 @@ func (s Snapshot) String() string {
 }
 
 // List lists all the snapshots available.
-func (s *SnapshotsServiceOp) List(opt *ListOptions) ([]Snapshot, *Response, error) {
-	return s.list(opt, nil)
+func (s *SnapshotsServiceOp) List(ctx context.Context, opt *ListOptions) ([]Snapshot, *Response, error) {
+	return s.list(ctx, opt, nil)
 }
 
 // ListDroplet lists all the Droplet snapshots.
-func (s *SnapshotsServiceOp) ListDroplet(opt *ListOptions) ([]Snapshot, *Response, error) {
+func (s *SnapshotsServiceOp) ListDroplet(ctx context.Context, opt *ListOptions) ([]Snapshot, *Response, error) {
 	listOpt := listSnapshotOptions{ResourceType: "droplet"}
-	return s.list(opt, &listOpt)
+	return s.list(ctx, opt, &listOpt)
 }
 
 // ListVolume lists all the volume snapshots.
-func (s *SnapshotsServiceOp) ListVolume(opt *ListOptions) ([]Snapshot, *Response, error) {
+func (s *SnapshotsServiceOp) ListVolume(ctx context.Context, opt *ListOptions) ([]Snapshot, *Response, error) {
 	listOpt := listSnapshotOptions{ResourceType: "volume"}
-	return s.list(opt, &listOpt)
+	return s.list(ctx, opt, &listOpt)
 }
 
 // Get retrieves an snapshot by id.
-func (s *SnapshotsServiceOp) Get(snapshotID string) (*Snapshot, *Response, error) {
-	return s.get(interface{}(snapshotID))
+func (s *SnapshotsServiceOp) Get(ctx context.Context, snapshotID string) (*Snapshot, *Response, error) {
+	return s.get(ctx, snapshotID)
 }
 
 // Delete an snapshot.
-func (s *SnapshotsServiceOp) Delete(snapshotID string) (*Response, error) {
+func (s *SnapshotsServiceOp) Delete(ctx context.Context, snapshotID string) (*Response, error) {
 	path := fmt.Sprintf("%s/%s", snapshotBasePath, snapshotID)
 
-	req, err := s.client.NewRequest("DELETE", path, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -89,10 +92,10 @@ func (s *SnapshotsServiceOp) Delete(snapshotID string) (*Response, error) {
 }
 
 // Helper method for getting an individual snapshot
-func (s *SnapshotsServiceOp) get(ID interface{}) (*Snapshot, *Response, error) {
-	path := fmt.Sprintf("%s/%v", snapshotBasePath, ID)
+func (s *SnapshotsServiceOp) get(ctx context.Context, ID string) (*Snapshot, *Response, error) {
+	path := fmt.Sprintf("%s/%s", snapshotBasePath, ID)
 
-	req, err := s.client.NewRequest("GET", path, nil)
+	req, err := s.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -107,7 +110,7 @@ func (s *SnapshotsServiceOp) get(ID interface{}) (*Snapshot, *Response, error) {
 }
 
 // Helper method for listing snapshots
-func (s *SnapshotsServiceOp) list(opt *ListOptions, listOpt *listSnapshotOptions) ([]Snapshot, *Response, error) {
+func (s *SnapshotsServiceOp) list(ctx context.Context, opt *ListOptions, listOpt *listSnapshotOptions) ([]Snapshot, *Response, error) {
 	path := snapshotBasePath
 	path, err := addOptions(path, opt)
 	if err != nil {
@@ -118,7 +121,7 @@ func (s *SnapshotsServiceOp) list(opt *ListOptions, listOpt *listSnapshotOptions
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", path, nil)
+	req, err := s.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/snapshots_test.go
+++ b/snapshots_test.go
@@ -1,6 +1,7 @@
 package godo
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -15,8 +16,8 @@ func TestSnapshots_List(t *testing.T) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{"snapshots":[{"id":"1"},{"id":"2", "size_gigabytes": 4.84}]}`)
 	})
-
-	snapshots, _, err := client.Snapshots.List(nil)
+	ctx := context.Background()
+	snapshots, _, err := client.Snapshots.List(ctx, nil)
 	if err != nil {
 		t.Errorf("Snapshots.List returned error: %v", err)
 	}
@@ -41,7 +42,8 @@ func TestSnapshots_ListVolume(t *testing.T) {
 		fmt.Fprint(w, `{"snapshots":[{"id":"1"},{"id":"2"}]}`)
 	})
 
-	snapshots, _, err := client.Snapshots.ListVolume(nil)
+	ctx := context.Background()
+	snapshots, _, err := client.Snapshots.ListVolume(ctx, nil)
 	if err != nil {
 		t.Errorf("Snapshots.ListVolume returned error: %v", err)
 	}
@@ -67,7 +69,8 @@ func TestSnapshots_ListDroplet(t *testing.T) {
 		fmt.Fprint(w, `{"snapshots":[{"id":"1"},{"id":"2", "size_gigabytes": 4.84}]}`)
 	})
 
-	snapshots, _, err := client.Snapshots.ListDroplet(nil)
+	ctx := context.Background()
+	snapshots, _, err := client.Snapshots.ListDroplet(ctx, nil)
 	if err != nil {
 		t.Errorf("Snapshots.ListDroplet returned error: %v", err)
 	}
@@ -87,7 +90,8 @@ func TestSnapshots_ListSnapshotsMultiplePages(t *testing.T) {
 		fmt.Fprint(w, `{"snapshots": [{"id":"1"},{"id":"2"}], "links":{"pages":{"next":"http://example.com/v2/snapshots/?page=2"}}}`)
 	})
 
-	_, resp, err := client.Snapshots.List(&ListOptions{Page: 2})
+	ctx := context.Background()
+	_, resp, err := client.Snapshots.List(ctx, &ListOptions{Page: 2})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,8 +120,9 @@ func TestSnapshots_RetrievePageByNumber(t *testing.T) {
 		fmt.Fprint(w, jBlob)
 	})
 
+	ctx := context.Background()
 	opt := &ListOptions{Page: 2}
-	_, resp, err := client.Snapshots.List(opt)
+	_, resp, err := client.Snapshots.List(ctx, opt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +139,8 @@ func TestSnapshots_GetSnapshotByID(t *testing.T) {
 		fmt.Fprint(w, `{"snapshot":{"id":"12345"}}`)
 	})
 
-	snapshots, _, err := client.Snapshots.Get("12345")
+	ctx := context.Background()
+	snapshots, _, err := client.Snapshots.Get(ctx, "12345")
 	if err != nil {
 		t.Errorf("Snapshot.GetByID returned error: %v", err)
 	}
@@ -153,7 +159,8 @@ func TestSnapshots_Destroy(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Snapshots.Delete("12345")
+	ctx := context.Background()
+	_, err := client.Snapshots.Delete(ctx, "12345")
 	if err != nil {
 		t.Errorf("Snapshot.Delete returned error: %v", err)
 	}

--- a/storage.go
+++ b/storage.go
@@ -1,6 +1,7 @@
 package godo
 
 import (
+	"context"
 	"fmt"
 	"time"
 )
@@ -15,14 +16,14 @@ const (
 // endpoints of the Digital Ocean API.
 // See: https://developers.digitalocean.com/documentation/v2#storage
 type StorageService interface {
-	ListVolumes(*ListVolumeParams) ([]Volume, *Response, error)
-	GetVolume(string) (*Volume, *Response, error)
-	CreateVolume(*VolumeCreateRequest) (*Volume, *Response, error)
-	DeleteVolume(string) (*Response, error)
-	ListSnapshots(volumeID string, opts *ListOptions) ([]Snapshot, *Response, error)
-	GetSnapshot(string) (*Snapshot, *Response, error)
-	CreateSnapshot(*SnapshotCreateRequest) (*Snapshot, *Response, error)
-	DeleteSnapshot(string) (*Response, error)
+	ListVolumes(context.Context, *ListVolumeParams) ([]Volume, *Response, error)
+	GetVolume(context.Context, string) (*Volume, *Response, error)
+	CreateVolume(context.Context, *VolumeCreateRequest) (*Volume, *Response, error)
+	DeleteVolume(context.Context, string) (*Response, error)
+	ListSnapshots(ctx context.Context, volumeID string, opts *ListOptions) ([]Snapshot, *Response, error)
+	GetSnapshot(context.Context, string) (*Snapshot, *Response, error)
+	CreateSnapshot(context.Context, *SnapshotCreateRequest) (*Snapshot, *Response, error)
+	DeleteSnapshot(context.Context, string) (*Response, error)
 }
 
 // StorageServiceOp handles communication with the storage volumes related methods of the
@@ -75,7 +76,7 @@ type VolumeCreateRequest struct {
 }
 
 // ListVolumes lists all storage volumes.
-func (svc *StorageServiceOp) ListVolumes(params *ListVolumeParams) ([]Volume, *Response, error) {
+func (svc *StorageServiceOp) ListVolumes(ctx context.Context, params *ListVolumeParams) ([]Volume, *Response, error) {
 	path := storageAllocPath
 	if params != nil {
 		if params.Region != "" && params.Name != "" {
@@ -91,7 +92,7 @@ func (svc *StorageServiceOp) ListVolumes(params *ListVolumeParams) ([]Volume, *R
 		}
 	}
 
-	req, err := svc.client.NewRequest("GET", path, nil)
+	req, err := svc.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -110,10 +111,10 @@ func (svc *StorageServiceOp) ListVolumes(params *ListVolumeParams) ([]Volume, *R
 }
 
 // CreateVolume creates a storage volume. The name must be unique.
-func (svc *StorageServiceOp) CreateVolume(createRequest *VolumeCreateRequest) (*Volume, *Response, error) {
+func (svc *StorageServiceOp) CreateVolume(ctx context.Context, createRequest *VolumeCreateRequest) (*Volume, *Response, error) {
 	path := storageAllocPath
 
-	req, err := svc.client.NewRequest("POST", path, createRequest)
+	req, err := svc.client.NewRequest(ctx, "POST", path, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -127,10 +128,10 @@ func (svc *StorageServiceOp) CreateVolume(createRequest *VolumeCreateRequest) (*
 }
 
 // GetVolume retrieves an individual storage volume.
-func (svc *StorageServiceOp) GetVolume(id string) (*Volume, *Response, error) {
+func (svc *StorageServiceOp) GetVolume(ctx context.Context, id string) (*Volume, *Response, error) {
 	path := fmt.Sprintf("%s/%s", storageAllocPath, id)
 
-	req, err := svc.client.NewRequest("GET", path, nil)
+	req, err := svc.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -145,10 +146,10 @@ func (svc *StorageServiceOp) GetVolume(id string) (*Volume, *Response, error) {
 }
 
 // DeleteVolume deletes a storage volume.
-func (svc *StorageServiceOp) DeleteVolume(id string) (*Response, error) {
+func (svc *StorageServiceOp) DeleteVolume(ctx context.Context, id string) (*Response, error) {
 	path := fmt.Sprintf("%s/%s", storageAllocPath, id)
 
-	req, err := svc.client.NewRequest("DELETE", path, nil)
+	req, err := svc.client.NewRequest(ctx, "DELETE", path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -164,14 +165,14 @@ type SnapshotCreateRequest struct {
 }
 
 // ListSnapshots lists all snapshots related to a storage volume.
-func (svc *StorageServiceOp) ListSnapshots(volumeID string, opt *ListOptions) ([]Snapshot, *Response, error) {
+func (svc *StorageServiceOp) ListSnapshots(ctx context.Context, volumeID string, opt *ListOptions) ([]Snapshot, *Response, error) {
 	path := fmt.Sprintf("%s/%s/snapshots", storageAllocPath, volumeID)
 	path, err := addOptions(path, opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := svc.client.NewRequest("GET", path, nil)
+	req, err := svc.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -190,10 +191,10 @@ func (svc *StorageServiceOp) ListSnapshots(volumeID string, opt *ListOptions) ([
 }
 
 // CreateSnapshot creates a snapshot of a storage volume.
-func (svc *StorageServiceOp) CreateSnapshot(createRequest *SnapshotCreateRequest) (*Snapshot, *Response, error) {
+func (svc *StorageServiceOp) CreateSnapshot(ctx context.Context, createRequest *SnapshotCreateRequest) (*Snapshot, *Response, error) {
 	path := fmt.Sprintf("%s/%s/snapshots", storageAllocPath, createRequest.VolumeID)
 
-	req, err := svc.client.NewRequest("POST", path, createRequest)
+	req, err := svc.client.NewRequest(ctx, "POST", path, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -207,10 +208,10 @@ func (svc *StorageServiceOp) CreateSnapshot(createRequest *SnapshotCreateRequest
 }
 
 // GetSnapshot retrieves an individual snapshot.
-func (svc *StorageServiceOp) GetSnapshot(id string) (*Snapshot, *Response, error) {
+func (svc *StorageServiceOp) GetSnapshot(ctx context.Context, id string) (*Snapshot, *Response, error) {
 	path := fmt.Sprintf("%s/%s", storageSnapPath, id)
 
-	req, err := svc.client.NewRequest("GET", path, nil)
+	req, err := svc.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -225,10 +226,10 @@ func (svc *StorageServiceOp) GetSnapshot(id string) (*Snapshot, *Response, error
 }
 
 // DeleteSnapshot deletes a snapshot.
-func (svc *StorageServiceOp) DeleteSnapshot(id string) (*Response, error) {
+func (svc *StorageServiceOp) DeleteSnapshot(ctx context.Context, id string) (*Response, error) {
 	path := fmt.Sprintf("%s/%s", storageSnapPath, id)
 
-	req, err := svc.client.NewRequest("DELETE", path, nil)
+	req, err := svc.client.NewRequest(ctx, "DELETE", path, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/storage_actions.go
+++ b/storage_actions.go
@@ -1,17 +1,20 @@
 package godo
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // StorageActionsService is an interface for interfacing with the
 // storage actions endpoints of the Digital Ocean API.
 // See: https://developers.digitalocean.com/documentation/v2#storage-actions
 type StorageActionsService interface {
-	Attach(volumeID string, dropletID int) (*Action, *Response, error)
-	Detach(volumeID string) (*Action, *Response, error)
-	DetachByDropletID(volumeID string, dropletID int) (*Action, *Response, error)
-	Get(volumeID string, actionID int) (*Action, *Response, error)
-	List(volumeID string, opt *ListOptions) ([]Action, *Response, error)
-	Resize(volumeID string, sizeGigabytes int, regionSlug string) (*Action, *Response, error)
+	Attach(ctx context.Context, volumeID string, dropletID int) (*Action, *Response, error)
+	Detach(ctx context.Context, volumeID string) (*Action, *Response, error)
+	DetachByDropletID(ctx context.Context, volumeID string, dropletID int) (*Action, *Response, error)
+	Get(ctx context.Context, volumeID string, actionID int) (*Action, *Response, error)
+	List(ctx context.Context, volumeID string, opt *ListOptions) ([]Action, *Response, error)
+	Resize(ctx context.Context, volumeID string, sizeGigabytes int, regionSlug string) (*Action, *Response, error)
 }
 
 // StorageActionsServiceOp handles communication with the storage volumes
@@ -27,62 +30,62 @@ type StorageAttachment struct {
 }
 
 // Attach a storage volume to a Droplet.
-func (s *StorageActionsServiceOp) Attach(volumeID string, dropletID int) (*Action, *Response, error) {
+func (s *StorageActionsServiceOp) Attach(ctx context.Context, volumeID string, dropletID int) (*Action, *Response, error) {
 	request := &ActionRequest{
 		"type":       "attach",
 		"droplet_id": dropletID,
 	}
-	return s.doAction(volumeID, request)
+	return s.doAction(ctx, volumeID, request)
 }
 
 // Detach a storage volume from a Droplet.
-func (s *StorageActionsServiceOp) Detach(volumeID string) (*Action, *Response, error) {
+func (s *StorageActionsServiceOp) Detach(ctx context.Context, volumeID string) (*Action, *Response, error) {
 	request := &ActionRequest{
 		"type": "detach",
 	}
-	return s.doAction(volumeID, request)
+	return s.doAction(ctx, volumeID, request)
 }
 
 // DetachByDropletID a storage volume from a Droplet by Droplet ID.
-func (s *StorageActionsServiceOp) DetachByDropletID(volumeID string, dropletID int) (*Action, *Response, error) {
+func (s *StorageActionsServiceOp) DetachByDropletID(ctx context.Context, volumeID string, dropletID int) (*Action, *Response, error) {
 	request := &ActionRequest{
 		"type":       "detach",
 		"droplet_id": dropletID,
 	}
-	return s.doAction(volumeID, request)
+	return s.doAction(ctx, volumeID, request)
 }
 
 // Get an action for a particular storage volume by id.
-func (s *StorageActionsServiceOp) Get(volumeID string, actionID int) (*Action, *Response, error) {
+func (s *StorageActionsServiceOp) Get(ctx context.Context, volumeID string, actionID int) (*Action, *Response, error) {
 	path := fmt.Sprintf("%s/%d", storageAllocationActionPath(volumeID), actionID)
-	return s.get(path)
+	return s.get(ctx, path)
 }
 
 // List the actions for a particular storage volume.
-func (s *StorageActionsServiceOp) List(volumeID string, opt *ListOptions) ([]Action, *Response, error) {
+func (s *StorageActionsServiceOp) List(ctx context.Context, volumeID string, opt *ListOptions) ([]Action, *Response, error) {
 	path := storageAllocationActionPath(volumeID)
 	path, err := addOptions(path, opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return s.list(path)
+	return s.list(ctx, path)
 }
 
 // Resize a storage volume.
-func (s *StorageActionsServiceOp) Resize(volumeID string, sizeGigabytes int, regionSlug string) (*Action, *Response, error) {
+func (s *StorageActionsServiceOp) Resize(ctx context.Context, volumeID string, sizeGigabytes int, regionSlug string) (*Action, *Response, error) {
 	request := &ActionRequest{
 		"type":           "resize",
 		"size_gigabytes": sizeGigabytes,
 		"region":         regionSlug,
 	}
-	return s.doAction(volumeID, request)
+	return s.doAction(ctx, volumeID, request)
 }
 
-func (s *StorageActionsServiceOp) doAction(volumeID string, request *ActionRequest) (*Action, *Response, error) {
+func (s *StorageActionsServiceOp) doAction(ctx context.Context, volumeID string, request *ActionRequest) (*Action, *Response, error) {
 	path := storageAllocationActionPath(volumeID)
 
-	req, err := s.client.NewRequest("POST", path, request)
+	req, err := s.client.NewRequest(ctx, "POST", path, request)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -96,8 +99,8 @@ func (s *StorageActionsServiceOp) doAction(volumeID string, request *ActionReque
 	return root.Event, resp, err
 }
 
-func (s *StorageActionsServiceOp) get(path string) (*Action, *Response, error) {
-	req, err := s.client.NewRequest("GET", path, nil)
+func (s *StorageActionsServiceOp) get(ctx context.Context, path string) (*Action, *Response, error) {
+	req, err := s.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -111,8 +114,8 @@ func (s *StorageActionsServiceOp) get(path string) (*Action, *Response, error) {
 	return root.Event, resp, err
 }
 
-func (s *StorageActionsServiceOp) list(path string) ([]Action, *Response, error) {
-	req, err := s.client.NewRequest("GET", path, nil)
+func (s *StorageActionsServiceOp) list(ctx context.Context, path string) ([]Action, *Response, error) {
+	req, err := s.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/storage_actions_test.go
+++ b/storage_actions_test.go
@@ -36,7 +36,7 @@ func TestStoragesActions_Attach(t *testing.T) {
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
-	_, _, err := client.StorageActions.Attach(volumeID, dropletID)
+	_, _, err := client.StorageActions.Attach(ctx, volumeID, dropletID)
 	if err != nil {
 		t.Errorf("StoragesActions.Attach returned error: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestStoragesActions_Detach(t *testing.T) {
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
-	_, _, err := client.StorageActions.Detach(volumeID)
+	_, _, err := client.StorageActions.Detach(ctx, volumeID)
 	if err != nil {
 		t.Errorf("StoragesActions.Detach returned error: %v", err)
 	}
@@ -98,7 +98,7 @@ func TestStoragesActions_DetachByDropletID(t *testing.T) {
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
-	_, _, err := client.StorageActions.DetachByDropletID(volumeID, dropletID)
+	_, _, err := client.StorageActions.DetachByDropletID(ctx, volumeID, dropletID)
 	if err != nil {
 		t.Errorf("StoragesActions.DetachByDropletID returned error: %v", err)
 	}
@@ -114,7 +114,7 @@ func TestStorageActions_Get(t *testing.T) {
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
-	action, _, err := client.StorageActions.Get(volumeID, 456)
+	action, _, err := client.StorageActions.Get(ctx, volumeID, 456)
 	if err != nil {
 		t.Errorf("StorageActions.Get returned error: %v", err)
 	}
@@ -135,7 +135,7 @@ func TestStorageActions_List(t *testing.T) {
 		fmt.Fprintf(w, `{"actions":[{"status":"in-progress"}]}`)
 	})
 
-	actions, _, err := client.StorageActions.List(volumeID, nil)
+	actions, _, err := client.StorageActions.List(ctx, volumeID, nil)
 	if err != nil {
 		t.Errorf("StorageActions.List returned error: %v", err)
 	}
@@ -172,7 +172,7 @@ func TestStoragesActions_Resize(t *testing.T) {
 		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
 	})
 
-	_, _, err := client.StorageActions.Resize(volumeID, 500, "nyc1")
+	_, _, err := client.StorageActions.Resize(ctx, volumeID, 500, "nyc1")
 	if err != nil {
 		t.Errorf("StoragesActions.Resize returned error: %v", err)
 	}

--- a/storage_test.go
+++ b/storage_test.go
@@ -52,7 +52,7 @@ func TestStorageVolumes_ListStorageVolumes(t *testing.T) {
 		fmt.Fprint(w, jBlob)
 	})
 
-	volumes, _, err := client.Storage.ListVolumes(nil)
+	volumes, _, err := client.Storage.ListVolumes(ctx, nil)
 	if err != nil {
 		t.Errorf("Storage.ListVolumes returned error: %v", err)
 	}
@@ -118,7 +118,7 @@ func TestStorageVolumes_Get(t *testing.T) {
 		fmt.Fprint(w, jBlob)
 	})
 
-	got, _, err := client.Storage.GetVolume("80d414c6-295e-4e3a-ac58-eb9456c1e1d1")
+	got, _, err := client.Storage.GetVolume(ctx, "80d414c6-295e-4e3a-ac58-eb9456c1e1d1")
 	if err != nil {
 		t.Errorf("Storage.GetVolume returned error: %v", err)
 	}
@@ -174,7 +174,7 @@ func TestStorageVolumes_ListVolumesByName(t *testing.T) {
 		Name:   "myvolume",
 		Region: "nyc3",
 	}
-	volumes, _, err := client.Storage.ListVolumes(options)
+	volumes, _, err := client.Storage.ListVolumes(ctx, options)
 	if err != nil {
 		t.Errorf("Storage.GetVolumeByName returned error: %v", err)
 	}
@@ -230,7 +230,7 @@ func TestStorageVolumes_Create(t *testing.T) {
 		fmt.Fprint(w, jBlob)
 	})
 
-	got, _, err := client.Storage.CreateVolume(createRequest)
+	got, _, err := client.Storage.CreateVolume(ctx, createRequest)
 	if err != nil {
 		t.Errorf("Storage.CreateVolume returned error: %v", err)
 	}
@@ -247,7 +247,7 @@ func TestStorageVolumes_Destroy(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Storage.DeleteVolume("80d414c6-295e-4e3a-ac58-eb9456c1e1d1")
+	_, err := client.Storage.DeleteVolume(ctx, "80d414c6-295e-4e3a-ac58-eb9456c1e1d1")
 	if err != nil {
 		t.Errorf("Storage.DeleteVolume returned error: %v", err)
 	}
@@ -291,7 +291,7 @@ func TestStorageSnapshots_ListStorageSnapshots(t *testing.T) {
 		fmt.Fprint(w, jBlob)
 	})
 
-	volumes, _, err := client.Storage.ListSnapshots("98d414c6-295e-4e3a-ac58-eb9456c1e1d1", nil)
+	volumes, _, err := client.Storage.ListSnapshots(ctx, "98d414c6-295e-4e3a-ac58-eb9456c1e1d1", nil)
 	if err != nil {
 		t.Errorf("Storage.ListSnapshots returned error: %v", err)
 	}
@@ -351,7 +351,7 @@ func TestStorageSnapshots_Get(t *testing.T) {
 		fmt.Fprint(w, jBlob)
 	})
 
-	got, _, err := client.Storage.GetSnapshot("80d414c6-295e-4e3a-ac58-eb9456c1e1d1")
+	got, _, err := client.Storage.GetSnapshot(ctx, "80d414c6-295e-4e3a-ac58-eb9456c1e1d1")
 	if err != nil {
 		t.Errorf("Storage.GetSnapshot returned error: %v", err)
 	}
@@ -412,7 +412,7 @@ func TestStorageSnapshots_Create(t *testing.T) {
 		fmt.Fprint(w, jBlob)
 	})
 
-	got, _, err := client.Storage.CreateSnapshot(createRequest)
+	got, _, err := client.Storage.CreateSnapshot(ctx, createRequest)
 	if err != nil {
 		t.Errorf("Storage.CreateSnapshot returned error: %v", err)
 	}
@@ -429,7 +429,7 @@ func TestStorageSnapshots_Destroy(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Storage.DeleteSnapshot("80d414c6-295e-4e3a-ac58-eb9456c1e1d1")
+	_, err := client.Storage.DeleteSnapshot(ctx, "80d414c6-295e-4e3a-ac58-eb9456c1e1d1")
 	if err != nil {
 		t.Errorf("Storage.DeleteSnapshot returned error: %v", err)
 	}

--- a/tags.go
+++ b/tags.go
@@ -1,6 +1,9 @@
 package godo
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 const tagsBasePath = "v2/tags"
 
@@ -8,14 +11,14 @@ const tagsBasePath = "v2/tags"
 // endpoints of the DigitalOcean API
 // See: https://developers.digitalocean.com/documentation/v2#tags
 type TagsService interface {
-	List(*ListOptions) ([]Tag, *Response, error)
-	Get(string) (*Tag, *Response, error)
-	Create(*TagCreateRequest) (*Tag, *Response, error)
-	Update(string, *TagUpdateRequest) (*Response, error)
-	Delete(string) (*Response, error)
+	List(context.Context, *ListOptions) ([]Tag, *Response, error)
+	Get(context.Context, string) (*Tag, *Response, error)
+	Create(context.Context, *TagCreateRequest) (*Tag, *Response, error)
+	Update(context.Context, string, *TagUpdateRequest) (*Response, error)
+	Delete(context.Context, string) (*Response, error)
 
-	TagResources(string, *TagResourcesRequest) (*Response, error)
-	UntagResources(string, *UntagResourcesRequest) (*Response, error)
+	TagResources(context.Context, string, *TagResourcesRequest) (*Response, error)
+	UntagResources(context.Context, string, *UntagResourcesRequest) (*Response, error)
 }
 
 // TagsServiceOp handles communication with tag related method of the
@@ -87,7 +90,7 @@ type tagRoot struct {
 }
 
 // List all tags
-func (s *TagsServiceOp) List(opt *ListOptions) ([]Tag, *Response, error) {
+func (s *TagsServiceOp) List(ctx context.Context, opt *ListOptions) ([]Tag, *Response, error) {
 	path := tagsBasePath
 	path, err := addOptions(path, opt)
 
@@ -95,7 +98,7 @@ func (s *TagsServiceOp) List(opt *ListOptions) ([]Tag, *Response, error) {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", path, nil)
+	req, err := s.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -113,10 +116,10 @@ func (s *TagsServiceOp) List(opt *ListOptions) ([]Tag, *Response, error) {
 }
 
 // Get a single tag
-func (s *TagsServiceOp) Get(name string) (*Tag, *Response, error) {
+func (s *TagsServiceOp) Get(ctx context.Context, name string) (*Tag, *Response, error) {
 	path := fmt.Sprintf("%s/%s", tagsBasePath, name)
 
-	req, err := s.client.NewRequest("GET", path, nil)
+	req, err := s.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -131,12 +134,12 @@ func (s *TagsServiceOp) Get(name string) (*Tag, *Response, error) {
 }
 
 // Create a new tag
-func (s *TagsServiceOp) Create(createRequest *TagCreateRequest) (*Tag, *Response, error) {
+func (s *TagsServiceOp) Create(ctx context.Context, createRequest *TagCreateRequest) (*Tag, *Response, error) {
 	if createRequest == nil {
 		return nil, nil, NewArgError("createRequest", "cannot be nil")
 	}
 
-	req, err := s.client.NewRequest("POST", tagsBasePath, createRequest)
+	req, err := s.client.NewRequest(ctx, "POST", tagsBasePath, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -151,7 +154,7 @@ func (s *TagsServiceOp) Create(createRequest *TagCreateRequest) (*Tag, *Response
 }
 
 // Update an exsting tag
-func (s *TagsServiceOp) Update(name string, updateRequest *TagUpdateRequest) (*Response, error) {
+func (s *TagsServiceOp) Update(ctx context.Context, name string, updateRequest *TagUpdateRequest) (*Response, error) {
 	if name == "" {
 		return nil, NewArgError("name", "cannot be empty")
 	}
@@ -161,7 +164,7 @@ func (s *TagsServiceOp) Update(name string, updateRequest *TagUpdateRequest) (*R
 	}
 
 	path := fmt.Sprintf("%s/%s", tagsBasePath, name)
-	req, err := s.client.NewRequest("PUT", path, updateRequest)
+	req, err := s.client.NewRequest(ctx, "PUT", path, updateRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -172,13 +175,13 @@ func (s *TagsServiceOp) Update(name string, updateRequest *TagUpdateRequest) (*R
 }
 
 // Delete an existing tag
-func (s *TagsServiceOp) Delete(name string) (*Response, error) {
+func (s *TagsServiceOp) Delete(ctx context.Context, name string) (*Response, error) {
 	if name == "" {
 		return nil, NewArgError("name", "cannot be empty")
 	}
 
 	path := fmt.Sprintf("%s/%s", tagsBasePath, name)
-	req, err := s.client.NewRequest("DELETE", path, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +192,7 @@ func (s *TagsServiceOp) Delete(name string) (*Response, error) {
 }
 
 // TagResources associates resources with a given Tag.
-func (s *TagsServiceOp) TagResources(name string, tagRequest *TagResourcesRequest) (*Response, error) {
+func (s *TagsServiceOp) TagResources(ctx context.Context, name string, tagRequest *TagResourcesRequest) (*Response, error) {
 	if name == "" {
 		return nil, NewArgError("name", "cannot be empty")
 	}
@@ -199,7 +202,7 @@ func (s *TagsServiceOp) TagResources(name string, tagRequest *TagResourcesReques
 	}
 
 	path := fmt.Sprintf("%s/%s/resources", tagsBasePath, name)
-	req, err := s.client.NewRequest("POST", path, tagRequest)
+	req, err := s.client.NewRequest(ctx, "POST", path, tagRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -210,7 +213,7 @@ func (s *TagsServiceOp) TagResources(name string, tagRequest *TagResourcesReques
 }
 
 // UntagResources dissociates resources with a given Tag.
-func (s *TagsServiceOp) UntagResources(name string, untagRequest *UntagResourcesRequest) (*Response, error) {
+func (s *TagsServiceOp) UntagResources(ctx context.Context, name string, untagRequest *UntagResourcesRequest) (*Response, error) {
 	if name == "" {
 		return nil, NewArgError("name", "cannot be empty")
 	}
@@ -220,7 +223,7 @@ func (s *TagsServiceOp) UntagResources(name string, untagRequest *UntagResources
 	}
 
 	path := fmt.Sprintf("%s/%s/resources", tagsBasePath, name)
-	req, err := s.client.NewRequest("DELETE", path, untagRequest)
+	req, err := s.client.NewRequest(ctx, "DELETE", path, untagRequest)
 	if err != nil {
 		return nil, err
 	}

--- a/tags_test.go
+++ b/tags_test.go
@@ -160,7 +160,7 @@ var (
 				}
 			}
 		}
-	}	
+	}
 	`
 )
 
@@ -173,7 +173,7 @@ func TestTags_List(t *testing.T) {
 		fmt.Fprint(w, listJSON)
 	})
 
-	tags, _, err := client.Tags.List(nil)
+	tags, _, err := client.Tags.List(ctx, nil)
 	if err != nil {
 		t.Errorf("Tags.List returned error: %v", err)
 	}
@@ -194,7 +194,7 @@ func TestTags_ListEmpty(t *testing.T) {
 		fmt.Fprint(w, listEmptyJSON)
 	})
 
-	tags, _, err := client.Tags.List(nil)
+	tags, _, err := client.Tags.List(ctx, nil)
 	if err != nil {
 		t.Errorf("Tags.List returned error: %v", err)
 	}
@@ -214,7 +214,7 @@ func TestTags_ListPaging(t *testing.T) {
 		fmt.Fprint(w, listJSON)
 	})
 
-	_, resp, err := client.Tags.List(nil)
+	_, resp, err := client.Tags.List(ctx, nil)
 	if err != nil {
 		t.Errorf("Tags.List returned error: %v", err)
 	}
@@ -230,7 +230,7 @@ func TestTags_Get(t *testing.T) {
 		fmt.Fprint(w, getJSON)
 	})
 
-	tag, _, err := client.Tags.Get("testing-1")
+	tag, _, err := client.Tags.Get(ctx, "testing-1")
 	if err != nil {
 		t.Errorf("Tags.Get returned error: %v", err)
 	}
@@ -271,7 +271,7 @@ func TestTags_Create(t *testing.T) {
 		fmt.Fprintf(w, createJSON)
 	})
 
-	tag, _, err := client.Tags.Create(createRequest)
+	tag, _, err := client.Tags.Create(ctx, createRequest)
 	if err != nil {
 		t.Errorf("Tags.Create returned error: %v", err)
 	}
@@ -305,7 +305,7 @@ func TestTags_Update(t *testing.T) {
 
 	})
 
-	_, err := client.Tags.Update("old-testing-1", updateRequest)
+	_, err := client.Tags.Update(ctx, "old-testing-1", updateRequest)
 	if err != nil {
 		t.Errorf("Tags.Update returned error: %v", err)
 	}
@@ -319,7 +319,7 @@ func TestTags_Delete(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Tags.Delete("testing-1")
+	_, err := client.Tags.Delete(ctx, "testing-1")
 	if err != nil {
 		t.Errorf("Tags.Delete returned error: %v", err)
 	}
@@ -348,7 +348,7 @@ func TestTags_TagResource(t *testing.T) {
 
 	})
 
-	_, err := client.Tags.TagResources("testing-1", tagResourcesRequest)
+	_, err := client.Tags.TagResources(ctx, "testing-1", tagResourcesRequest)
 	if err != nil {
 		t.Errorf("Tags.TagResources returned error: %v", err)
 	}
@@ -377,7 +377,7 @@ func TestTags_UntagResource(t *testing.T) {
 
 	})
 
-	_, err := client.Tags.UntagResources("testing-1", untagResourcesRequest)
+	_, err := client.Tags.UntagResources(ctx, "testing-1", untagResourcesRequest)
 	if err != nil {
 		t.Errorf("Tags.UntagResources returned error: %v", err)
 	}

--- a/util/droplet_test.go
+++ b/util/droplet_test.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"context"
+
 	"golang.org/x/oauth2"
 
 	"github.com/digitalocean/godo"
@@ -19,7 +21,7 @@ func ExampleWaitForActive() {
 	uri := "https://api.digitalocean.com/v2/actions/xxxxxxxx"
 
 	// block until until the action is complete
-	err := WaitForActive(client, uri)
+	err := WaitForActive(context.TODO(), client, uri)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This adds `context.Context` to all the API calls. This allows us to insert the `ctx` in the `http.Request.Context()`, so that calls can be traced and cancelled and so on.

## This is a breaking change.