### PR TITLE
Allow creating domain records with a weight of 0

### DIFF
--- a/domains.go
+++ b/domains.go
@@ -75,7 +75,7 @@ type DomainRecord struct {
 	Priority int    `json:"priority"`
 	Port     int    `json:"port,omitempty"`
 	TTL      int    `json:"ttl,omitempty"`
-	Weight   int    `json:"weight,omitempty"`
+	Weight   int    `json:"weight"`
 	Flags    int    `json:"flags"`
 	Tag      string `json:"tag,omitempty"`
 }
@@ -88,7 +88,7 @@ type DomainRecordEditRequest struct {
 	Priority int    `json:"priority"`
 	Port     int    `json:"port,omitempty"`
 	TTL      int    `json:"ttl,omitempty"`
-	Weight   int    `json:"weight,omitempty"`
+	Weight   int    `json:"weight"`
 	Flags    int    `json:"flags"`
 	Tag      string `json:"tag,omitempty"`
 }


### PR DESCRIPTION
Creating an MX record with the weight set to 0 currently does not work as the value is omitted when marshalling to JSON.