### PR TITLE
Adds support for creating droplets with monitoring

### DIFF
--- a/droplets.go
+++ b/droplets.go
@@ -204,6 +204,7 @@ type DropletCreateRequest struct {
 	Backups           bool                  `json:"backups"`
 	IPv6              bool                  `json:"ipv6"`
 	PrivateNetworking bool                  `json:"private_networking"`
+	Monitoring        bool                  `json:"monitoring"`
 	UserData          string                `json:"user_data,omitempty"`
 	Volumes           []DropletCreateVolume `json:"volumes,omitempty"`
 	Tags              []string              `json:"tags"`
@@ -219,6 +220,7 @@ type DropletMultiCreateRequest struct {
 	Backups           bool                  `json:"backups"`
 	IPv6              bool                  `json:"ipv6"`
 	PrivateNetworking bool                  `json:"private_networking"`
+	Monitoring        bool                  `json:"monitoring"`
 	UserData          string                `json:"user_data,omitempty"`
 	Tags              []string              `json:"tags"`
 }

--- a/droplets_test.go
+++ b/droplets_test.go
@@ -165,6 +165,7 @@ func TestDroplets_Create(t *testing.T) {
 			"backups":            false,
 			"ipv6":               false,
 			"private_networking": false,
+			"monitoring":         false,
 			"volumes": []interface{}{
 				map[string]interface{}{"name": "hello-im-a-volume"},
 				map[string]interface{}{"id": "hello-im-another-volume"},
@@ -224,6 +225,7 @@ func TestDroplets_CreateMultiple(t *testing.T) {
 			"backups":            false,
 			"ipv6":               false,
 			"private_networking": false,
+			"monitoring":         false,
 			"tags":               []interface{}{"one", "two"},
 		}
 

--- a/godo_test.go
+++ b/godo_test.go
@@ -133,7 +133,7 @@ func TestNewRequest(t *testing.T) {
 	inBody, outBody := &DropletCreateRequest{Name: "l"},
 		`{"name":"l","region":"","size":"","image":0,`+
 			`"ssh_keys":null,"backups":false,"ipv6":false,`+
-			`"private_networking":false,"tags":null}`+"\n"
+			`"private_networking":false,"monitoring":false,"tags":null}`+"\n"
 	req, _ := c.NewRequest("GET", inURL, inBody)
 
 	// test relative URL was expanded
@@ -161,7 +161,7 @@ func TestNewRequest_withUserData(t *testing.T) {
 	inBody, outBody := &DropletCreateRequest{Name: "l", UserData: "u"},
 		`{"name":"l","region":"","size":"","image":0,`+
 			`"ssh_keys":null,"backups":false,"ipv6":false,`+
-			`"private_networking":false,"user_data":"u","tags":null}`+"\n"
+			`"private_networking":false,"monitoring":false,"user_data":"u","tags":null}`+"\n"
 	req, _ := c.NewRequest("GET", inURL, inBody)
 
 	// test relative URL was expanded


### PR DESCRIPTION
This adds the `monitoring` boolean flag to `DropletCreateRequest` and `DropletMultiCreateRequest`.

DO NOT MERGE until API is updated!