### PR TITLE
Fix return of Domains.EditRecord function (Fixes: #198).

### DIFF
--- a/domains.go
+++ b/domains.go
@@ -294,18 +294,18 @@ func (s *DomainsServiceOp) EditRecord(ctx context.Context,
 
 	path := fmt.Sprintf("%s/%s/records/%d", domainsBasePath, domain, id)
 
-	req, err := s.client.NewRequest(ctx, "PUT", path, editRequest)
+	req, err := s.client.NewRequest(ctx, http.MethodPut, path, editRequest)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	d := new(DomainRecord)
-	resp, err := s.client.Do(ctx, req, d)
+	root := new(domainRecordRoot)
+	resp, err := s.client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return d, resp, err
+	return root.DomainRecord, resp, err
 }
 
 // CreateRecord creates a record using a DomainRecordEditRequest

--- a/domains_test.go
+++ b/domains_test.go
@@ -291,12 +291,12 @@ func TestDomains_EditRecordForDomainName(t *testing.T) {
 			t.Fatalf("decode json: %v", err)
 		}
 
-		testMethod(t, r, "PUT")
+		testMethod(t, r, http.MethodPut)
 		if !reflect.DeepEqual(v, editRequest) {
 			t.Errorf("Request body = %+v, expected %+v", v, editRequest)
 		}
 
-		fmt.Fprintf(w, `{"id":1}`)
+		fmt.Fprintf(w, `{"domain_record": {"id":1, "type": "CNAME", "name": "example"}}`)
 	})
 
 	record, _, err := client.Domains.EditRecord(ctx, "example.com", 1, editRequest)
@@ -304,7 +304,7 @@ func TestDomains_EditRecordForDomainName(t *testing.T) {
 		t.Errorf("Domains.EditRecord returned error: %v", err)
 	}
 
-	expected := &DomainRecord{ID: 1}
+	expected := &DomainRecord{ID: 1, Type: "CNAME", Name: "example"}
 	if !reflect.DeepEqual(record, expected) {
 		t.Errorf("Domains.EditRecord returned %+v, expected %+v", record, expected)
 	}


### PR DESCRIPTION
This PR fixes the Domains.EditRecord function so that it correctly return the record's information. This was maskeds by a faulty test fixed here as well. Resolved #198 