### PR TITLE
Allow creating domains without an IP address.

### DIFF
--- a/domains.go
+++ b/domains.go
@@ -52,7 +52,7 @@ type domainsRoot struct {
 // DomainCreateRequest respresents a request to create a domain.
 type DomainCreateRequest struct {
 	Name      string `json:"name"`
-	IPAddress string `json:"ip_address"`
+	IPAddress string `json:"ip_address,omitempty"`
 }
 
 // DomainRecordRoot is the root of an individual Domain Record response


### PR DESCRIPTION
We recently introduced a change to the Domains API. It now mirrors the control panel behavior. Domains can be created without needing an IP address (and the automatic A record that goes along with that).

Using godo to do so results in a `422 Data can't be blank` as the IP address attribute is still sent if blank. This PR adds `omitempty` to IPAddress in the `DomainCreateRequest` type.

See: https://developers.digitalocean.com/documentation/changelog/api-v2/create-domains-without-providing-an-ip-address/
