### PR TITLE
Add resource type for load-balancers.

### DIFF
--- a/tags.go
+++ b/tags.go
@@ -39,6 +39,8 @@ const (
 	ImageResourceType ResourceType = "image"
 	//VolumeResourceType holds the string representing our ResourceType of Volume.
 	VolumeResourceType ResourceType = "volume"
+	//LoadBalancerResourceType holds the string representing our ResourceType of LoadBalancer.
+	LoadBalancerResourceType ResourceType = "load_balancer"
 )
 
 // Resource represent a single resource for associating/disassociating with tags
@@ -63,13 +65,16 @@ type TaggedDropletsResources struct {
 	LastTaggedURI string   `json:"last_tagged_uri,omitempty"`
 }
 
-// TaggedResourcesData represent the image resources a tag is attached to
+// TaggedResourcesData represent the generic resources a tag is attached to
 type TaggedResourcesData struct {
 	Count         int    `json:"count,float64,omitempty"`
 	LastTaggedURI string `json:"last_tagged_uri,omitempty"`
 }
 
+// TaggedImagesResources represent the image resources a tag is attached to
 type TaggedImagesResources TaggedResourcesData
+
+// TaggedVolumesResources represent the volume resources a tag is attached to
 type TaggedVolumesResources TaggedResourcesData
 
 // Tag represent DigitalOcean tag


### PR DESCRIPTION
Dedicated tagged resources were not added because the API does not expose any LB-related information yet.

Also added some missing GoDocs as a drive-by improvement.