### PR TITLE
Handle non-json errors from the API

### DIFF
--- a/godo.go
+++ b/godo.go
@@ -356,7 +356,7 @@ func CheckResponse(r *http.Response) error {
 	if err == nil && len(data) > 0 {
 		err := json.Unmarshal(data, errorResponse)
 		if err != nil {
-			return err
+			errorResponse.Message = string(data)
 		}
 	}
 


### PR DESCRIPTION
When the DigitalOcean API sometimes returns a non-JSON error message, godo propagates it as a mysterious error "invalid character '<' looking for beginning of value", which really stems from the failure to parse the API error as JSON. See #142.

This PR attempts to rectify the issue by propagating the original error message instead if it's not parseable as JSON.