### PR TITLE
Implementing Image Convert action

### DIFF
--- a/image_actions.go
+++ b/image_actions.go
@@ -11,6 +11,7 @@ import (
 type ImageActionsService interface {
 	Get(context.Context, int, int) (*Action, *Response, error)
 	Transfer(context.Context, int, *ActionRequest) (*Action, *Response, error)
+	Convert(context.Context, int) (*Action, *Response, error)
 }
 
 // ImageActionsServiceOp handles communition with the image action related methods of the
@@ -34,6 +35,32 @@ func (i *ImageActionsServiceOp) Transfer(ctx context.Context, imageID int, trans
 	path := fmt.Sprintf("v2/images/%d/actions", imageID)
 
 	req, err := i.client.NewRequest(ctx, "POST", path, transferRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(actionRoot)
+	resp, err := i.client.Do(req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Event, resp, err
+}
+
+// Convert an image to a snapshot
+func (i *ImageActionsServiceOp) Convert(ctx context.Context, imageID int) (*Action, *Response, error) {
+	if imageID < 1 {
+		return nil, nil, NewArgError("imageID", "cannont be less than 1")
+	}
+
+	path := fmt.Sprintf("v2/images/%d/actions", imageID)
+
+	convertRequest := &ActionRequest{
+		"type": "convert",
+	}
+
+	req, err := i.client.NewRequest(ctx, "POST", path, convertRequest)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/image_actions_test.go
+++ b/image_actions_test.go
@@ -41,6 +41,41 @@ func TestImageActions_Transfer(t *testing.T) {
 	}
 }
 
+func TestImageActions_Convert(t *testing.T) {
+	setup()
+	defer teardown()
+
+	convertRequest := &ActionRequest{
+		"type": "convert",
+	}
+
+	mux.HandleFunc("/v2/images/12345/actions", func(w http.ResponseWriter, r *http.Request) {
+		v := new(ActionRequest)
+		err := json.NewDecoder(r.Body).Decode(v)
+		if err != nil {
+			t.Fatalf("decode json: %v", err)
+		}
+
+		testMethod(t, r, "POST")
+		if !reflect.DeepEqual(v, convertRequest) {
+			t.Errorf("Request body = %+v, expected %+v", v, convertRequest)
+		}
+
+		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
+
+	})
+
+	transfer, _, err := client.ImageActions.Convert(ctx, 12345)
+	if err != nil {
+		t.Errorf("ImageActions.Transfer returned error: %v", err)
+	}
+
+	expected := &Action{Status: "in-progress"}
+	if !reflect.DeepEqual(transfer, expected) {
+		t.Errorf("ImageActions.Transfer returned %+v, expected %+v", transfer, expected)
+	}
+}
+
 func TestImageActions_Get(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
This Pull Requests implement Convert Image action. For example, convert image can be used to convert an backup to a snapshot.

Action is described in [Convert - Image Actions](https://developers.digitalocean.com/documentation/v2/#convert-an-image-to-a-snapshot) API docs.

It's a very similar to a Transfer action. It could be made into one function, but it would require a `Transfer` rename.
I'm not sure about project backward compatibility policy, so I decided to go with another function.

Because `ActionRequest` is fixed, and is always taking the same data - `type: convert`, I predefined it.
If it's the problem, I'll go ahead and make it same as the `Transfer` action.

This also comes with a test unit for action.

cc @mauricio @aybabtme 