### PR TITLE
Add AsRequest method on LoadBalancer

### DIFF
--- a/load_balancers.go
+++ b/load_balancers.go
@@ -48,6 +48,32 @@ func (l LoadBalancer) String() string {
 	return Stringify(l)
 }
 
+// AsRequest creates a LoadBalancerRequest that can be submitted to Update with the current values of the LoadBalancer.
+// Modifying the returned LoadBalancerRequest will not modify the original LoadBalancer.
+func (l LoadBalancer) AsRequest() *LoadBalancerRequest {
+	r := LoadBalancerRequest{
+		Name:                l.Name,
+		Algorithm:           l.Algorithm,
+		ForwardingRules:     append([]ForwardingRule(nil), l.ForwardingRules...),
+		DropletIDs:          append([]int(nil), l.DropletIDs...),
+		Tag:                 l.Tag,
+		RedirectHttpToHttps: l.RedirectHttpToHttps,
+		HealthCheck:         l.HealthCheck,
+	}
+	if l.HealthCheck != nil {
+		r.HealthCheck = &HealthCheck{}
+		*r.HealthCheck = *l.HealthCheck
+	}
+	if l.StickySessions != nil {
+		r.StickySessions = &StickySessions{}
+		*r.StickySessions = *l.StickySessions
+	}
+	if l.Region != nil {
+		r.Region = l.Region.Slug
+	}
+	return &r
+}
+
 // ForwardingRule represents load balancer forwarding rules.
 type ForwardingRule struct {
 	EntryProtocol  string `json:"entry_protocol,omitempty"`


### PR DESCRIPTION
Updating a LoadBalancer requires a LoadBalancerRequest, which is not
easily creatable from a LoadBalancer.

Serializing the LoadBalancer to JSON and then deserializing it to a
LoadBalancerRequest mostly works, except that Region is a string on
the Request but not on the LB (since the LB returns the entire
Region object), so json.Unmarshal returns an error.

An explicit AsRequest method makes it easier for consumers of the API
to modify existing LoadBalancer objects, and is designed to avoid
modifying attributes on the original LoadBalancer when the
LoadBalancerRequest is modified.