### PR TITLE
k8saas: remove defaults from options

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -176,7 +176,6 @@ type KubernetesOptions struct {
 	Versions []*KubernetesVersion  `json:"versions,omitempty"`
 	Regions  []*KubernetesRegion   `json:"regions,omitempty"`
 	Sizes    []*KubernetesNodeSize `json:"sizes,omitempty"`
-	Defaults *KubernetesDefaults   `json:"defaults,omitempty"`
 }
 
 // KubernetesVersion is a DigitalOcean Kubernetes release.
@@ -195,14 +194,6 @@ type KubernetesNodeSize struct {
 type KubernetesRegion struct {
 	Name string `json:"name"`
 	Slug string `json:"slug"`
-}
-
-// KubernetesDefaults are sensible defaults for creating Kubernetes clusters.
-type KubernetesDefaults struct {
-	VersionSlug  string `json:"version_slug"`
-	NodeSizeSlug string `json:"node_size_slug"`
-	RegionSlug   string `json:"region_slug"`
-	NodeCount    int    `json:"node_count"`
 }
 
 type kubernetesClustersRoot struct {

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -753,12 +753,6 @@ func TestKubernetesVersions_List(t *testing.T) {
 		Sizes: []*KubernetesNodeSize{
 			{Name: "c-8", Slug: "c-8"},
 		},
-		Defaults: &KubernetesDefaults{
-			VersionSlug:  "1.10.0-gen0",
-			RegionSlug:   "nyc3",
-			NodeSizeSlug: "c-8",
-			NodeCount:    3,
-		},
 	}
 	jBlob := `
 {
@@ -780,13 +774,7 @@ func TestKubernetesVersions_List(t *testing.T) {
 				"name": "c-8",
 				"slug": "c-8"
 			}
-		],
-		"defaults": {
-			"version_slug": "1.10.0-gen0",
-			"node_size_slug": "c-8",
-			"region_slug": "nyc3",
-			"node_count": 3
-		}
+		]
 	}
 }`
 


### PR DESCRIPTION
Removing `defaults` while we revisit the response from the `/v2/kubernetes/options` endpoint.