### PR TITLE
make linters happy

### DIFF
--- a/droplet_actions.go
+++ b/droplet_actions.go
@@ -8,7 +8,7 @@ import (
 // ActionRequest reprents DigitalOcean Action Request
 type ActionRequest map[string]interface{}
 
-// DropletActionsService is an interface for interfacing with the droplet actions
+// DropletActionsService is an interface for interfacing with the Droplet actions
 // endpoints of the DigitalOcean API
 // See: https://developers.digitalocean.com/documentation/v2#droplet-actions
 type DropletActionsService interface {
@@ -43,7 +43,7 @@ type DropletActionsService interface {
 	GetByURI(string) (*Action, *Response, error)
 }
 
-// DropletActionsServiceOp handles communication with the droplet action related
+// DropletActionsServiceOp handles communication with the Droplet action related
 // methods of the DigitalOcean API.
 type DropletActionsServiceOp struct {
 	client *Client
@@ -57,7 +57,7 @@ func (s *DropletActionsServiceOp) Shutdown(id int) (*Action, *Response, error) {
 	return s.doAction(id, request)
 }
 
-// Shutdown Droplets by Tag
+// ShutdownByTag shuts down Droplets matched by a Tag.
 func (s *DropletActionsServiceOp) ShutdownByTag(tag string) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "shutdown"}
 	return s.doActionByTag(tag, request)
@@ -69,7 +69,7 @@ func (s *DropletActionsServiceOp) PowerOff(id int) (*Action, *Response, error) {
 	return s.doAction(id, request)
 }
 
-// PowerOff a Droplet by Tag
+// PowerOffByTag powers off Droplets matched by a Tag.
 func (s *DropletActionsServiceOp) PowerOffByTag(tag string) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "power_off"}
 	return s.doActionByTag(tag, request)
@@ -81,7 +81,7 @@ func (s *DropletActionsServiceOp) PowerOn(id int) (*Action, *Response, error) {
 	return s.doAction(id, request)
 }
 
-// PowerOn a Droplet by Tag
+// PowerOnByTag powers on Droplets matched by a Tag.
 func (s *DropletActionsServiceOp) PowerOnByTag(tag string) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "power_on"}
 	return s.doActionByTag(tag, request)
@@ -93,7 +93,7 @@ func (s *DropletActionsServiceOp) PowerCycle(id int) (*Action, *Response, error)
 	return s.doAction(id, request)
 }
 
-// PowerCycle a Droplet by Tag
+// PowerCycleByTag power cycles Droplets matched by a Tag.
 func (s *DropletActionsServiceOp) PowerCycleByTag(tag string) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "power_cycle"}
 	return s.doActionByTag(tag, request)
@@ -146,7 +146,7 @@ func (s *DropletActionsServiceOp) Snapshot(id int, name string) (*Action, *Respo
 	return s.doAction(id, request)
 }
 
-// Snapshot a Droplet by Tag
+// SnapshotByTag snapshots Droplets matched by a Tag.
 func (s *DropletActionsServiceOp) SnapshotByTag(tag string, name string) (*Action, *Response, error) {
 	requestType := "snapshot"
 	request := &ActionRequest{
@@ -156,79 +156,79 @@ func (s *DropletActionsServiceOp) SnapshotByTag(tag string, name string) (*Actio
 	return s.doActionByTag(tag, request)
 }
 
-// EnableBackups enables backups for a droplet.
+// EnableBackups enables backups for a Droplet.
 func (s *DropletActionsServiceOp) EnableBackups(id int) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "enable_backups"}
 	return s.doAction(id, request)
 }
 
-// EnableBackups enables backups for a droplet by Tag
+// EnableBackupsByTag enables backups for Droplets matched by a Tag.
 func (s *DropletActionsServiceOp) EnableBackupsByTag(tag string) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "enable_backups"}
 	return s.doActionByTag(tag, request)
 }
 
-// DisableBackups disables backups for a droplet.
+// DisableBackups disables backups for a Droplet.
 func (s *DropletActionsServiceOp) DisableBackups(id int) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "disable_backups"}
 	return s.doAction(id, request)
 }
 
-// DisableBackups disables backups for a droplet by tag
+// DisableBackupsByTag disables backups for Droplet matched by a Tag.
 func (s *DropletActionsServiceOp) DisableBackupsByTag(tag string) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "disable_backups"}
 	return s.doActionByTag(tag, request)
 }
 
-// PasswordReset resets the password for a droplet.
+// PasswordReset resets the password for a Droplet.
 func (s *DropletActionsServiceOp) PasswordReset(id int) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "password_reset"}
 	return s.doAction(id, request)
 }
 
-// RebuildByImageID rebuilds a droplet droplet from an image with a given id.
+// RebuildByImageID rebuilds a Droplet from an image with a given id.
 func (s *DropletActionsServiceOp) RebuildByImageID(id, imageID int) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "rebuild", "image": imageID}
 	return s.doAction(id, request)
 }
 
-// RebuildByImageSlug rebuilds a droplet from an image with a given slug.
+// RebuildByImageSlug rebuilds a Droplet from an Image matched by a given Slug.
 func (s *DropletActionsServiceOp) RebuildByImageSlug(id int, slug string) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "rebuild", "image": slug}
 	return s.doAction(id, request)
 }
 
-// ChangeKernel changes the kernel for a droplet.
+// ChangeKernel changes the kernel for a Droplet.
 func (s *DropletActionsServiceOp) ChangeKernel(id, kernelID int) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "change_kernel", "kernel": kernelID}
 	return s.doAction(id, request)
 }
 
-// EnableIPv6 enables IPv6 for a droplet.
+// EnableIPv6 enables IPv6 for a Droplet.
 func (s *DropletActionsServiceOp) EnableIPv6(id int) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "enable_ipv6"}
 	return s.doAction(id, request)
 }
 
-// EnableIPv6 enables IPv6 for a droplet by Tag
+// EnableIPv6ByTag enables IPv6 for Droplets matched by a Tag.
 func (s *DropletActionsServiceOp) EnableIPv6ByTag(tag string) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "enable_ipv6"}
 	return s.doActionByTag(tag, request)
 }
 
-// EnablePrivateNetworking enables private networking for a droplet.
+// EnablePrivateNetworking enables private networking for a Droplet.
 func (s *DropletActionsServiceOp) EnablePrivateNetworking(id int) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "enable_private_networking"}
 	return s.doAction(id, request)
 }
 
-// EnablePrivateNetworking enables private networking for a droplet by Tag
+// EnablePrivateNetworkingByTag enables private networking for Droplets matched by a Tag.
 func (s *DropletActionsServiceOp) EnablePrivateNetworkingByTag(tag string) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "enable_private_networking"}
 	return s.doActionByTag(tag, request)
 }
 
-// Upgrade a droplet.
+// Upgrade a Droplet.
 func (s *DropletActionsServiceOp) Upgrade(id int) (*Action, *Response, error) {
 	request := &ActionRequest{"type": "upgrade"}
 	return s.doAction(id, request)
@@ -284,7 +284,7 @@ func (s *DropletActionsServiceOp) doActionByTag(tag string, request *ActionReque
 	return root.Event, resp, err
 }
 
-// Get an action for a particular droplet by id.
+// Get an action for a particular Droplet by id.
 func (s *DropletActionsServiceOp) Get(dropletID, actionID int) (*Action, *Response, error) {
 	if dropletID < 1 {
 		return nil, nil, NewArgError("dropletID", "cannot be less than 1")
@@ -298,7 +298,7 @@ func (s *DropletActionsServiceOp) Get(dropletID, actionID int) (*Action, *Respon
 	return s.get(path)
 }
 
-// GetByURI gets an action for a particular droplet by id.
+// GetByURI gets an action for a particular Droplet by id.
 func (s *DropletActionsServiceOp) GetByURI(rawurl string) (*Action, *Response, error) {
 	u, err := url.Parse(rawurl)
 	if err != nil {

--- a/droplets.go
+++ b/droplets.go
@@ -10,7 +10,7 @@ const dropletBasePath = "v2/droplets"
 
 var errNoNetworks = errors.New("no networks have been defined")
 
-// DropletsService is an interface for interfacing with the droplet
+// DropletsService is an interface for interfacing with the Droplet
 // endpoints of the DigitalOcean API
 // See: https://developers.digitalocean.com/documentation/v2#droplets
 type DropletsService interface {
@@ -28,7 +28,7 @@ type DropletsService interface {
 	Neighbors(int) ([]Droplet, *Response, error)
 }
 
-// DropletsServiceOp handles communication with the droplet related methods of the
+// DropletsServiceOp handles communication with the Droplet related methods of the
 // DigitalOcean API.
 type DropletsServiceOp struct {
 	client *Client
@@ -194,7 +194,7 @@ func (d DropletCreateSSHKey) MarshalJSON() ([]byte, error) {
 	return json.Marshal(d.ID)
 }
 
-// DropletCreateRequest represents a request to create a droplet.
+// DropletCreateRequest represents a request to create a Droplet.
 type DropletCreateRequest struct {
 	Name              string                `json:"name"`
 	Region            string                `json:"region"`
@@ -209,7 +209,7 @@ type DropletCreateRequest struct {
 	Tags              []string              `json:"tags"`
 }
 
-// DropletMultiCreateRequest is a request to create multiple droplets.
+// DropletMultiCreateRequest is a request to create multiple Droplets.
 type DropletMultiCreateRequest struct {
 	Names             []string              `json:"names"`
 	Region            string                `json:"region"`
@@ -231,13 +231,13 @@ func (d DropletMultiCreateRequest) String() string {
 	return Stringify(d)
 }
 
-// Networks represents the droplet's networks
+// Networks represents the Droplet's Networks.
 type Networks struct {
 	V4 []NetworkV4 `json:"v4,omitempty"`
 	V6 []NetworkV6 `json:"v6,omitempty"`
 }
 
-// NetworkV4 represents a DigitalOcean IPv4 Network
+// NetworkV4 represents a DigitalOcean IPv4 Network.
 type NetworkV4 struct {
 	IPAddress string `json:"ip_address,omitempty"`
 	Netmask   string `json:"netmask,omitempty"`
@@ -261,7 +261,7 @@ func (n NetworkV6) String() string {
 	return Stringify(n)
 }
 
-// Performs a list request given a path
+// Performs a list request given a path.
 func (s *DropletsServiceOp) list(path string) ([]Droplet, *Response, error) {
 	req, err := s.client.NewRequest("GET", path, nil)
 	if err != nil {
@@ -280,7 +280,7 @@ func (s *DropletsServiceOp) list(path string) ([]Droplet, *Response, error) {
 	return root.Droplets, resp, err
 }
 
-// List all droplets
+// List all Droplets.
 func (s *DropletsServiceOp) List(opt *ListOptions) ([]Droplet, *Response, error) {
 	path := dropletBasePath
 	path, err := addOptions(path, opt)
@@ -291,7 +291,7 @@ func (s *DropletsServiceOp) List(opt *ListOptions) ([]Droplet, *Response, error)
 	return s.list(path)
 }
 
-// List all droplets by tag
+// ListByTag lists all Droplets matched by a Tag.
 func (s *DropletsServiceOp) ListByTag(tag string, opt *ListOptions) ([]Droplet, *Response, error) {
 	path := fmt.Sprintf("%s?tag_name=%s", dropletBasePath, tag)
 	path, err := addOptions(path, opt)
@@ -302,7 +302,7 @@ func (s *DropletsServiceOp) ListByTag(tag string, opt *ListOptions) ([]Droplet, 
 	return s.list(path)
 }
 
-// Get individual droplet
+// Get individual Droplet.
 func (s *DropletsServiceOp) Get(dropletID int) (*Droplet, *Response, error) {
 	if dropletID < 1 {
 		return nil, nil, NewArgError("dropletID", "cannot be less than 1")
@@ -324,7 +324,7 @@ func (s *DropletsServiceOp) Get(dropletID int) (*Droplet, *Response, error) {
 	return root.Droplet, resp, err
 }
 
-// Create droplet
+// Create Droplet
 func (s *DropletsServiceOp) Create(createRequest *DropletCreateRequest) (*Droplet, *Response, error) {
 	if createRequest == nil {
 		return nil, nil, NewArgError("createRequest", "cannot be nil")
@@ -349,7 +349,7 @@ func (s *DropletsServiceOp) Create(createRequest *DropletCreateRequest) (*Drople
 	return root.Droplet, resp, err
 }
 
-// CreateMultiple creates multiple droplets.
+// CreateMultiple creates multiple Droplets.
 func (s *DropletsServiceOp) CreateMultiple(createRequest *DropletMultiCreateRequest) ([]Droplet, *Response, error) {
 	if createRequest == nil {
 		return nil, nil, NewArgError("createRequest", "cannot be nil")
@@ -386,7 +386,7 @@ func (s *DropletsServiceOp) delete(path string) (*Response, error) {
 	return resp, err
 }
 
-// Delete droplet
+// Delete Droplet.
 func (s *DropletsServiceOp) Delete(dropletID int) (*Response, error) {
 	if dropletID < 1 {
 		return nil, NewArgError("dropletID", "cannot be less than 1")
@@ -397,7 +397,7 @@ func (s *DropletsServiceOp) Delete(dropletID int) (*Response, error) {
 	return s.delete(path)
 }
 
-// Delete droplets by tag
+// DeleteByTag deletes Droplets matched by a Tag.
 func (s *DropletsServiceOp) DeleteByTag(tag string) (*Response, error) {
 	if tag == "" {
 		return nil, NewArgError("tag", "cannot be empty")
@@ -408,7 +408,7 @@ func (s *DropletsServiceOp) DeleteByTag(tag string) (*Response, error) {
 	return s.delete(path)
 }
 
-// Kernels lists kernels available for a droplet.
+// Kernels lists kernels available for a Droplet.
 func (s *DropletsServiceOp) Kernels(dropletID int, opt *ListOptions) ([]Kernel, *Response, error) {
 	if dropletID < 1 {
 		return nil, nil, NewArgError("dropletID", "cannot be less than 1")
@@ -434,7 +434,7 @@ func (s *DropletsServiceOp) Kernels(dropletID int, opt *ListOptions) ([]Kernel, 
 	return root.Kernels, resp, err
 }
 
-// Actions lists the actions for a droplet.
+// Actions lists the actions for a Droplet.
 func (s *DropletsServiceOp) Actions(dropletID int, opt *ListOptions) ([]Action, *Response, error) {
 	if dropletID < 1 {
 		return nil, nil, NewArgError("dropletID", "cannot be less than 1")
@@ -463,7 +463,7 @@ func (s *DropletsServiceOp) Actions(dropletID int, opt *ListOptions) ([]Action, 
 	return root.Actions, resp, err
 }
 
-// Backups lists the backups for a droplet.
+// Backups lists the backups for a Droplet.
 func (s *DropletsServiceOp) Backups(dropletID int, opt *ListOptions) ([]Image, *Response, error) {
 	if dropletID < 1 {
 		return nil, nil, NewArgError("dropletID", "cannot be less than 1")
@@ -492,7 +492,7 @@ func (s *DropletsServiceOp) Backups(dropletID int, opt *ListOptions) ([]Image, *
 	return root.Backups, resp, err
 }
 
-// Snapshots lists the snapshots available for a droplet.
+// Snapshots lists the snapshots available for a Droplet.
 func (s *DropletsServiceOp) Snapshots(dropletID int, opt *ListOptions) ([]Image, *Response, error) {
 	if dropletID < 1 {
 		return nil, nil, NewArgError("dropletID", "cannot be less than 1")
@@ -521,7 +521,7 @@ func (s *DropletsServiceOp) Snapshots(dropletID int, opt *ListOptions) ([]Image,
 	return root.Snapshots, resp, err
 }
 
-// Neighbors lists the neighbors for a droplet.
+// Neighbors lists the neighbors for a Droplet.
 func (s *DropletsServiceOp) Neighbors(dropletID int) ([]Droplet, *Response, error) {
 	if dropletID < 1 {
 		return nil, nil, NewArgError("dropletID", "cannot be less than 1")

--- a/godo.go
+++ b/godo.go
@@ -220,7 +220,7 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 
 	buf := new(bytes.Buffer)
 	if body != nil {
-		err := json.NewEncoder(buf).Encode(body)
+		err = json.NewEncoder(buf).Encode(body)
 		if err != nil {
 			return nil, err
 		}
@@ -312,12 +312,12 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 
 	if v != nil {
 		if w, ok := v.(io.Writer); ok {
-			_, err := io.Copy(w, resp.Body)
+			_, err = io.Copy(w, resp.Body)
 			if err != nil {
 				return nil, err
 			}
 		} else {
-			err := json.NewDecoder(resp.Body).Decode(v)
+			err = json.NewDecoder(resp.Body).Decode(v)
 			if err != nil {
 				return nil, err
 			}

--- a/links.go
+++ b/links.go
@@ -58,11 +58,7 @@ func (l *Links) IsLastPage() bool {
 }
 
 func (p *Pages) isLast() bool {
-	if p.Last == "" {
-		return true
-	}
-
-	return false
+	return p.Last == ""
 }
 
 func pageForURL(urlText string) (int, error) {

--- a/regions.go
+++ b/regions.go
@@ -29,9 +29,9 @@ type regionsRoot struct {
 	Links   *Links `json:"links"`
 }
 
-type regionRoot struct {
-	Region *Region
-}
+// type regionRoot struct { // DEADCODE
+// 	Region *Region
+// }
 
 func (r Region) String() string {
 	return Stringify(r)

--- a/regions.go
+++ b/regions.go
@@ -29,10 +29,6 @@ type regionsRoot struct {
 	Links   *Links `json:"links"`
 }
 
-// type regionRoot struct { // DEADCODE
-// 	Region *Region
-// }
-
 func (r Region) String() string {
 	return Stringify(r)
 }

--- a/snapshots.go
+++ b/snapshots.go
@@ -69,7 +69,7 @@ func (s *SnapshotsServiceOp) ListVolume(opt *ListOptions) ([]Snapshot, *Response
 	return s.list(opt, &listOpt)
 }
 
-// GetByID retrieves an snapshot by id.
+// Get retrieves an snapshot by id.
 func (s *SnapshotsServiceOp) Get(snapshotID string) (*Snapshot, *Response, error) {
 	return s.get(interface{}(snapshotID))
 }

--- a/storage_actions.go
+++ b/storage_actions.go
@@ -21,12 +21,12 @@ type StorageActionsServiceOp struct {
 }
 
 // StorageAttachment represents the attachement of a block storage
-// volume to a specific droplet under the device name.
+// volume to a specific Droplet under the device name.
 type StorageAttachment struct {
 	DropletID int `json:"droplet_id"`
 }
 
-// Attach a storage volume to a droplet.
+// Attach a storage volume to a Droplet.
 func (s *StorageActionsServiceOp) Attach(volumeID string, dropletID int) (*Action, *Response, error) {
 	request := &ActionRequest{
 		"type":       "attach",
@@ -35,7 +35,7 @@ func (s *StorageActionsServiceOp) Attach(volumeID string, dropletID int) (*Actio
 	return s.doAction(volumeID, request)
 }
 
-// Detach a storage volume from a droplet.
+// Detach a storage volume from a Droplet.
 func (s *StorageActionsServiceOp) Detach(volumeID string) (*Action, *Response, error) {
 	request := &ActionRequest{
 		"type": "detach",
@@ -43,7 +43,7 @@ func (s *StorageActionsServiceOp) Detach(volumeID string) (*Action, *Response, e
 	return s.doAction(volumeID, request)
 }
 
-// Detach a storage volume from a droplet by droplet ID.
+// DetachByDropletID a storage volume from a Droplet by Droplet ID.
 func (s *StorageActionsServiceOp) DetachByDropletID(volumeID string, dropletID int) (*Action, *Response, error) {
 	request := &ActionRequest{
 		"type":       "detach",

--- a/storage_actions_test.go
+++ b/storage_actions_test.go
@@ -140,7 +140,7 @@ func TestStorageActions_List(t *testing.T) {
 		t.Errorf("StorageActions.List returned error: %v", err)
 	}
 
-	expected := []Action{Action{Status: "in-progress"}}
+	expected := []Action{{Status: "in-progress"}}
 	if !reflect.DeepEqual(actions, expected) {
 		t.Errorf("StorageActions.List returned %+v, expected %+v", actions, expected)
 	}

--- a/tags.go
+++ b/tags.go
@@ -30,6 +30,7 @@ var _ TagsService = &TagsServiceOp{}
 type ResourceType string
 
 const (
+	//DropletResourceType holds the string representing our ResourceType of Droplet.
 	DropletResourceType ResourceType = "droplet"
 )
 
@@ -56,18 +57,22 @@ type Tag struct {
 	Resources *TaggedResources `json:"resources,omitempty"`
 }
 
+//TagCreateRequest represents the JSON structure of a request of that type.
 type TagCreateRequest struct {
 	Name string `json:"name"`
 }
 
+//TagUpdateRequest represents the JSON structure of a request of that type.
 type TagUpdateRequest struct {
 	Name string `json:"name"`
 }
 
+// TagResourcesRequest represents the JSON structure of a request of that type.
 type TagResourcesRequest struct {
 	Resources []Resource `json:"resources"`
 }
 
+// UntagResourcesRequest represents the JSON structure of a request of that type.
 type UntagResourcesRequest struct {
 	Resources []Resource `json:"resources"`
 }
@@ -183,7 +188,7 @@ func (s *TagsServiceOp) Delete(name string) (*Response, error) {
 	return resp, err
 }
 
-// Associate resources with a tag
+// TagResources associates resources with a given Tag.
 func (s *TagsServiceOp) TagResources(name string, tagRequest *TagResourcesRequest) (*Response, error) {
 	if name == "" {
 		return nil, NewArgError("name", "cannot be empty")
@@ -204,7 +209,7 @@ func (s *TagsServiceOp) TagResources(name string, tagRequest *TagResourcesReques
 	return resp, err
 }
 
-// Dissociate resources with a tag
+// UntagResources dissociates resources with a given Tag.
 func (s *TagsServiceOp) UntagResources(name string, untagRequest *UntagResourcesRequest) (*Response, error) {
 	if name == "" {
 		return nil, NewArgError("name", "cannot be empty")

--- a/tags_test.go
+++ b/tags_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	listEmptyJson string = `
+	listEmptyJSON = `
 	{
 		"tags": [
 		],
@@ -19,7 +19,7 @@ var (
 	}
 	`
 
-	listJson string = `
+	listJSON = `
 	{
 		"tags": [
 		{
@@ -55,7 +55,7 @@ var (
 	}
 	`
 
-	createJson string = `
+	createJSON = `
 	{
 		"tag": {
 			"name": "testing-1",
@@ -69,7 +69,7 @@ var (
 	}
 	`
 
-	getJson string = `
+	getJSON = `
 	{
 		"tag": {
 			"name": "testing-1",
@@ -170,7 +170,7 @@ func TestTags_List(t *testing.T) {
 
 	mux.HandleFunc("/v2/tags", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, listJson)
+		fmt.Fprint(w, listJSON)
 	})
 
 	tags, _, err := client.Tags.List(nil)
@@ -191,7 +191,7 @@ func TestTags_ListEmpty(t *testing.T) {
 
 	mux.HandleFunc("/v2/tags", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, listEmptyJson)
+		fmt.Fprint(w, listEmptyJSON)
 	})
 
 	tags, _, err := client.Tags.List(nil)
@@ -211,7 +211,7 @@ func TestTags_ListPaging(t *testing.T) {
 
 	mux.HandleFunc("/v2/tags", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, listJson)
+		fmt.Fprint(w, listJSON)
 	})
 
 	_, resp, err := client.Tags.List(nil)
@@ -227,7 +227,7 @@ func TestTags_Get(t *testing.T) {
 
 	mux.HandleFunc("/v2/tags/testing-1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, getJson)
+		fmt.Fprint(w, getJSON)
 	})
 
 	tag, _, err := client.Tags.Get("testing-1")
@@ -268,7 +268,7 @@ func TestTags_Create(t *testing.T) {
 			t.Errorf("Request body = %+v, expected %+v", v, createRequest)
 		}
 
-		fmt.Fprintf(w, createJson)
+		fmt.Fprintf(w, createJSON)
 	})
 
 	tag, _, err := client.Tags.Create(createRequest)

--- a/timestamp_test.go
+++ b/timestamp_test.go
@@ -88,6 +88,9 @@ func TestTimstamp_MarshalReflexivity(t *testing.T) {
 		}
 		var got Timestamp
 		err = json.Unmarshal(data, &got)
+		if err != nil {
+			t.Errorf("%s: Unmarshal err=%v", data, err)
+		}
 		if !got.Equal(tc.data) {
 			t.Errorf("%s: %+v != %+v", tc.desc, got, data)
 		}
@@ -169,6 +172,9 @@ func TestWrappedTimestamp_MarshalReflexivity(t *testing.T) {
 		}
 		var got WrappedTimestamp
 		err = json.Unmarshal(bytes, &got)
+		if err != nil {
+			t.Errorf("%s: Unmarshal err=%v", bytes, err)
+		}
 		if !got.Time.Equal(tc.data.Time) {
 			t.Errorf("%s: %+v != %+v", tc.desc, got, tc.data)
 		}


### PR DESCRIPTION
Running linters on the package comes back with a number of stylistic errors relating to commenting, some cyclic complexity, opportunities for the use of an interface, and some shadowed/ineffectual/downright missing error checks. I fixed them so the Go report card looks clean(er). Tests run still, 