### PR TITLE
Remove references to deprecated oauth2.NoContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ func (t *TokenSource) Token() (*oauth2.Token, error) {
 tokenSource := &TokenSource{
     AccessToken: pat,
 }
-oauthClient := oauth2.NewClient(oauth2.NoContext, tokenSource)
+oauthClient := oauth2.NewClient(context.Background(), tokenSource)
 client := godo.NewClient(oauthClient)
 ```
 

--- a/util/droplet_test.go
+++ b/util/droplet_test.go
@@ -13,14 +13,15 @@ func ExampleWaitForActive() {
 	token := &oauth2.Token{AccessToken: pat}
 	t := oauth2.StaticTokenSource(token)
 
-	oauthClient := oauth2.NewClient(oauth2.NoContext, t)
+	ctx := context.TODO()
+	oauthClient := oauth2.NewClient(ctx, t)
 	client := godo.NewClient(oauthClient)
 
 	// create your droplet and retrieve the create action uri
 	uri := "https://api.digitalocean.com/v2/actions/xxxxxxxx"
 
 	// block until until the action is complete
-	err := WaitForActive(context.TODO(), client, uri)
+	err := WaitForActive(ctx, client, uri)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
The oauth2.NoContext variable was deprecated in
golang/oauth2@c10ba270aa0bf8b8c1c986e103859c67a9103061.