### PR TITLE
Remove betastorageservice, in production.

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -19,18 +19,6 @@ type StorageService interface {
 	GetVolume(string) (*Volume, *Response, error)
 	CreateVolume(*VolumeCreateRequest) (*Volume, *Response, error)
 	DeleteVolume(string) (*Response, error)
-}
-
-// BetaStorageService is an interface for the storage services that are
-// not yet stable. The interface is not exposed in the godo.Client and
-// requires type-asserting the `StorageService` to make it available.
-//
-// Note that Beta features will change and compiling against those
-// symbols (using type-assertion) is prone to breaking your build
-// if you use our master.
-type BetaStorageService interface {
-	StorageService
-
 	ListSnapshots(volumeID string, opts *ListOptions) ([]Snapshot, *Response, error)
 	GetSnapshot(string) (*Snapshot, *Response, error)
 	CreateSnapshot(*SnapshotCreateRequest) (*Snapshot, *Response, error)

--- a/storage_test.go
+++ b/storage_test.go
@@ -238,7 +238,7 @@ func TestStorageSnapshots_ListStorageSnapshots(t *testing.T) {
 		fmt.Fprint(w, jBlob)
 	})
 
-	volumes, _, err := client.Storage.(BetaStorageService).ListSnapshots("98d414c6-295e-4e3a-ac58-eb9456c1e1d1", nil)
+	volumes, _, err := client.Storage.ListSnapshots("98d414c6-295e-4e3a-ac58-eb9456c1e1d1", nil)
 	if err != nil {
 		t.Errorf("Storage.ListSnapshots returned error: %v", err)
 	}
@@ -306,7 +306,7 @@ func TestStorageSnapshots_Get(t *testing.T) {
 		fmt.Fprint(w, jBlob)
 	})
 
-	got, _, err := client.Storage.(BetaStorageService).GetSnapshot("80d414c6-295e-4e3a-ac58-eb9456c1e1d1")
+	got, _, err := client.Storage.GetSnapshot("80d414c6-295e-4e3a-ac58-eb9456c1e1d1")
 	if err != nil {
 		t.Errorf("Storage.GetSnapshot returned error: %v", err)
 	}
@@ -370,7 +370,7 @@ func TestStorageSnapshots_Create(t *testing.T) {
 		fmt.Fprint(w, jBlob)
 	})
 
-	got, _, err := client.Storage.(BetaStorageService).CreateSnapshot(createRequest)
+	got, _, err := client.Storage.CreateSnapshot(createRequest)
 	if err != nil {
 		t.Errorf("Storage.CreateSnapshot returned error: %v", err)
 	}
@@ -387,7 +387,7 @@ func TestStorageSnapshots_Destroy(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Storage.(BetaStorageService).DeleteSnapshot("80d414c6-295e-4e3a-ac58-eb9456c1e1d1")
+	_, err := client.Storage.DeleteSnapshot("80d414c6-295e-4e3a-ac58-eb9456c1e1d1")
 	if err != nil {
 		t.Errorf("Storage.DeleteSnapshot returned error: %v", err)
 	}


### PR DESCRIPTION
Follow up to https://github.com/digitalocean/godo/pull/108 based on feedback. removes `Beta` Interface.

cc @aybabtme 