### PR TITLE
fix database pool json field and update patch version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v1.10.1] - 2019-03-27
+
+- #219 Fix Database Pools json field - @sunny-b
+
 ## [v1.10.0] - 2019-03-20
 
 - #215 Add support for Databases - @mikejholly

--- a/databases.go
+++ b/databases.go
@@ -165,7 +165,7 @@ type DatabasePool struct {
 	User       string              `json:"user"`
 	Name       string              `json:"name"`
 	Size       int                 `json:"size"`
-	Database   string              `json:"database"`
+	Database   string              `json:"db"`
 	Mode       string              `json:"mode"`
 	Connection *DatabaseConnection `json:"connection"`
 }

--- a/databases_test.go
+++ b/databases_test.go
@@ -614,7 +614,7 @@ func TestDatabases_ListPools(t *testing.T) {
     "user": "user",
     "size": 10,
     "mode": "transaction",
-    "database": "db",
+    "db": "db",
     "connection": {
       "uri": "postgresql://user:pass@host.com/db",
       "host": "host.com",
@@ -669,7 +669,7 @@ func TestDatabases_CreatePool(t *testing.T) {
     "user": "user",
     "size": 10,
     "mode": "transaction",
-    "database": "db",
+    "db": "db",
     "connection": {
       "uri": "postgresql://user:pass@host.com/db",
       "host": "host.com",
@@ -732,7 +732,7 @@ func TestDatabases_GetPool(t *testing.T) {
     "user": "user",
     "size": 10,
     "mode": "transaction",
-    "database": "db",
+    "db": "db",
     "connection": {
       "uri": "postgresql://user:pass@host.com/db",
       "host": "host.com",

--- a/godo.go
+++ b/godo.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.10.0"
+	libraryVersion = "1.10.1"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"


### PR DESCRIPTION
I noticed that the `database` field was coming in empty while working on the integration into `doctl` and I believe the reason to be because the json field is mislabeled so the database name isn't getting UnMarshaled.

Here is a typical DO API response to show that the field is labeled `db`:

<img width="189" alt="image" src="https://user-images.githubusercontent.com/17665837/55087812-0f58ec80-5081-11e9-8bad-8f02c73c82aa.png">

