### PR TITLE
Align all timestamps to use *Timestamp types.

### DIFF
--- a/droplets.go
+++ b/droplets.go
@@ -38,24 +38,24 @@ var _ DropletsService = &DropletsServiceOp{}
 
 // Droplet represents a DigitalOcean Droplet
 type Droplet struct {
-	ID          int       `json:"id,float64,omitempty"`
-	Name        string    `json:"name,omitempty"`
-	Memory      int       `json:"memory,omitempty"`
-	Vcpus       int       `json:"vcpus,omitempty"`
-	Disk        int       `json:"disk,omitempty"`
-	Region      *Region   `json:"region,omitempty"`
-	Image       *Image    `json:"image,omitempty"`
-	Size        *Size     `json:"size,omitempty"`
-	SizeSlug    string    `json:"size_slug,omitempty"`
-	BackupIDs   []int     `json:"backup_ids,omitempty"`
-	SnapshotIDs []int     `json:"snapshot_ids,omitempty"`
-	Locked      bool      `json:"locked,bool,omitempty"`
-	Status      string    `json:"status,omitempty"`
-	Networks    *Networks `json:"networks,omitempty"`
-	Created     string    `json:"created_at,omitempty"`
-	Kernel      *Kernel   `json:"kernel,omitempty"`
-	Tags        []string  `json:"tags,omitempty"`
-	VolumeIDs   []string  `json:"volume_ids"`
+	ID          int        `json:"id,float64,omitempty"`
+	Name        string     `json:"name,omitempty"`
+	Memory      int        `json:"memory,omitempty"`
+	Vcpus       int        `json:"vcpus,omitempty"`
+	Disk        int        `json:"disk,omitempty"`
+	Region      *Region    `json:"region,omitempty"`
+	Image       *Image     `json:"image,omitempty"`
+	Size        *Size      `json:"size,omitempty"`
+	SizeSlug    string     `json:"size_slug,omitempty"`
+	BackupIDs   []int      `json:"backup_ids,omitempty"`
+	SnapshotIDs []int      `json:"snapshot_ids,omitempty"`
+	Locked      bool       `json:"locked,bool,omitempty"`
+	Status      string     `json:"status,omitempty"`
+	Networks    *Networks  `json:"networks,omitempty"`
+	Created     *Timestamp `json:"created_at,omitempty"`
+	Kernel      *Kernel    `json:"kernel,omitempty"`
+	Tags        []string   `json:"tags,omitempty"`
+	VolumeIDs   []string   `json:"volume_ids"`
 }
 
 // PublicIPv4 returns the public IPv4 address for the Droplet.

--- a/images.go
+++ b/images.go
@@ -28,15 +28,15 @@ var _ ImagesService = &ImagesServiceOp{}
 
 // Image represents a DigitalOcean Image
 type Image struct {
-	ID           int      `json:"id,float64,omitempty"`
-	Name         string   `json:"name,omitempty"`
-	Type         string   `json:"type,omitempty"`
-	Distribution string   `json:"distribution,omitempty"`
-	Slug         string   `json:"slug,omitempty"`
-	Public       bool     `json:"public,omitempty"`
-	Regions      []string `json:"regions,omitempty"`
-	MinDiskSize  int      `json:"min_disk_size,omitempty"`
-	Created      string   `json:"created_at,omitempty"`
+	ID           int        `json:"id,float64,omitempty"`
+	Name         string     `json:"name,omitempty"`
+	Type         string     `json:"type,omitempty"`
+	Distribution string     `json:"distribution,omitempty"`
+	Slug         string     `json:"slug,omitempty"`
+	Public       bool       `json:"public,omitempty"`
+	Regions      []string   `json:"regions,omitempty"`
+	MinDiskSize  int        `json:"min_disk_size,omitempty"`
+	Created      *Timestamp `json:"created_at,omitempty"`
 }
 
 // ImageUpdateRequest represents a request to update an image.

--- a/images_test.go
+++ b/images_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestImages_List(t *testing.T) {
@@ -242,6 +243,13 @@ func TestImages_Destroy(t *testing.T) {
 }
 
 func TestImage_String(t *testing.T) {
+	pt, err := time.Parse(time.RFC3339, "2013-11-27T09:24:55Z")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	created := &Timestamp{
+		Time: pt,
+	}
 	image := &Image{
 		ID:           1,
 		Name:         "Image",
@@ -251,11 +259,11 @@ func TestImage_String(t *testing.T) {
 		Public:       true,
 		Regions:      []string{"one", "two"},
 		MinDiskSize:  20,
-		Created:      "2013-11-27T09:24:55Z",
+		Created:      created,
 	}
 
 	stringified := image.String()
-	expected := `godo.Image{ID:1, Name:"Image", Type:"snapshot", Distribution:"Ubuntu", Slug:"image", Public:true, Regions:["one" "two"], MinDiskSize:20, Created:"2013-11-27T09:24:55Z"}`
+	expected := `godo.Image{ID:1, Name:"Image", Type:"snapshot", Distribution:"Ubuntu", Slug:"image", Public:true, Regions:["one" "two"], MinDiskSize:20, Created:godo.Timestamp{2013-11-27 09:24:55 +0000 UTC}}`
 	if expected != stringified {
 		t.Errorf("Image.String returned %+v, expected %+v", stringified, expected)
 	}

--- a/snapshots.go
+++ b/snapshots.go
@@ -25,14 +25,14 @@ var _ SnapshotsService = &SnapshotsServiceOp{}
 
 // Snapshot represents a DigitalOcean Snapshot
 type Snapshot struct {
-	ID            string   `json:"id,omitempty"`
-	Name          string   `json:"name,omitempty"`
-	ResourceID    string   `json:"resource_id,omitempty"`
-	ResourceType  string   `json:"resource_type,omitempty"`
-	Regions       []string `json:"regions,omitempty"`
-	MinDiskSize   int      `json:"min_disk_size,omitempty"`
-	SizeGigaBytes float64  `json:"size_gigabytes,omitempty"`
-	Created       string   `json:"created_at,omitempty"`
+	ID            string     `json:"id,omitempty"`
+	Name          string     `json:"name,omitempty"`
+	ResourceID    string     `json:"resource_id,omitempty"`
+	ResourceType  string     `json:"resource_type,omitempty"`
+	Regions       []string   `json:"regions,omitempty"`
+	MinDiskSize   int        `json:"min_disk_size,omitempty"`
+	SizeGigaBytes float64    `json:"size_gigabytes,omitempty"`
+	Created       *Timestamp `json:"created_at,omitempty"`
 }
 
 type snapshotRoot struct {

--- a/snapshots_test.go
+++ b/snapshots_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestSnapshots_List(t *testing.T) {
@@ -160,6 +161,13 @@ func TestSnapshots_Destroy(t *testing.T) {
 }
 
 func TestSnapshot_String(t *testing.T) {
+	pt, err := time.Parse(time.RFC3339, "2002-10-02T15:00:00.05Z")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	created := &Timestamp{
+		Time: pt,
+	}
 	snapshot := &Snapshot{
 		ID:            "1",
 		Name:          "Snapsh176ot",
@@ -168,11 +176,12 @@ func TestSnapshot_String(t *testing.T) {
 		Regions:       []string{"one"},
 		MinDiskSize:   20,
 		SizeGigaBytes: 4.84,
-		Created:       "2013-11-27T09:24:55Z",
+		Created:       created,
 	}
 
 	stringified := snapshot.String()
-	expected := `godo.Snapshot{ID:"1", Name:"Snapsh176ot", ResourceID:"0", ResourceType:"droplet", Regions:["one"], MinDiskSize:20, SizeGigaBytes:4.84, Created:"2013-11-27T09:24:55Z"}`
+	expected := `godo.Snapshot{ID:"1", Name:"Snapsh176ot", ResourceID:"0", ResourceType:"droplet", Regions:["one"], MinDiskSize:20, SizeGigaBytes:4.84, Created:godo.Timestamp{2002-10-02 15:00:00.05 +0000 UTC}}`
+
 	if expected != stringified {
 		t.Errorf("Snapshot.String returned %+v, expected %+v", stringified, expected)
 	}

--- a/storage.go
+++ b/storage.go
@@ -2,7 +2,6 @@ package godo
 
 import (
 	"fmt"
-	"time"
 )
 
 const (
@@ -47,13 +46,13 @@ var _ StorageService = &StorageServiceOp{}
 
 // Volume represents a Digital Ocean block store volume.
 type Volume struct {
-	ID            string    `json:"id"`
-	Region        *Region   `json:"region"`
-	Name          string    `json:"name"`
-	SizeGigaBytes int64     `json:"size_gigabytes"`
-	Description   string    `json:"description"`
-	DropletIDs    []int     `json:"droplet_ids"`
-	CreatedAt     time.Time `json:"created_at"`
+	ID            string     `json:"id"`
+	Region        *Region    `json:"region"`
+	Name          string     `json:"name"`
+	SizeGigaBytes int64      `json:"size_gigabytes"`
+	Description   string     `json:"description"`
+	DropletIDs    []int      `json:"droplet_ids"`
+	Created       *Timestamp `json:"created_at"`
 }
 
 func (f Volume) String() string {

--- a/storage_test.go
+++ b/storage_test.go
@@ -57,6 +57,22 @@ func TestStorageVolumes_ListStorageVolumes(t *testing.T) {
 		t.Errorf("Storage.ListVolumes returned error: %v", err)
 	}
 
+	pt1, err := time.Parse(time.RFC3339, "2002-10-02T15:00:00.05Z")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	createdFirst := &Timestamp{
+		Time: pt1,
+	}
+
+	pt2, err := time.Parse(time.RFC3339, "2012-10-03T15:00:01.05Z")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	createdSecond := &Timestamp{
+		Time: pt2,
+	}
+
 	expected := []Volume{
 		{
 			Region:        &Region{Slug: "nyc3"},
@@ -65,7 +81,7 @@ func TestStorageVolumes_ListStorageVolumes(t *testing.T) {
 			Description:   "my description",
 			SizeGigaBytes: 100,
 			DropletIDs:    []int{10},
-			CreatedAt:     time.Date(2002, 10, 02, 15, 00, 00, 50000000, time.UTC),
+			Created:       createdFirst,
 		},
 		{
 			Region:        &Region{Slug: "nyc3"},
@@ -73,7 +89,7 @@ func TestStorageVolumes_ListStorageVolumes(t *testing.T) {
 			Name:          "my other volume",
 			Description:   "my other description",
 			SizeGigaBytes: 100,
-			CreatedAt:     time.Date(2012, 10, 03, 15, 00, 01, 50000000, time.UTC),
+			Created:       createdSecond,
 		},
 	}
 	if !reflect.DeepEqual(volumes, expected) {
@@ -84,13 +100,20 @@ func TestStorageVolumes_ListStorageVolumes(t *testing.T) {
 func TestStorageVolumes_Get(t *testing.T) {
 	setup()
 	defer teardown()
+	pt, err := time.Parse(time.RFC3339, "2002-10-02T15:00:00.05Z")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	created := &Timestamp{
+		Time: pt,
+	}
 	want := &Volume{
 		Region:        &Region{Slug: "nyc3"},
 		ID:            "80d414c6-295e-4e3a-ac58-eb9456c1e1d1",
 		Name:          "my volume",
 		Description:   "my description",
 		SizeGigaBytes: 100,
-		CreatedAt:     time.Date(2002, 10, 02, 15, 00, 00, 50000000, time.UTC),
+		Created:       created,
 	}
 	jBlob := `{
 		"volume":{
@@ -138,13 +161,20 @@ func TestStorageVolumes_Create(t *testing.T) {
 		SizeGigaBytes: 100,
 	}
 
+	pt, err := time.Parse(time.RFC3339, "2002-10-02T15:00:00.05Z")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	created := &Timestamp{
+		Time: pt,
+	}
 	want := &Volume{
 		Region:        &Region{Slug: "nyc3"},
 		ID:            "80d414c6-295e-4e3a-ac58-eb9456c1e1d1",
 		Name:          "my volume",
 		Description:   "my description",
 		SizeGigaBytes: 100,
-		CreatedAt:     time.Date(2002, 10, 02, 15, 00, 00, 50000000, time.UTC),
+		Created:       created,
 	}
 	jBlob := `{
 		"volume":{
@@ -215,7 +245,7 @@ func TestStorageSnapshots_ListStorageSnapshots(t *testing.T) {
 				"id": "96d414c6-295e-4e3a-ac59-eb9456c1e1d1",
 				"name": "my other snapshot",
 				"size_gigabytes": 100,
-				"created_at": "2012-10-03T15:00:01.05Z"
+				"created_at": "2002-10-02T15:00:00.05Z"
 			}
 		],
 		"links": {
@@ -239,20 +269,27 @@ func TestStorageSnapshots_ListStorageSnapshots(t *testing.T) {
 		t.Errorf("Storage.ListSnapshots returned error: %v", err)
 	}
 
+	pt, err := time.Parse(time.RFC3339, "2002-10-02T15:00:00.05Z")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	created := &Timestamp{
+		Time: pt,
+	}
 	expected := []Snapshot{
 		{
 			Regions:       []string{"nyc3"},
 			ID:            "80d414c6-295e-4e3a-ac58-eb9456c1e1d1",
 			Name:          "my snapshot",
 			SizeGigaBytes: 100,
-			Created:       "2002-10-02T15:00:00.05Z",
+			Created:       created,
 		},
 		{
 			Regions:       []string{"nyc3"},
 			ID:            "96d414c6-295e-4e3a-ac59-eb9456c1e1d1",
 			Name:          "my other snapshot",
 			SizeGigaBytes: 100,
-			Created:       "2012-10-03T15:00:01.05Z",
+			Created:       created,
 		},
 	}
 	if !reflect.DeepEqual(volumes, expected) {
@@ -263,12 +300,20 @@ func TestStorageSnapshots_ListStorageSnapshots(t *testing.T) {
 func TestStorageSnapshots_Get(t *testing.T) {
 	setup()
 	defer teardown()
+
+	pt, err := time.Parse(time.RFC3339, "2002-10-02T15:00:00.05Z")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	created := &Timestamp{
+		Time: pt,
+	}
 	want := &Snapshot{
 		Regions:       []string{"nyc3"},
 		ID:            "80d414c6-295e-4e3a-ac58-eb9456c1e1d1",
 		Name:          "my snapshot",
 		SizeGigaBytes: 100,
-		Created:       "2002-10-02T15:00:00.05Z",
+		Created:       created,
 	}
 	jBlob := `{
 		"snapshot":{
@@ -313,12 +358,19 @@ func TestStorageSnapshots_Create(t *testing.T) {
 		Description: "my description",
 	}
 
+	pt, err := time.Parse(time.RFC3339, "2002-10-02T15:00:00.05Z")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	created := &Timestamp{
+		Time: pt,
+	}
 	want := &Snapshot{
 		Regions:       []string{"nyc3"},
 		ID:            "80d414c6-295e-4e3a-ac58-eb9456c1e1d1",
 		Name:          "my snapshot",
 		SizeGigaBytes: 100,
-		Created:       "2002-10-02T15:00:00.05Z",
+		Created:       created,
 	}
 	jBlob := `{
 		"snapshot":{


### PR DESCRIPTION
More follow up from https://github.com/digitalocean/godo/pull/108, this uses `*Timestamp` since it converts well between json and back to string, matching https://github.com/digitalocean/godo/blob/refactor/time-types/action.go#L44-L45.