### PR TITLE
Fix warnings in image.go

### DIFF
--- a/images.go
+++ b/images.go
@@ -58,7 +58,7 @@ type ImageUpdateRequest struct {
 // CustomImageCreateRequest represents a request to create a custom image.
 type CustomImageCreateRequest struct {
 	Name         string   `json:"name"`
-	Url          string   `json:"url"`
+	URL          string   `json:"url"`
 	Region       string   `json:"region"`
 	Distribution string   `json:"distribution,omitempty"`
 	Description  string   `json:"description,omitempty"`
@@ -131,6 +131,7 @@ func (s *ImagesServiceOp) GetBySlug(ctx context.Context, slug string) (*Image, *
 	return s.get(ctx, interface{}(slug))
 }
 
+// Create creates custom image.
 func (s *ImagesServiceOp) Create(ctx context.Context, createRequest *CustomImageCreateRequest) (*Image, *Response, error) {
 	if createRequest == nil {
 		return nil, nil, NewArgError("createRequest", "cannot be nil")

--- a/images_test.go
+++ b/images_test.go
@@ -223,7 +223,7 @@ func TestImages_Create(t *testing.T) {
 
 	createRequest := &CustomImageCreateRequest{
 		Name:         "my-new-image",
-		Url:          "http://example.com/distro-amd64.img",
+		URL:          "http://example.com/distro-amd64.img",
 		Region:       "nyc3",
 		Distribution: "Ubuntu",
 		Description:  "My new custom image",


### PR DESCRIPTION
- Fixed the following the warning.
```
$ golint ./... | grep "should be"
images.go:61:2: struct field Url should be URL
```

- Added a comment to `Create` method.