### PR TITLE
kubernetes: Add support for upgrades

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -204,6 +204,7 @@ const (
 	KubernetesClusterStatusDegraded     = KubernetesClusterStatusState("degraded")
 	KubernetesClusterStatusError        = KubernetesClusterStatusState("error")
 	KubernetesClusterStatusDeleted      = KubernetesClusterStatusState("deleted")
+	KubernetesClusterStatusUpgrading    = KubernetesClusterStatusState("upgrading")
 	KubernetesClusterStatusInvalid      = KubernetesClusterStatusState("invalid")
 )
 
@@ -225,6 +226,8 @@ func (s *KubernetesClusterStatusState) UnmarshalText(text []byte) error {
 		*s = KubernetesClusterStatusError
 	case KubernetesClusterStatusDeleted:
 		*s = KubernetesClusterStatusDeleted
+	case KubernetesClusterStatusUpgrading:
+		*s = KubernetesClusterStatusUpgrading
 	case "", KubernetesClusterStatusInvalid:
 		*s = KubernetesClusterStatusInvalid
 	default:

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -56,6 +56,7 @@ type KubernetesClusterCreateRequest struct {
 	NodePools []*KubernetesNodePoolCreateRequest `json:"node_pools,omitempty"`
 
 	MaintenancePolicy *KubernetesMaintenancePolicy `json:"maintenance_policy"`
+	AutoUpgrade       bool                         `json:"auto_upgrade"`
 }
 
 // KubernetesClusterUpdateRequest represents a request to update a Kubernetes cluster.
@@ -63,6 +64,7 @@ type KubernetesClusterUpdateRequest struct {
 	Name              string                       `json:"name,omitempty"`
 	Tags              []string                     `json:"tags,omitempty"`
 	MaintenancePolicy *KubernetesMaintenancePolicy `json:"maintenance_policy"`
+	AutoUpgrade       bool                         `json:"auto_upgrade"`
 }
 
 // KubernetesNodePoolCreateRequest represents a request to create a node pool for a
@@ -104,6 +106,7 @@ type KubernetesCluster struct {
 	NodePools []*KubernetesNodePool `json:"node_pools,omitempty"`
 
 	MaintenancePolicy *KubernetesMaintenancePolicy `json:"maintenance_policy,omitempty"`
+	AutoUpgrade       bool                         `json:"auto_upgrade,omitempty"`
 
 	Status    *KubernetesClusterStatus `json:"status,omitempty"`
 	CreatedAt time.Time                `json:"created_at,omitempty"`


### PR DESCRIPTION
There are three changes in this PR, all in support of version upgrades for Kubernetes clusters:

1. Support the `upgrading` cluster status, which will be returned from the API when a cluster is in the process of being upgraded.
2. Support the `auto_upgrade` flag when fetching, creating, and updating clusters. When `auto_upgrade` is set to true for a cluster it will be automatically upgraded to new patch versions during its maintenance window.
3. Support fetching available upgrade versions from the `/v2/kubernetes/clusters/{cluster_id}/upgrades` endpoint and requesting an immediate upgrade via the `/v2/kubernetes/clustesr/{cluster_id}/upgrade` endpoint.