### PR TITLE
adding tests for godo.SetBaseURL()

### DIFF
--- a/godo_test.go
+++ b/godo_test.go
@@ -513,3 +513,24 @@ func TestCustomUserAgent(t *testing.T) {
 		t.Errorf("New() UserAgent = %s; expected %s", got, expected)
 	}
 }
+
+func TestCustomBaseURL(t *testing.T) {
+	baseURL := "http://localhost/foo"
+	c, err := New(nil, SetBaseURL(baseURL))
+
+	if err != nil {
+		t.Fatalf("New() unexpected error: %v", err)
+	}
+
+	expected := baseURL
+	if got := c.BaseURL.String(); got != expected {
+		t.Errorf("New() BaseURL = %s; expected %s", got, expected)
+	}
+}
+
+func TestCustomBaseURL_badURL(t *testing.T) {
+	baseURL := ":"
+	_, err := New(nil, SetBaseURL(baseURL))
+
+	testURLParseError(t, err)
+}


### PR DESCRIPTION
Added TestCustomBaseURL and TestCustomBaseURL_badURL to godo_test.go to help test the SetBaseURL function.

This will help validate Client.BaseURL field matches the defined url when setting in Client.New(nil, SetBaseURL("url").

Also added test to handle errors on url.Parse to ensure that we return err as expected.

Thanks. 

(fyi..  New to golang/opensource and learning so much from godo and doctl projects!!)