### PR TITLE
droplet_actions: return array of actions instead of action for tagged resources

### DIFF
--- a/droplet_actions.go
+++ b/droplet_actions.go
@@ -15,31 +15,31 @@ type ActionRequest map[string]interface{}
 // See: https://developers.digitalocean.com/documentation/v2#droplet-actions
 type DropletActionsService interface {
 	Shutdown(context.Context, int) (*Action, *Response, error)
-	ShutdownByTag(context.Context, string) (*Action, *Response, error)
+	ShutdownByTag(context.Context, string) ([]Action, *Response, error)
 	PowerOff(context.Context, int) (*Action, *Response, error)
-	PowerOffByTag(context.Context, string) (*Action, *Response, error)
+	PowerOffByTag(context.Context, string) ([]Action, *Response, error)
 	PowerOn(context.Context, int) (*Action, *Response, error)
-	PowerOnByTag(context.Context, string) (*Action, *Response, error)
+	PowerOnByTag(context.Context, string) ([]Action, *Response, error)
 	PowerCycle(context.Context, int) (*Action, *Response, error)
-	PowerCycleByTag(context.Context, string) (*Action, *Response, error)
+	PowerCycleByTag(context.Context, string) ([]Action, *Response, error)
 	Reboot(context.Context, int) (*Action, *Response, error)
 	Restore(context.Context, int, int) (*Action, *Response, error)
 	Resize(context.Context, int, string, bool) (*Action, *Response, error)
 	Rename(context.Context, int, string) (*Action, *Response, error)
 	Snapshot(context.Context, int, string) (*Action, *Response, error)
-	SnapshotByTag(context.Context, string, string) (*Action, *Response, error)
+	SnapshotByTag(context.Context, string, string) ([]Action, *Response, error)
 	EnableBackups(context.Context, int) (*Action, *Response, error)
-	EnableBackupsByTag(context.Context, string) (*Action, *Response, error)
+	EnableBackupsByTag(context.Context, string) ([]Action, *Response, error)
 	DisableBackups(context.Context, int) (*Action, *Response, error)
-	DisableBackupsByTag(context.Context, string) (*Action, *Response, error)
+	DisableBackupsByTag(context.Context, string) ([]Action, *Response, error)
 	PasswordReset(context.Context, int) (*Action, *Response, error)
 	RebuildByImageID(context.Context, int, int) (*Action, *Response, error)
 	RebuildByImageSlug(context.Context, int, string) (*Action, *Response, error)
 	ChangeKernel(context.Context, int, int) (*Action, *Response, error)
 	EnableIPv6(context.Context, int) (*Action, *Response, error)
-	EnableIPv6ByTag(context.Context, string) (*Action, *Response, error)
+	EnableIPv6ByTag(context.Context, string) ([]Action, *Response, error)
 	EnablePrivateNetworking(context.Context, int) (*Action, *Response, error)
-	EnablePrivateNetworkingByTag(context.Context, string) (*Action, *Response, error)
+	EnablePrivateNetworkingByTag(context.Context, string) ([]Action, *Response, error)
 	Upgrade(context.Context, int) (*Action, *Response, error)
 	Get(context.Context, int, int) (*Action, *Response, error)
 	GetByURI(context.Context, string) (*Action, *Response, error)
@@ -60,7 +60,7 @@ func (s *DropletActionsServiceOp) Shutdown(ctx context.Context, id int) (*Action
 }
 
 // ShutdownByTag shuts down Droplets matched by a Tag.
-func (s *DropletActionsServiceOp) ShutdownByTag(ctx context.Context, tag string) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) ShutdownByTag(ctx context.Context, tag string) ([]Action, *Response, error) {
 	request := &ActionRequest{"type": "shutdown"}
 	return s.doActionByTag(ctx, tag, request)
 }
@@ -72,7 +72,7 @@ func (s *DropletActionsServiceOp) PowerOff(ctx context.Context, id int) (*Action
 }
 
 // PowerOffByTag powers off Droplets matched by a Tag.
-func (s *DropletActionsServiceOp) PowerOffByTag(ctx context.Context, tag string) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) PowerOffByTag(ctx context.Context, tag string) ([]Action, *Response, error) {
 	request := &ActionRequest{"type": "power_off"}
 	return s.doActionByTag(ctx, tag, request)
 }
@@ -84,7 +84,7 @@ func (s *DropletActionsServiceOp) PowerOn(ctx context.Context, id int) (*Action,
 }
 
 // PowerOnByTag powers on Droplets matched by a Tag.
-func (s *DropletActionsServiceOp) PowerOnByTag(ctx context.Context, tag string) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) PowerOnByTag(ctx context.Context, tag string) ([]Action, *Response, error) {
 	request := &ActionRequest{"type": "power_on"}
 	return s.doActionByTag(ctx, tag, request)
 }
@@ -96,7 +96,7 @@ func (s *DropletActionsServiceOp) PowerCycle(ctx context.Context, id int) (*Acti
 }
 
 // PowerCycleByTag power cycles Droplets matched by a Tag.
-func (s *DropletActionsServiceOp) PowerCycleByTag(ctx context.Context, tag string) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) PowerCycleByTag(ctx context.Context, tag string) ([]Action, *Response, error) {
 	request := &ActionRequest{"type": "power_cycle"}
 	return s.doActionByTag(ctx, tag, request)
 }
@@ -149,7 +149,7 @@ func (s *DropletActionsServiceOp) Snapshot(ctx context.Context, id int, name str
 }
 
 // SnapshotByTag snapshots Droplets matched by a Tag.
-func (s *DropletActionsServiceOp) SnapshotByTag(ctx context.Context, tag string, name string) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) SnapshotByTag(ctx context.Context, tag string, name string) ([]Action, *Response, error) {
 	requestType := "snapshot"
 	request := &ActionRequest{
 		"type": requestType,
@@ -165,7 +165,7 @@ func (s *DropletActionsServiceOp) EnableBackups(ctx context.Context, id int) (*A
 }
 
 // EnableBackupsByTag enables backups for Droplets matched by a Tag.
-func (s *DropletActionsServiceOp) EnableBackupsByTag(ctx context.Context, tag string) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) EnableBackupsByTag(ctx context.Context, tag string) ([]Action, *Response, error) {
 	request := &ActionRequest{"type": "enable_backups"}
 	return s.doActionByTag(ctx, tag, request)
 }
@@ -177,7 +177,7 @@ func (s *DropletActionsServiceOp) DisableBackups(ctx context.Context, id int) (*
 }
 
 // DisableBackupsByTag disables backups for Droplet matched by a Tag.
-func (s *DropletActionsServiceOp) DisableBackupsByTag(ctx context.Context, tag string) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) DisableBackupsByTag(ctx context.Context, tag string) ([]Action, *Response, error) {
 	request := &ActionRequest{"type": "disable_backups"}
 	return s.doActionByTag(ctx, tag, request)
 }
@@ -213,7 +213,7 @@ func (s *DropletActionsServiceOp) EnableIPv6(ctx context.Context, id int) (*Acti
 }
 
 // EnableIPv6ByTag enables IPv6 for Droplets matched by a Tag.
-func (s *DropletActionsServiceOp) EnableIPv6ByTag(ctx context.Context, tag string) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) EnableIPv6ByTag(ctx context.Context, tag string) ([]Action, *Response, error) {
 	request := &ActionRequest{"type": "enable_ipv6"}
 	return s.doActionByTag(ctx, tag, request)
 }
@@ -225,7 +225,7 @@ func (s *DropletActionsServiceOp) EnablePrivateNetworking(ctx context.Context, i
 }
 
 // EnablePrivateNetworkingByTag enables private networking for Droplets matched by a Tag.
-func (s *DropletActionsServiceOp) EnablePrivateNetworkingByTag(ctx context.Context, tag string) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) EnablePrivateNetworkingByTag(ctx context.Context, tag string) ([]Action, *Response, error) {
 	request := &ActionRequest{"type": "enable_private_networking"}
 	return s.doActionByTag(ctx, tag, request)
 }
@@ -261,7 +261,7 @@ func (s *DropletActionsServiceOp) doAction(ctx context.Context, id int, request 
 	return root.Event, resp, err
 }
 
-func (s *DropletActionsServiceOp) doActionByTag(ctx context.Context, tag string, request *ActionRequest) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) doActionByTag(ctx context.Context, tag string, request *ActionRequest) ([]Action, *Response, error) {
 	if tag == "" {
 		return nil, nil, NewArgError("tag", "cannot be empty")
 	}
@@ -277,13 +277,13 @@ func (s *DropletActionsServiceOp) doActionByTag(ctx context.Context, tag string,
 		return nil, nil, err
 	}
 
-	root := new(actionRoot)
+	root := new(actionsRoot)
 	resp, err := s.client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return root.Event, resp, err
+	return root.Actions, resp, err
 }
 
 // Get an action for a particular Droplet by id.

--- a/droplet_actions_test.go
+++ b/droplet_actions_test.go
@@ -66,7 +66,7 @@ func TestDropletActions_ShutdownByTag(t *testing.T) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
 		}
 
-		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
+		fmt.Fprint(w, `{"actions": [{"status":"in-progress"},{"status":"in-progress"}]}`)
 	})
 
 	action, _, err := client.DropletActions.ShutdownByTag(ctx, "testing-1")
@@ -74,7 +74,7 @@ func TestDropletActions_ShutdownByTag(t *testing.T) {
 		t.Errorf("DropletActions.ShutdownByTag returned error: %v", err)
 	}
 
-	expected := &Action{Status: "in-progress"}
+	expected := []Action{{Status: "in-progress"}, {Status: "in-progress"}}
 	if !reflect.DeepEqual(action, expected) {
 		t.Errorf("DropletActions.ShutdownByTag returned %+v, expected %+v", action, expected)
 	}
@@ -138,7 +138,7 @@ func TestDropletAction_PowerOffByTag(t *testing.T) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
 		}
 
-		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
+		fmt.Fprint(w, `{"actions": [{"status":"in-progress"},{"status":"in-progress"}]}`)
 	})
 
 	action, _, err := client.DropletActions.PowerOffByTag(ctx, "testing-1")
@@ -146,7 +146,7 @@ func TestDropletAction_PowerOffByTag(t *testing.T) {
 		t.Errorf("DropletActions.PowerOffByTag returned error: %v", err)
 	}
 
-	expected := &Action{Status: "in-progress"}
+	expected := []Action{{Status: "in-progress"}, {Status: "in-progress"}}
 	if !reflect.DeepEqual(action, expected) {
 		t.Errorf("DropletActions.PoweroffByTag returned %+v, expected %+v", action, expected)
 	}
@@ -210,7 +210,7 @@ func TestDropletAction_PowerOnByTag(t *testing.T) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
 		}
 
-		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
+		fmt.Fprint(w, `{"actions": [{"status":"in-progress"},{"status":"in-progress"}]}`)
 	})
 
 	action, _, err := client.DropletActions.PowerOnByTag(ctx, "testing-1")
@@ -218,7 +218,7 @@ func TestDropletAction_PowerOnByTag(t *testing.T) {
 		t.Errorf("DropletActions.PowerOnByTag returned error: %v", err)
 	}
 
-	expected := &Action{Status: "in-progress"}
+	expected := []Action{{Status: "in-progress"}, {Status: "in-progress"}}
 	if !reflect.DeepEqual(action, expected) {
 		t.Errorf("DropletActions.PowerOnByTag returned %+v, expected %+v", action, expected)
 	}
@@ -428,8 +428,7 @@ func TestDropletAction_PowerCycleByTag(t *testing.T) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
 		}
 
-		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
-
+		fmt.Fprint(w, `{"actions": [{"status":"in-progress"},{"status":"in-progress"}]}`)
 	})
 
 	action, _, err := client.DropletActions.PowerCycleByTag(ctx, "testing-1")
@@ -437,7 +436,7 @@ func TestDropletAction_PowerCycleByTag(t *testing.T) {
 		t.Errorf("DropletActions.PowerCycleByTag returned error: %v", err)
 	}
 
-	expected := &Action{Status: "in-progress"}
+	expected := []Action{{Status: "in-progress"}, {Status: "in-progress"}}
 	if !reflect.DeepEqual(action, expected) {
 		t.Errorf("DropletActions.PowerCycleByTag returned %+v, expected %+v", action, expected)
 	}
@@ -505,7 +504,7 @@ func TestDropletAction_SnapshotByTag(t *testing.T) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
 		}
 
-		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
+		fmt.Fprint(w, `{"actions": [{"status":"in-progress"},{"status":"in-progress"}]}`)
 	})
 
 	action, _, err := client.DropletActions.SnapshotByTag(ctx, "testing-1", "Image-Name")
@@ -513,7 +512,7 @@ func TestDropletAction_SnapshotByTag(t *testing.T) {
 		t.Errorf("DropletActions.SnapshotByTag returned error: %v", err)
 	}
 
-	expected := &Action{Status: "in-progress"}
+	expected := []Action{{Status: "in-progress"}, {Status: "in-progress"}}
 	if !reflect.DeepEqual(action, expected) {
 		t.Errorf("DropletActions.SnapshotByTag returned %+v, expected %+v", action, expected)
 	}
@@ -579,7 +578,7 @@ func TestDropletAction_EnableBackupsByTag(t *testing.T) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
 		}
 
-		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
+		fmt.Fprint(w, `{"actions": [{"status":"in-progress"},{"status":"in-progress"}]}`)
 	})
 
 	action, _, err := client.DropletActions.EnableBackupsByTag(ctx, "testing-1")
@@ -587,7 +586,7 @@ func TestDropletAction_EnableBackupsByTag(t *testing.T) {
 		t.Errorf("DropletActions.EnableBackupsByTag returned error: %v", err)
 	}
 
-	expected := &Action{Status: "in-progress"}
+	expected := []Action{{Status: "in-progress"}, {Status: "in-progress"}}
 	if !reflect.DeepEqual(action, expected) {
 		t.Errorf("DropletActions.EnableBackupsByTag returned %+v, expected %+v", action, expected)
 	}
@@ -653,7 +652,7 @@ func TestDropletAction_DisableBackupsByTag(t *testing.T) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
 		}
 
-		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
+		fmt.Fprint(w, `{"actions": [{"status":"in-progress"},{"status":"in-progress"}]}`)
 	})
 
 	action, _, err := client.DropletActions.DisableBackupsByTag(ctx, "testing-1")
@@ -661,7 +660,7 @@ func TestDropletAction_DisableBackupsByTag(t *testing.T) {
 		t.Errorf("DropletActions.DisableBackupsByTag returned error: %v", err)
 	}
 
-	expected := &Action{Status: "in-progress"}
+	expected := []Action{{Status: "in-progress"}, {Status: "in-progress"}}
 	if !reflect.DeepEqual(action, expected) {
 		t.Errorf("DropletActions.DisableBackupsByTag returned %+v, expected %+v", action, expected)
 	}
@@ -870,7 +869,7 @@ func TestDropletAction_EnableIPv6ByTag(t *testing.T) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
 		}
 
-		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
+		fmt.Fprint(w, `{"actions": [{"status":"in-progress"},{"status":"in-progress"}]}`)
 	})
 
 	action, _, err := client.DropletActions.EnableIPv6ByTag(ctx, "testing-1")
@@ -878,7 +877,7 @@ func TestDropletAction_EnableIPv6ByTag(t *testing.T) {
 		t.Errorf("DropletActions.EnableIPv6ByTag returned error: %v", err)
 	}
 
-	expected := &Action{Status: "in-progress"}
+	expected := []Action{{Status: "in-progress"}, {Status: "in-progress"}}
 	if !reflect.DeepEqual(action, expected) {
 		t.Errorf("DropletActions.EnableIPv6byTag returned %+v, expected %+v", action, expected)
 	}
@@ -944,7 +943,7 @@ func TestDropletAction_EnablePrivateNetworkingByTag(t *testing.T) {
 			t.Errorf("Request body = %+v, expected %+v", v, request)
 		}
 
-		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
+		fmt.Fprint(w, `{"actions": [{"status":"in-progress"},{"status":"in-progress"}]}`)
 	})
 
 	action, _, err := client.DropletActions.EnablePrivateNetworkingByTag(ctx, "testing-1")
@@ -952,7 +951,7 @@ func TestDropletAction_EnablePrivateNetworkingByTag(t *testing.T) {
 		t.Errorf("DropletActions.EnablePrivateNetworkingByTag returned error: %v", err)
 	}
 
-	expected := &Action{Status: "in-progress"}
+	expected := []Action{{Status: "in-progress"}, {Status: "in-progress"}}
 	if !reflect.DeepEqual(action, expected) {
 		t.Errorf("DropletActions.EnablePrivateNetworkingByTag returned %+v, expected %+v", action, expected)
 	}


### PR DESCRIPTION
This PR fixes bug with Droplet Actions on tagged resources.

Current version of `godo` returns pointer on Action for actions on tagged resources, however, [API returns array of actions](https://developers.digitalocean.com/documentation/v2/#acting-on-tagged-droplets). This results in bug where `godo` returns nil pointer instead of array of actions.

/cc @mauricio @aybabtme @andrewsomething 