### PR TITLE
Add OnRequest and OnResponse hooks

### DIFF
--- a/godo.go
+++ b/godo.go
@@ -66,10 +66,18 @@ type Client struct {
 
 	// Optional function called after every successful request made to the DO APIs
 	onRequestCompleted RequestCompletionCallback
+	onRequest          RequestCallback
+	onResponse         ResponseCallback
 }
 
 // RequestCompletionCallback defines the type of the request callback function
 type RequestCompletionCallback func(*http.Request, *http.Response)
+
+// RequestCallback defines the type of the request callback function
+type RequestCallback func(*http.Request)
+
+// ResponseCallback defines the type of the response callback function
+type ResponseCallback func(*http.Response)
 
 // ListOptions specifies the optional parameters to various List methods that
 // support pagination.
@@ -248,6 +256,16 @@ func (c *Client) OnRequestCompleted(rc RequestCompletionCallback) {
 	c.onRequestCompleted = rc
 }
 
+// OnRequest sets the DO API request callback
+func (c *Client) OnRequest(rc RequestCallback) {
+	c.onRequest = rc
+}
+
+// OnResponse sets the DO API response callback
+func (c *Client) OnResponse(rc ResponseCallback) {
+	c.onResponse = rc
+}
+
 // newResponse creates a new Response for the provided http.Response
 func newResponse(r *http.Response) *Response {
 	response := Response{Response: r}
@@ -294,10 +312,19 @@ func (r *Response) populateRate() {
 // pointed to by v, or returned as an error if an API error has occurred. If v implements the io.Writer interface,
 // the raw response will be written to v, without attempting to decode it.
 func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*Response, error) {
+	if c.onRequest != nil {
+		c.onRequest(req)
+	}
+
 	resp, err := context.DoRequestWithClient(ctx, c.client, req)
 	if err != nil {
 		return nil, err
 	}
+
+	if c.onResponse != nil {
+		c.onResponse(resp)
+	}
+
 	if c.onRequestCompleted != nil {
 		c.onRequestCompleted(req, resp)
 	}


### PR DESCRIPTION
To gather some data for further debugging of (potential) DO API issues I enabled logging of requests & responses using the existing `OnRequestCompleted` hook, but I learnt that hook has two drawbacks:

1. It logs both request and response at the time of receiving response, which means
  a. the request may not be logged at all if response isn't received (e.g. connection reset)
  b. both request and response are logged with the same timestamp, which makes it tricky to measure time between request and response
2. The request body is not available for reading, most likely because `Do()` closes it as part of sending the request to the API. See repro in a form of a failing test [here](https://github.com/digitalocean/godo/compare/master...radeksimko:b-callback-repro-case).

This is why I'm proposing two new hooks - `OnRequest` and `OnResponse` which deal with the mentioned issues.
