### PR TITLE
allow tagging volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v1.7.4] - 2019-02-08
+
+- #202 Allow tagging volumes - @mchitten
+
 ## [v1.7.3] - 2018-12-18
 
 - #196 Expose tag support for creating Load Balancers.

--- a/godo.go
+++ b/godo.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.6.0"
+	libraryVersion = "1.7.4"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/tags.go
+++ b/tags.go
@@ -37,6 +37,8 @@ const (
 	DropletResourceType ResourceType = "droplet"
 	//ImageResourceType holds the string representing our ResourceType of Image.
 	ImageResourceType ResourceType = "image"
+	//VolumeResourceType holds the string representing our ResourceType of Volume.
+	VolumeResourceType ResourceType = "volume"
 )
 
 // Resource represent a single resource for associating/disassociating with tags
@@ -51,6 +53,7 @@ type TaggedResources struct {
 	LastTaggedURI string                   `json:"last_tagged_uri,omitempty"`
 	Droplets      *TaggedDropletsResources `json:"droplets,omitempty"`
 	Images        *TaggedImagesResources   `json:"images"`
+	Volumes       *TaggedVolumesResources  `json:"volumes"`
 }
 
 // TaggedDropletsResources represent the droplet resources a tag is attached to
@@ -60,11 +63,14 @@ type TaggedDropletsResources struct {
 	LastTaggedURI string   `json:"last_tagged_uri,omitempty"`
 }
 
-// TaggedImagesResources represent the image resources a tag is attached to
-type TaggedImagesResources struct {
+// TaggedResourcesData represent the image resources a tag is attached to
+type TaggedResourcesData struct {
 	Count         int    `json:"count,float64,omitempty"`
 	LastTaggedURI string `json:"last_tagged_uri,omitempty"`
 }
+
+type TaggedImagesResources TaggedResourcesData
+type TaggedVolumesResources TaggedResourcesData
 
 // Tag represent DigitalOcean tag
 type Tag struct {

--- a/tags_test.go
+++ b/tags_test.go
@@ -32,6 +32,9 @@ var (
 				},
 				"images": {
 					"count": 0
+				},
+				"volumes": {
+					"count": 0
 				}
 			}
 		},
@@ -44,6 +47,9 @@ var (
 					"last_tagged": null
 				},
 				"images": {
+					"count": 0
+				},
+				"volumes": {
 					"count": 0
 				}
 			}
@@ -74,6 +80,9 @@ var (
 					"last_tagged": null
 				},
 				"images": {
+					"count": 0
+				},
+				"volumes": {
 					"count": 0
 				}
 			}
@@ -176,6 +185,10 @@ var (
 				"images": {
 					"count": 1,
 					"last_tagged_uri": "https://api.digitalocean.com/v2/images/1"
+				},
+				"volumes": {
+					"count": 1,
+					"last_tagged_uri": "https://api.digitalocean.com/v2/volumes/abc"
 				}
 			}
 		}
@@ -197,8 +210,10 @@ func TestTags_List(t *testing.T) {
 		t.Errorf("Tags.List returned error: %v", err)
 	}
 
-	expected := []Tag{{Name: "testing-1", Resources: &TaggedResources{Count: 0, Droplets: &TaggedDropletsResources{Count: 0, LastTagged: nil}, Images: &TaggedImagesResources{Count: 0}}},
-		{Name: "testing-2", Resources: &TaggedResources{Count: 0, Droplets: &TaggedDropletsResources{Count: 0, LastTagged: nil}, Images: &TaggedImagesResources{Count: 0}}}}
+	expected := []Tag{
+		{Name: "testing-1", Resources: &TaggedResources{Count: 0, Droplets: &TaggedDropletsResources{Count: 0, LastTagged: nil}, Images: &TaggedImagesResources{Count: 0}, Volumes: &TaggedVolumesResources{Count: 0}}},
+		{Name: "testing-2", Resources: &TaggedResources{Count: 0, Droplets: &TaggedDropletsResources{Count: 0, LastTagged: nil}, Images: &TaggedImagesResources{Count: 0}, Volumes: &TaggedVolumesResources{Count: 0}}},
+	}
 	if !reflect.DeepEqual(tags, expected) {
 		t.Errorf("Tags.List returned %+v, expected %+v", tags, expected)
 	}
@@ -315,7 +330,15 @@ func TestTags_Create(t *testing.T) {
 		t.Errorf("Tags.Create returned error: %v", err)
 	}
 
-	expected := &Tag{Name: "testing-1", Resources: &TaggedResources{Count: 0, Droplets: &TaggedDropletsResources{Count: 0, LastTagged: nil}, Images: &TaggedImagesResources{Count: 0}}}
+	expected := &Tag{
+		Name: "testing-1",
+		Resources: &TaggedResources{
+			Count:    0,
+			Droplets: &TaggedDropletsResources{Count: 0, LastTagged: nil},
+			Images:   &TaggedImagesResources{Count: 0},
+			Volumes:  &TaggedVolumesResources{Count: 0},
+		},
+	}
 	if !reflect.DeepEqual(tag, expected) {
 		t.Errorf("Tags.Create returned %+v, expected %+v", tag, expected)
 	}


### PR DESCRIPTION
this allows the tagging of volumes via godo. Tagging volumes via the tags endpoints was introduced [on Feb 5](https://developers.digitalocean.com/documentation/changelog/api-v2/add-volume-tagging/). See [the tags documentation](https://developers.digitalocean.com/documentation/v2/#tags) for more details.