### PR TITLE
Follow User-Agent header field recommendations

### DIFF
--- a/godo.go
+++ b/godo.go
@@ -210,7 +210,7 @@ func SetBaseURL(bu string) ClientOpt {
 // SetUserAgent is a client option for setting the user agent.
 func SetUserAgent(ua string) ClientOpt {
 	return func(c *Client) error {
-		c.UserAgent = fmt.Sprintf("%s+%s", ua, c.UserAgent)
+		c.UserAgent = fmt.Sprintf("%s %s", ua, c.UserAgent)
 		return nil
 	}
 }

--- a/godo_test.go
+++ b/godo_test.go
@@ -106,7 +106,7 @@ func testClientDefaultBaseURL(t *testing.T, c *Client) {
 
 func testClientDefaultUserAgent(t *testing.T, c *Client) {
 	if c.UserAgent != userAgent {
-		t.Errorf("NewClick UserAgent = %v, expected %v", c.UserAgent, userAgent)
+		t.Errorf("NewClient UserAgent = %v, expected %v", c.UserAgent, userAgent)
 	}
 }
 
@@ -193,7 +193,7 @@ func TestNewRequest_badURL(t *testing.T) {
 }
 
 func TestNewRequest_withCustomUserAgent(t *testing.T) {
-	ua := "testing"
+	ua := "testing/0.0.1"
 	c, err := New(nil, SetUserAgent(ua))
 
 	if err != nil {
@@ -202,7 +202,7 @@ func TestNewRequest_withCustomUserAgent(t *testing.T) {
 
 	req, _ := c.NewRequest(ctx, http.MethodGet, "/foo", nil)
 
-	expected := fmt.Sprintf("%s+%s", ua, userAgent)
+	expected := fmt.Sprintf("%s %s", ua, userAgent)
 	if got := req.Header.Get("User-Agent"); got != expected {
 		t.Errorf("New() UserAgent = %s; expected %s", got, expected)
 	}
@@ -506,13 +506,14 @@ func TestAddOptions(t *testing.T) {
 }
 
 func TestCustomUserAgent(t *testing.T) {
-	c, err := New(nil, SetUserAgent("testing"))
+	ua := "testing/0.0.1"
+	c, err := New(nil, SetUserAgent(ua))
 
 	if err != nil {
 		t.Fatalf("New() unexpected error: %v", err)
 	}
 
-	expected := fmt.Sprintf("%s+%s", "testing", userAgent)
+	expected := fmt.Sprintf("%s %s", ua, userAgent)
 	if got := c.UserAgent; got != expected {
 		t.Errorf("New() UserAgent = %s; expected %s", got, expected)
 	}


### PR DESCRIPTION
Per [RFC 7231#5.5.3](https://tools.ietf.org/html/rfc7231#section-5.5.3), it seems to me that we should be preferring this formatting over what we currently have.

I plan to make use of this functionality over at the [terraform-provider-digitalocean#43](https://github.com/terraform-providers/terraform-provider-digitalocean/pull/43) to report the current Terraform version (and distinguish it from other API clients), and so I thought it'd be useful to improve the formatting slightly.