### PR TITLE
Changes monitoring option from monitoring to install_agent

### DIFF
--- a/droplets.go
+++ b/droplets.go
@@ -204,7 +204,7 @@ type DropletCreateRequest struct {
 	Backups           bool                  `json:"backups"`
 	IPv6              bool                  `json:"ipv6"`
 	PrivateNetworking bool                  `json:"private_networking"`
-	Monitoring        bool                  `json:"monitoring"`
+	Monitoring        bool                  `json:"install_agent"`
 	UserData          string                `json:"user_data,omitempty"`
 	Volumes           []DropletCreateVolume `json:"volumes,omitempty"`
 	Tags              []string              `json:"tags"`
@@ -220,7 +220,7 @@ type DropletMultiCreateRequest struct {
 	Backups           bool                  `json:"backups"`
 	IPv6              bool                  `json:"ipv6"`
 	PrivateNetworking bool                  `json:"private_networking"`
-	Monitoring        bool                  `json:"monitoring"`
+	Monitoring        bool                  `json:"install_agent"`
 	UserData          string                `json:"user_data,omitempty"`
 	Tags              []string              `json:"tags"`
 }

--- a/droplets_test.go
+++ b/droplets_test.go
@@ -165,7 +165,7 @@ func TestDroplets_Create(t *testing.T) {
 			"backups":            false,
 			"ipv6":               false,
 			"private_networking": false,
-			"monitoring":         false,
+			"install_agent":      false,
 			"volumes": []interface{}{
 				map[string]interface{}{"name": "hello-im-a-volume"},
 				map[string]interface{}{"id": "hello-im-another-volume"},
@@ -225,7 +225,7 @@ func TestDroplets_CreateMultiple(t *testing.T) {
 			"backups":            false,
 			"ipv6":               false,
 			"private_networking": false,
-			"monitoring":         false,
+			"install_agent":      false,
 			"tags":               []interface{}{"one", "two"},
 		}
 

--- a/godo_test.go
+++ b/godo_test.go
@@ -133,7 +133,7 @@ func TestNewRequest(t *testing.T) {
 	inBody, outBody := &DropletCreateRequest{Name: "l"},
 		`{"name":"l","region":"","size":"","image":0,`+
 			`"ssh_keys":null,"backups":false,"ipv6":false,`+
-			`"private_networking":false,"monitoring":false,"tags":null}`+"\n"
+			`"private_networking":false,"install_agent":false,"tags":null}`+"\n"
 	req, _ := c.NewRequest("GET", inURL, inBody)
 
 	// test relative URL was expanded
@@ -161,7 +161,7 @@ func TestNewRequest_withUserData(t *testing.T) {
 	inBody, outBody := &DropletCreateRequest{Name: "l", UserData: "u"},
 		`{"name":"l","region":"","size":"","image":0,`+
 			`"ssh_keys":null,"backups":false,"ipv6":false,`+
-			`"private_networking":false,"monitoring":false,"user_data":"u","tags":null}`+"\n"
+			`"private_networking":false,"install_agent":false,"user_data":"u","tags":null}`+"\n"
 	req, _ := c.NewRequest("GET", inURL, inBody)
 
 	// test relative URL was expanded


### PR DESCRIPTION
Based on the current API it appears that this option will be called `install_agent` instead of `monitoring`. 

```
{
. . .
  "features": [
    "private_networking",
    "backups",
    "ipv6",
    "metadata",
    "install_agent"
  ]
. . .
}
```

When creating a new Droplet via the website, if you check **Monitoring**, it adds `options=install_agent` to the URL.