### PR TITLE
Allow creating domain records with a priority of 0.

### DIFF
--- a/domains.go
+++ b/domains.go
@@ -73,7 +73,7 @@ type DomainRecord struct {
 	Type     string `json:"type,omitempty"`
 	Name     string `json:"name,omitempty"`
 	Data     string `json:"data,omitempty"`
-	Priority int    `json:"priority,omitempty"`
+	Priority int    `json:"priority"`
 	Port     int    `json:"port,omitempty"`
 	TTL      int    `json:"ttl,omitempty"`
 	Weight   int    `json:"weight,omitempty"`
@@ -86,7 +86,7 @@ type DomainRecordEditRequest struct {
 	Type     string `json:"type,omitempty"`
 	Name     string `json:"name,omitempty"`
 	Data     string `json:"data,omitempty"`
-	Priority int    `json:"priority,omitempty"`
+	Priority int    `json:"priority"`
 	Port     int    `json:"port,omitempty"`
 	TTL      int    `json:"ttl,omitempty"`
 	Weight   int    `json:"weight,omitempty"`


### PR DESCRIPTION
Creating an MX record with the priority set to `0` currently does not work as the value is lost when marshalling to JSON. This PR removes `omitempty` in order to retain that value.

```
$ doctl compute domain records create "foo.net" --record-type "MX" --record-name "@" --record-data "relay.foo.net." --record-priority "0" --trace
doctl: 2018/04/26 17:18:33 -> "POST /v2/domains/foo.net/records HTTP/1.1\r\nHost: api.digitalocean.com\r\nUser-Agent: doctl/1.0.0-dev+godo/1.1.0\r\nContent-Length: 60\r\nAccept: application/json\r\nContent-Type: application/json\r\nAccept-Encoding: gzip\r\n\r\n{\"type\":\"MX\",\"name\":\"@\",\"data\":\"relay.foo.net.\",\"ttl\":1800}\n"
doctl: 2018/04/26 17:18:33 <- "HTTP/2.0 422 Unprocessable Entity\r\nContent-Length: 118\r\nCache-Control: no-cache\r\nCf-Ray: 411c15219a039248-EWR\r\nContent-Type: application/json; charset=utf-8\r\nDate: Thu, 26 Apr 2018 21:18:33 GMT\r\nExpect-Ct: max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"\r\nRatelimit-Limit: 5000\r\nRatelimit-Remaining: 4971\r\nRatelimit-Reset: 1524773965\r\nServer: cloudflare\r\nSet-Cookie: __cfduid=d162db82d3ddf3120aac9124eff5ef2231524777513; expires=Fri, 26-Apr-19 21:18:33 GMT; path=/; domain=.digitalocean.com; HttpOnly\r\nX-Content-Type-Options: nosniff\r\nX-Frame-Options: SAMEORIGIN\r\nX-Gateway: Edge-Gateway\r\nX-Request-Id: 2a9ae4be-4c48-4ca6-8ad8-0d18eead9b3b\r\nX-Response-From: service\r\nX-Runtime: 0.226053\r\nX-Xss-Protection: 1; mode=block\r\n\r\n{\"id\":\"unprocessable_entity\",\"message\":\"Priority is not a number and Priority must be an integer between 0 and 65535\"}"

[snipping usage]

Error: POST https://api.digitalocean.com/v2/domains/foo.net/records: 422 Priority is not a number and Priority must be an integer between 0 and 65535
```

This comes from an internal report.
