### PR TITLE
Add TTL property to Domains

### DIFF
--- a/domains.go
+++ b/domains.go
@@ -74,6 +74,7 @@ type DomainRecord struct {
 	Data     string `json:"data,omitempty"`
 	Priority int    `json:"priority,omitempty"`
 	Port     int    `json:"port,omitempty"`
+	TTL      int    `json:"ttl,omitempty"`
 	Weight   int    `json:"weight,omitempty"`
 }
 
@@ -84,6 +85,7 @@ type DomainRecordEditRequest struct {
 	Data     string `json:"data,omitempty"`
 	Priority int    `json:"priority,omitempty"`
 	Port     int    `json:"port,omitempty"`
+	TTL      int    `json:"ttl,omitempty"`
 	Weight   int    `json:"weight,omitempty"`
 }
 

--- a/domains_test.go
+++ b/domains_test.go
@@ -234,6 +234,7 @@ func TestDomains_CreateRecordForDomainName(t *testing.T) {
 		Data:     "@",
 		Priority: 10,
 		Port:     10,
+		TTL:      1800,
 		Weight:   10,
 	}
 
@@ -275,6 +276,7 @@ func TestDomains_EditRecordForDomainName(t *testing.T) {
 		Data:     "@",
 		Priority: 10,
 		Port:     10,
+		TTL:      1800,
 		Weight:   10,
 	}
 
@@ -312,11 +314,12 @@ func TestDomainRecord_String(t *testing.T) {
 		Data:     "@",
 		Priority: 10,
 		Port:     10,
+		TTL:      1800,
 		Weight:   10,
 	}
 
 	stringified := record.String()
-	expected := `godo.DomainRecord{ID:1, Type:"CNAME", Name:"example", Data:"@", Priority:10, Port:10, Weight:10}`
+	expected := `godo.DomainRecord{ID:1, Type:"CNAME", Name:"example", Data:"@", Priority:10, Port:10, TTL:1800, Weight:10}`
 	if expected != stringified {
 		t.Errorf("DomainRecord.String returned %+v, expected %+v", stringified, expected)
 	}
@@ -329,11 +332,12 @@ func TestDomainRecordEditRequest_String(t *testing.T) {
 		Data:     "@",
 		Priority: 10,
 		Port:     10,
+		TTL:      1800,
 		Weight:   10,
 	}
 
 	stringified := record.String()
-	expected := `godo.DomainRecordEditRequest{Type:"CNAME", Name:"example", Data:"@", Priority:10, Port:10, Weight:10}`
+	expected := `godo.DomainRecordEditRequest{Type:"CNAME", Name:"example", Data:"@", Priority:10, Port:10, TTL:1800, Weight:10}`
 	if expected != stringified {
 		t.Errorf("DomainRecordEditRequest.String returned %+v, expected %+v", stringified, expected)
 	}


### PR DESCRIPTION
This PR adds TTL field for domain record operations.
By [API docs](https://developers.digitalocean.com/documentation/v2/#create-a-new-domain-record), it's now possible to specify TTL for all domain records.

/cc @mauricio 