### PR TITLE
Remove non-working Detach function

### DIFF
--- a/storage_actions.go
+++ b/storage_actions.go
@@ -10,7 +10,6 @@ import (
 // See: https://developers.digitalocean.com/documentation/v2#storage-actions
 type StorageActionsService interface {
 	Attach(ctx context.Context, volumeID string, dropletID int) (*Action, *Response, error)
-	Detach(ctx context.Context, volumeID string) (*Action, *Response, error)
 	DetachByDropletID(ctx context.Context, volumeID string, dropletID int) (*Action, *Response, error)
 	Get(ctx context.Context, volumeID string, actionID int) (*Action, *Response, error)
 	List(ctx context.Context, volumeID string, opt *ListOptions) ([]Action, *Response, error)
@@ -34,14 +33,6 @@ func (s *StorageActionsServiceOp) Attach(ctx context.Context, volumeID string, d
 	request := &ActionRequest{
 		"type":       "attach",
 		"droplet_id": dropletID,
-	}
-	return s.doAction(ctx, volumeID, request)
-}
-
-// Detach a storage volume from a Droplet.
-func (s *StorageActionsServiceOp) Detach(ctx context.Context, volumeID string) (*Action, *Response, error) {
-	request := &ActionRequest{
-		"type": "detach",
 	}
 	return s.doAction(ctx, volumeID, request)
 }

--- a/storage_actions_test.go
+++ b/storage_actions_test.go
@@ -42,36 +42,6 @@ func TestStoragesActions_Attach(t *testing.T) {
 	}
 }
 
-func TestStoragesActions_Detach(t *testing.T) {
-	setup()
-	defer teardown()
-	volumeID := "98d414c6-295e-4e3a-ac58-eb9456c1e1d1"
-
-	detachRequest := &ActionRequest{
-		"type": "detach",
-	}
-
-	mux.HandleFunc("/v2/volumes/"+volumeID+"/actions", func(w http.ResponseWriter, r *http.Request) {
-		v := new(ActionRequest)
-		err := json.NewDecoder(r.Body).Decode(v)
-		if err != nil {
-			t.Fatalf("decode json: %v", err)
-		}
-
-		testMethod(t, r, "POST")
-		if !reflect.DeepEqual(v, detachRequest) {
-			t.Errorf("want=%#v", detachRequest)
-			t.Errorf("got=%#v", v)
-		}
-		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
-	})
-
-	_, _, err := client.StorageActions.Detach(ctx, volumeID)
-	if err != nil {
-		t.Errorf("StoragesActions.Detach returned error: %v", err)
-	}
-}
-
 func TestStoragesActions_DetachByDropletID(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
The function returns "422 Attachment not found" all the time (tested
with doctl), and the doc* also says that droplet id should be
specified.

* https://developers.digitalocean.com/documentation/v2/#remove-a-block-storage-volume-from-a-droplet