### PR TITLE
Remove upgrade droplet action (deprecated)

### DIFF
--- a/droplet_actions.go
+++ b/droplet_actions.go
@@ -40,7 +40,6 @@ type DropletActionsService interface {
 	EnableIPv6ByTag(context.Context, string) ([]Action, *Response, error)
 	EnablePrivateNetworking(context.Context, int) (*Action, *Response, error)
 	EnablePrivateNetworkingByTag(context.Context, string) ([]Action, *Response, error)
-	Upgrade(context.Context, int) (*Action, *Response, error)
 	Get(context.Context, int, int) (*Action, *Response, error)
 	GetByURI(context.Context, string) (*Action, *Response, error)
 }
@@ -228,12 +227,6 @@ func (s *DropletActionsServiceOp) EnablePrivateNetworking(ctx context.Context, i
 func (s *DropletActionsServiceOp) EnablePrivateNetworkingByTag(ctx context.Context, tag string) ([]Action, *Response, error) {
 	request := &ActionRequest{"type": "enable_private_networking"}
 	return s.doActionByTag(ctx, tag, request)
-}
-
-// Upgrade a Droplet.
-func (s *DropletActionsServiceOp) Upgrade(ctx context.Context, id int) (*Action, *Response, error) {
-	request := &ActionRequest{"type": "upgrade"}
-	return s.doAction(ctx, id, request)
 }
 
 func (s *DropletActionsServiceOp) doAction(ctx context.Context, id int, request *ActionRequest) (*Action, *Response, error) {

--- a/droplet_actions_test.go
+++ b/droplet_actions_test.go
@@ -957,41 +957,6 @@ func TestDropletAction_EnablePrivateNetworkingByTag(t *testing.T) {
 	}
 }
 
-func TestDropletAction_Upgrade(t *testing.T) {
-	setup()
-	defer teardown()
-
-	request := &ActionRequest{
-		"type": "upgrade",
-	}
-
-	mux.HandleFunc("/v2/droplets/1/actions", func(w http.ResponseWriter, r *http.Request) {
-		v := new(ActionRequest)
-		err := json.NewDecoder(r.Body).Decode(v)
-		if err != nil {
-			t.Fatalf("decode json: %v", err)
-		}
-
-		testMethod(t, r, http.MethodPost)
-
-		if !reflect.DeepEqual(v, request) {
-			t.Errorf("Request body = %+v, expected %+v", v, request)
-		}
-
-		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
-	})
-
-	action, _, err := client.DropletActions.Upgrade(ctx, 1)
-	if err != nil {
-		t.Errorf("DropletActions.Upgrade returned error: %v", err)
-	}
-
-	expected := &Action{Status: "in-progress"}
-	if !reflect.DeepEqual(action, expected) {
-		t.Errorf("DropletActions.Upgrade returned %+v, expected %+v", action, expected)
-	}
-}
-
 func TestDropletActions_Get(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
Hi, the upgrade droplet action is no longer supported by the v2 API. (See the [droplet-actions endpoint in the docs](https://developers.digitalocean.com/documentation/v2/#droplet-actions))

Quick example script:

```go
package main

import (
  "github.com/digitalocean/godo"
  "github.com/digitalocean/godo/context"
  "golang.org/x/oauth2"
  "fmt"
)

const (
  pat = "AccessToken"
  doid = 12345
)

type TokenSource struct {
  AccessToken string
}

func (t *TokenSource) Token() (*oauth2.Token, error) {
  token := &oauth2.Token{
  AccessToken: t.AccessToken,
  }
  return token, nil
}

func main() {
  tokenSource := &TokenSource{
    AccessToken: pat,
  }

  oauthClient := oauth2.NewClient(context.Background(), tokenSource)
  client := godo.NewClient(oauthClient)

  action, _, err  := client.DropletActions.Upgrade(context.TODO(), doid)
  if err != nil {
    fmt.Print("Error: ", err)
  } else {
    fmt.Print("Action: ", action)
  }
}
```

This outputs:

```
Error: POST https://api.digitalocean.com/v2/droplets/12345/actions: 410 The specified action type is no longer available.
```

This PR removes the `Upgrade` method from the `DropletActionsService` and the associated test.

Let me know if it looks good or if there's anything else I need to do.