### PR TITLE
docs: replace first example with fully-runnable example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,25 +27,37 @@ at the DigitalOcean Control Panel [Applications Page](https://cloud.digitalocean
 You can then use your token to create a new client:
 
 ```go
-import "golang.org/x/oauth2"
+package main
 
-pat := "mytoken"
+import (
+	"github.com/digitalocean/godo"
+	"github.com/digitalocean/godo/context"
+	"golang.org/x/oauth2"
+)
+
+const (
+    pat = "mytoken"
+)
+
 type TokenSource struct {
-    AccessToken string
+	AccessToken string
 }
 
 func (t *TokenSource) Token() (*oauth2.Token, error) {
-    token := &oauth2.Token{
-        AccessToken: t.AccessToken,
-    }
-    return token, nil
+	token := &oauth2.Token{
+		AccessToken: t.AccessToken,
+	}
+	return token, nil
 }
 
-tokenSource := &TokenSource{
-    AccessToken: pat,
+func main() {
+	tokenSource := &TokenSource{
+		AccessToken: pat,
+	}
+
+	oauthClient := oauth2.NewClient(context.Background(), tokenSource)
+	client := godo.NewClient(oauthClient)
 }
-oauthClient := oauth2.NewClient(context.Background(), tokenSource)
-client := godo.NewClient(oauthClient)
 ```
 
 ## Examples


### PR DESCRIPTION
This PR replaces current authentication example for a better one, fully-runnable one. Personally, I prefer to have a sort of boilerplate code in the README, which I can easily copy and run without additional changes.

/cc @mauricio 