### PR TITLE
k8s: add details of `options` call

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -173,13 +173,36 @@ type KubernetesNodeStatus struct {
 
 // KubernetesOptions represents options available for creating Kubernetes clusters.
 type KubernetesOptions struct {
-	Versions []*KubernetesVersion `json:"versions,omitempty"`
+	Versions []*KubernetesVersion  `json:"versions,omitempty"`
+	Regions  []*KubernetesRegion   `json:"regions,omitempty"`
+	Sizes    []*KubernetesNodeSize `json:"sizes,omitempty"`
+	Defaults *KubernetesDefaults   `json:"defaults,omitempty"`
 }
 
 // KubernetesVersion is a DigitalOcean Kubernetes release.
 type KubernetesVersion struct {
 	Slug              string `json:"slug,omitempty"`
 	KubernetesVersion string `json:"kubernetes_version,omitempty"`
+}
+
+// KubernetesNodeSize is a node sizes supported for Kubernetes clusters.
+type KubernetesNodeSize struct {
+	Name string `json:"name"`
+	Slug string `json:"slug"`
+}
+
+// KubernetesRegion is a region usable by Kubernetes clusters.
+type KubernetesRegion struct {
+	Name string `json:"name"`
+	Slug string `json:"slug"`
+}
+
+// KubernetesDefaults are sensible defaults for creating Kubernetes clusters.
+type KubernetesDefaults struct {
+	VersionSlug  string `json:"version_slug"`
+	NodeSizeSlug string `json:"node_size_slug"`
+	RegionSlug   string `json:"region_slug"`
+	NodeCount    int    `json:"node_count"`
 }
 
 type kubernetesClustersRoot struct {

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -747,6 +747,18 @@ func TestKubernetesVersions_List(t *testing.T) {
 		Versions: []*KubernetesVersion{
 			{Slug: "1.10.0-gen0", KubernetesVersion: "1.10.0"},
 		},
+		Regions: []*KubernetesRegion{
+			{Name: "New York 3", Slug: "nyc3"},
+		},
+		Sizes: []*KubernetesNodeSize{
+			{Name: "c-8", Slug: "c-8"},
+		},
+		Defaults: &KubernetesDefaults{
+			VersionSlug:  "1.10.0-gen0",
+			RegionSlug:   "nyc3",
+			NodeSizeSlug: "c-8",
+			NodeCount:    3,
+		},
 	}
 	jBlob := `
 {
@@ -756,7 +768,25 @@ func TestKubernetesVersions_List(t *testing.T) {
 				"slug": "1.10.0-gen0",
 				"kubernetes_version": "1.10.0"
 			}
-		]
+		],
+		"regions": [
+			{
+				"name": "New York 3",
+				"slug": "nyc3"
+			}
+		],
+		"sizes": [
+			{
+				"name": "c-8",
+				"slug": "c-8"
+			}
+		],
+		"defaults": {
+			"version_slug": "1.10.0-gen0",
+			"node_size_slug": "c-8",
+			"region_slug": "nyc3",
+			"node_count": 3
+		}
 	}
 }`
 


### PR DESCRIPTION
Maps the new fields on the API so we can use them in `doctl`.