### PR TITLE
Add support to tagging images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v1.5.0] - 2018-10-01
+
+- #179 Adding tagging images support - @hugocorbucci
+
 ## [v1.4.2] - 2018-08-30
 
 - #178 Allowing creating domain records with weight of 0 - @TFaga

--- a/godo.go
+++ b/godo.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.4.2"
+	libraryVersion = "1.5.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/tags.go
+++ b/tags.go
@@ -35,6 +35,8 @@ type ResourceType string
 const (
 	//DropletResourceType holds the string representing our ResourceType of Droplet.
 	DropletResourceType ResourceType = "droplet"
+	//ImageResourceType holds the string representing our ResourceType of Image.
+	ImageResourceType ResourceType = "image"
 )
 
 // Resource represent a single resource for associating/disassociating with tags
@@ -45,13 +47,23 @@ type Resource struct {
 
 // TaggedResources represent the set of resources a tag is attached to
 type TaggedResources struct {
-	Droplets *TaggedDropletsResources `json:"droplets,omitempty"`
+	Count         int                      `json:"count"`
+	LastTaggedURI string                   `json:"last_tagged_uri,omitempty"`
+	Droplets      *TaggedDropletsResources `json:"droplets,omitempty"`
+	Images        *TaggedImagesResources   `json:"images"`
 }
 
 // TaggedDropletsResources represent the droplet resources a tag is attached to
 type TaggedDropletsResources struct {
-	Count      int      `json:"count,float64,omitempty"`
-	LastTagged *Droplet `json:"last_tagged,omitempty"`
+	Count         int      `json:"count,float64,omitempty"`
+	LastTagged    *Droplet `json:"last_tagged,omitempty"`
+	LastTaggedURI string   `json:"last_tagged_uri,omitempty"`
+}
+
+// TaggedImagesResources represent the image resources a tag is attached to
+type TaggedImagesResources struct {
+	Count         int    `json:"count,float64,omitempty"`
+	LastTaggedURI string `json:"last_tagged_uri,omitempty"`
 }
 
 // Tag represent DigitalOcean tag

--- a/tags_test.go
+++ b/tags_test.go
@@ -25,18 +25,26 @@ var (
 		{
 			"name": "testing-1",
 			"resources": {
+				"count": 0,
 				"droplets": {
 					"count": 0,
 					"last_tagged": null
+				},
+				"images": {
+					"count": 0
 				}
 			}
 		},
 		{
 			"name": "testing-2",
 			"resources": {
+				"count": 0,
 				"droplets": {
 					"count": 0,
 					"last_tagged": null
+				},
+				"images": {
+					"count": 0
 				}
 			}
 		}
@@ -60,9 +68,13 @@ var (
 		"tag": {
 			"name": "testing-1",
 			"resources": {
+				"count": 0,
 				"droplets": {
 					"count": 0,
 					"last_tagged": null
+				},
+				"images": {
+					"count": 0
 				}
 			}
 		}
@@ -74,8 +86,11 @@ var (
 		"tag": {
 			"name": "testing-1",
 			"resources": {
+				"count": 2,
+				"last_tagged_uri": "https://api.digitalocean.com/v2/droplets/1",
 				"droplets": {
 					"count": 1,
+					"last_tagged_uri": "https://api.digitalocean.com/v2/droplets/1",
 					"last_tagged": {
 						"id": 1,
 						"name": "test.example.com",
@@ -157,6 +172,10 @@ var (
 						"tag-2"
 						]
 					}
+				},
+				"images": {
+					"count": 1,
+					"last_tagged_uri": "https://api.digitalocean.com/v2/images/1"
 				}
 			}
 		}
@@ -178,8 +197,8 @@ func TestTags_List(t *testing.T) {
 		t.Errorf("Tags.List returned error: %v", err)
 	}
 
-	expected := []Tag{{Name: "testing-1", Resources: &TaggedResources{Droplets: &TaggedDropletsResources{Count: 0, LastTagged: nil}}},
-		{Name: "testing-2", Resources: &TaggedResources{Droplets: &TaggedDropletsResources{Count: 0, LastTagged: nil}}}}
+	expected := []Tag{{Name: "testing-1", Resources: &TaggedResources{Count: 0, Droplets: &TaggedDropletsResources{Count: 0, LastTagged: nil}, Images: &TaggedImagesResources{Count: 0}}},
+		{Name: "testing-2", Resources: &TaggedResources{Count: 0, Droplets: &TaggedDropletsResources{Count: 0, LastTagged: nil}, Images: &TaggedImagesResources{Count: 0}}}}
 	if !reflect.DeepEqual(tags, expected) {
 		t.Errorf("Tags.List returned %+v, expected %+v", tags, expected)
 	}
@@ -239,12 +258,32 @@ func TestTags_Get(t *testing.T) {
 		t.Errorf("Tags.Get return an incorrect name, got %+v, expected %+v", tag.Name, "testing-1")
 	}
 
+	if tag.Resources.Count != 2 {
+		t.Errorf("Tags.Get return an incorrect resource count, got %+v, expected %+v", tag.Resources.Count, 2)
+	}
+
+	if tag.Resources.LastTaggedURI != "https://api.digitalocean.com/v2/droplets/1" {
+		t.Errorf("Tags.Get return an incorrect last tagged uri %+v, expected %+v", tag.Resources.LastTaggedURI, "https://api.digitalocean.com/v2/droplets/1")
+	}
+
 	if tag.Resources.Droplets.Count != 1 {
 		t.Errorf("Tags.Get return an incorrect droplet resource count, got %+v, expected %+v", tag.Resources.Droplets.Count, 1)
 	}
 
 	if tag.Resources.Droplets.LastTagged.ID != 1 {
 		t.Errorf("Tags.Get return an incorrect last tagged droplet %+v, expected %+v", tag.Resources.Droplets.LastTagged.ID, 1)
+	}
+
+	if tag.Resources.Droplets.LastTaggedURI != "https://api.digitalocean.com/v2/droplets/1" {
+		t.Errorf("Tags.Get return an incorrect last tagged droplet uri %+v, expected %+v", tag.Resources.Droplets.LastTaggedURI, "https://api.digitalocean.com/v2/droplets/1")
+	}
+
+	if tag.Resources.Images.Count != 1 {
+		t.Errorf("Tags.Get return an incorrect image resource count, got %+v, expected %+v", tag.Resources.Images.Count, 1)
+	}
+
+	if tag.Resources.Images.LastTaggedURI != "https://api.digitalocean.com/v2/images/1" {
+		t.Errorf("Tags.Get return an incorrect last tagged droplet uri %+v, expected %+v", tag.Resources.Images.LastTaggedURI, "https://api.digitalocean.com/v2/images/1")
 	}
 }
 
@@ -276,7 +315,7 @@ func TestTags_Create(t *testing.T) {
 		t.Errorf("Tags.Create returned error: %v", err)
 	}
 
-	expected := &Tag{Name: "testing-1", Resources: &TaggedResources{Droplets: &TaggedDropletsResources{Count: 0, LastTagged: nil}}}
+	expected := &Tag{Name: "testing-1", Resources: &TaggedResources{Count: 0, Droplets: &TaggedDropletsResources{Count: 0, LastTagged: nil}, Images: &TaggedImagesResources{Count: 0}}}
 	if !reflect.DeepEqual(tag, expected) {
 		t.Errorf("Tags.Create returned %+v, expected %+v", tag, expected)
 	}
@@ -301,7 +340,10 @@ func TestTags_TagResource(t *testing.T) {
 	defer teardown()
 
 	tagResourcesRequest := &TagResourcesRequest{
-		Resources: []Resource{{ID: "1", Type: DropletResourceType}},
+		Resources: []Resource{
+			{ID: "1", Type: DropletResourceType},
+			{ID: "1", Type: ImageResourceType},
+		},
 	}
 
 	mux.HandleFunc("/v2/tags/testing-1/resources", func(w http.ResponseWriter, r *http.Request) {
@@ -330,7 +372,10 @@ func TestTags_UntagResource(t *testing.T) {
 	defer teardown()
 
 	untagResourcesRequest := &UntagResourcesRequest{
-		Resources: []Resource{{ID: "1", Type: DropletResourceType}},
+		Resources: []Resource{
+			{ID: "1", Type: DropletResourceType},
+			{ID: "1", Type: ImageResourceType},
+		},
 	}
 
 	mux.HandleFunc("/v2/tags/testing-1/resources", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This adds support to some new results as well as the new ability to tag images described in https://developers.digitalocean.com/documentation/changelog/api-v2/adding-tagged-uri/ and https://developers.digitalocean.com/documentation/changelog/api-v2/support-for-custom-images-and-image-tagging/.
Similar to https://github.com/digitalocean/droplet_kit/pull/154.

Could you take a peek @mauricio and/or @jrm780 ?