### PR TITLE
fix create database pool json fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v1.11.1] - 2019-04-04
+
+- #222 Fix Create Database Pools json fields - @sunny-b
+
 ## [v1.11.0] - 2019-04-03
 
 - #220 roll out vpc functionality - @jheimann

--- a/databases.go
+++ b/databases.go
@@ -172,7 +172,11 @@ type DatabasePool struct {
 
 // DatabaseCreatePoolRequest is used to create a new database connection pool
 type DatabaseCreatePoolRequest struct {
-	Pool *DatabasePool `json:"pool"`
+	User     string `json:"user"`
+	Name     string `json:"name"`
+	Size     int    `json:"size"`
+	Database string `json:"db"`
+	Mode     string `json:"mode"`
 }
 
 // DatabaseCreateUserRequest is used to create a new database user

--- a/databases_test.go
+++ b/databases_test.go
@@ -690,13 +690,11 @@ func TestDatabases_CreatePool(t *testing.T) {
 	})
 
 	got, _, err := client.Databases.CreatePool(ctx, dbID, &DatabaseCreatePoolRequest{
-		Pool: &DatabasePool{
-			Name:     "pool",
-			Database: "db",
-			Size:     10,
-			User:     "foo",
-			Mode:     "transaction",
-		},
+		Name:     "pool",
+		Database: "db",
+		Size:     10,
+		User:     "foo",
+		Mode:     "transaction",
 	})
 	require.NoError(t, err)
 	require.Equal(t, want, got)

--- a/godo.go
+++ b/godo.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.11.0"
+	libraryVersion = "1.11.1"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"


### PR DESCRIPTION
Currently, the json fields for the `CreateDatabasePoolRequest` don't match what the API expects and it's causing it to through 422 responses. This fixes the json fields to match what is expected.

https://developers.digitalocean.com/documentation/v2/#add-a-new-connection-pool

cc: @mikejholly 