### PR TITLE
Deprecate tag rename (PUT /v2/tags/:name)

### DIFF
--- a/tags.go
+++ b/tags.go
@@ -14,7 +14,6 @@ type TagsService interface {
 	List(context.Context, *ListOptions) ([]Tag, *Response, error)
 	Get(context.Context, string) (*Tag, *Response, error)
 	Create(context.Context, *TagCreateRequest) (*Tag, *Response, error)
-	Update(context.Context, string, *TagUpdateRequest) (*Response, error)
 	Delete(context.Context, string) (*Response, error)
 
 	TagResources(context.Context, string, *TagResourcesRequest) (*Response, error)
@@ -62,11 +61,6 @@ type Tag struct {
 
 //TagCreateRequest represents the JSON structure of a request of that type.
 type TagCreateRequest struct {
-	Name string `json:"name"`
-}
-
-//TagUpdateRequest represents the JSON structure of a request of that type.
-type TagUpdateRequest struct {
 	Name string `json:"name"`
 }
 
@@ -151,27 +145,6 @@ func (s *TagsServiceOp) Create(ctx context.Context, createRequest *TagCreateRequ
 	}
 
 	return root.Tag, resp, err
-}
-
-// Update an exsting tag
-func (s *TagsServiceOp) Update(ctx context.Context, name string, updateRequest *TagUpdateRequest) (*Response, error) {
-	if name == "" {
-		return nil, NewArgError("name", "cannot be empty")
-	}
-
-	if updateRequest == nil {
-		return nil, NewArgError("updateRequest", "cannot be nil")
-	}
-
-	path := fmt.Sprintf("%s/%s", tagsBasePath, name)
-	req, err := s.client.NewRequest(ctx, "PUT", path, updateRequest)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := s.client.Do(req, nil)
-
-	return resp, err
 }
 
 // Delete an existing tag

--- a/tags_test.go
+++ b/tags_test.go
@@ -42,7 +42,7 @@ var (
 		}
 		],
 		"links": {
- 			"pages":{
+			"pages":{
 				"next":"http://example.com/v2/tags/?page=3",
 				"prev":"http://example.com/v2/tags/?page=1",
 				"last":"http://example.com/v2/tags/?page=3",
@@ -279,35 +279,6 @@ func TestTags_Create(t *testing.T) {
 	expected := &Tag{Name: "testing-1", Resources: &TaggedResources{Droplets: &TaggedDropletsResources{Count: 0, LastTagged: nil}}}
 	if !reflect.DeepEqual(tag, expected) {
 		t.Errorf("Tags.Create returned %+v, expected %+v", tag, expected)
-	}
-}
-
-func TestTags_Update(t *testing.T) {
-	setup()
-	defer teardown()
-
-	updateRequest := &TagUpdateRequest{
-		Name: "testing-1",
-	}
-
-	mux.HandleFunc("/v2/tags/old-testing-1", func(w http.ResponseWriter, r *http.Request) {
-		v := new(TagUpdateRequest)
-
-		err := json.NewDecoder(r.Body).Decode(v)
-		if err != nil {
-			t.Fatalf("decode json: %v", err)
-		}
-
-		testMethod(t, r, "PUT")
-		if !reflect.DeepEqual(v, updateRequest) {
-			t.Errorf("Request body = %+v, expected %+v", v, updateRequest)
-		}
-
-	})
-
-	_, err := client.Tags.Update(ctx, "old-testing-1", updateRequest)
-	if err != nil {
-		t.Errorf("Tags.Update returned error: %v", err)
 	}
 }
 


### PR DESCRIPTION
Per [our changelog](https://developers.digitalocean.com/documentation/changelog/api-v2/deprecating-update-tag/), tag rename will be deprecated on April 26, 2017.

cc @mauricio @hugocorbucci @magicgrl111 