### PR TITLE
Add private connection fields to Databases

### DIFF
--- a/databases.go
+++ b/databases.go
@@ -68,19 +68,21 @@ var _ DatabasesService = &DatabasesServiceOp{}
 // "pg", "mysql" or "redis". A Database also includes connection information and other
 // properties of the service like region, size and current status.
 type Database struct {
-	ID                string                     `json:"id,omitempty"`
-	Name              string                     `json:"name,omitempty"`
-	EngineSlug        string                     `json:"engine,omitempty"`
-	VersionSlug       string                     `json:"version,omitempty"`
-	Connection        *DatabaseConnection        `json:"connection,omitempty"`
-	Users             []DatabaseUser             `json:"users,omitempty"`
-	NumNodes          int                        `json:"num_nodes,omitempty"`
-	SizeSlug          string                     `json:"size,omitempty"`
-	DBNames           []string                   `json:"db_names,omitempty"`
-	RegionSlug        string                     `json:"region,omitempty"`
-	Status            string                     `json:"status,omitempty"`
-	MaintenanceWindow *DatabaseMaintenanceWindow `json:"maintenance_window,omitempty"`
-	CreatedAt         time.Time                  `json:"created_at,omitempty"`
+	ID                 string                     `json:"id,omitempty"`
+	Name               string                     `json:"name,omitempty"`
+	EngineSlug         string                     `json:"engine,omitempty"`
+	VersionSlug        string                     `json:"version,omitempty"`
+	Connection         *DatabaseConnection        `json:"connection,omitempty"`
+	PrivateConnection  *DatabaseConnection        `json:"private_connection,omitempty"`
+	Users              []DatabaseUser             `json:"users,omitempty"`
+	NumNodes           int                        `json:"num_nodes,omitempty"`
+	SizeSlug           string                     `json:"size,omitempty"`
+	DBNames            []string                   `json:"db_names,omitempty"`
+	RegionSlug         string                     `json:"region,omitempty"`
+	Status             string                     `json:"status,omitempty"`
+	MaintenanceWindow  *DatabaseMaintenanceWindow `json:"maintenance_window,omitempty"`
+	CreatedAt          time.Time                  `json:"created_at,omitempty"`
+	PrivateNetworkUUID string                     `json:"private_network_uuid,omitempty"`
 }
 
 // DatabaseConnection represents a database connection
@@ -153,21 +155,24 @@ type DatabaseDB struct {
 
 // DatabaseReplica represents a read-only replica of a particular database
 type DatabaseReplica struct {
-	Name       string              `json:"name"`
-	Connection *DatabaseConnection `json:"connection"`
-	Region     string              `json:"region"`
-	Status     string              `json:"status"`
-	CreatedAt  time.Time           `json:"created_at"`
+	Name               string              `json:"name"`
+	Connection         *DatabaseConnection `json:"connection"`
+	PrivateConnection  *DatabaseConnection `json:"private_connection,omitempty"`
+	Region             string              `json:"region"`
+	Status             string              `json:"status"`
+	CreatedAt          time.Time           `json:"created_at"`
+	PrivateNetworkUUID string              `json:"private_network_uuid"`
 }
 
 // DatabasePool represents a database connection pool
 type DatabasePool struct {
-	User       string              `json:"user"`
-	Name       string              `json:"name"`
-	Size       int                 `json:"size"`
-	Database   string              `json:"db"`
-	Mode       string              `json:"mode"`
-	Connection *DatabaseConnection `json:"connection"`
+	User              string              `json:"user"`
+	Name              string              `json:"name"`
+	Size              int                 `json:"size"`
+	Database          string              `json:"db"`
+	Mode              string              `json:"mode"`
+	Connection        *DatabaseConnection `json:"connection"`
+	PrivateConnection *DatabaseConnection `json:"private_connection,omitempty"`
 }
 
 // DatabaseCreatePoolRequest is used to create a new database connection pool

--- a/databases.go
+++ b/databases.go
@@ -161,7 +161,7 @@ type DatabaseReplica struct {
 	Region             string              `json:"region"`
 	Status             string              `json:"status"`
 	CreatedAt          time.Time           `json:"created_at"`
-	PrivateNetworkUUID string              `json:"private_network_uuid"`
+	PrivateNetworkUUID string              `json:"private_network_uuid,omitempty"`
 }
 
 // DatabasePool represents a database connection pool

--- a/databases_test.go
+++ b/databases_test.go
@@ -102,7 +102,7 @@ var dbJSON = `
 		"description": null
 	},
 	"size": "db-s-2vcpu-4gb",
-    "private_network_uuid": "da4e0206-d019-41d7-b51f-deadbeefbb8f"
+	"private_network_uuid": "da4e0206-d019-41d7-b51f-deadbeefbb8f"
 }
 `
 
@@ -218,7 +218,7 @@ func TestDatabases_Create(t *testing.T) {
 			"password": "zt91mum075ofzyww",
 			"ssl": true
 		},
-        "private_connection": {
+		"private_connection": {
 			"uri": "postgres://doadmin:zt91mum075ofzyww@private-dbtest-do-user-3342561-0.db.ondigitalocean.com:25060/defaultdb?sslmode=require",
 			"database": "defaultdb",
 			"host": "dbtest-do-user-3342561-0.db.ondigitalocean.com",

--- a/databases_test.go
+++ b/databases_test.go
@@ -17,7 +17,16 @@ var db = Database{
 	VersionSlug: "11",
 	Connection: &DatabaseConnection{
 		URI:      "postgres://doadmin:zt91mum075ofzyww@dbtest-do-user-3342561-0.db.ondigitalocean.com:25060/defaultdb?sslmode=require",
-		Database: "",
+		Database: "defaultdb",
+		Host:     "dbtest-do-user-3342561-0.db.ondigitalocean.com",
+		Port:     25060,
+		User:     "doadmin",
+		Password: "zt91mum075ofzyww",
+		SSL:      true,
+	},
+	PrivateConnection: &DatabaseConnection{
+		URI:      "postgres://doadmin:zt91mum075ofzyww@private-dbtest-do-user-3342561-0.db.ondigitalocean.com:25060/defaultdb?sslmode=require",
+		Database: "defaultdb",
 		Host:     "dbtest-do-user-3342561-0.db.ondigitalocean.com",
 		Port:     25060,
 		User:     "doadmin",
@@ -44,7 +53,8 @@ var db = Database{
 		Pending:     false,
 		Description: nil,
 	},
-	SizeSlug: "db-s-2vcpu-4gb",
+	SizeSlug:           "db-s-2vcpu-4gb",
+	PrivateNetworkUUID: "da4e0206-d019-41d7-b51f-deadbeefbb8f",
 }
 
 var dbJSON = `
@@ -55,7 +65,16 @@ var dbJSON = `
 	"version": "11",
 	"connection": {
 		"uri": "postgres://doadmin:zt91mum075ofzyww@dbtest-do-user-3342561-0.db.ondigitalocean.com:25060/defaultdb?sslmode=require",
-		"database": "",
+		"database": "defaultdb",
+		"host": "dbtest-do-user-3342561-0.db.ondigitalocean.com",
+		"port": 25060,
+		"user": "doadmin",
+		"password": "zt91mum075ofzyww",
+		"ssl": true
+	},
+	"private_connection": {
+		"uri": "postgres://doadmin:zt91mum075ofzyww@private-dbtest-do-user-3342561-0.db.ondigitalocean.com:25060/defaultdb?sslmode=require",
+		"database": "defaultdb",
 		"host": "dbtest-do-user-3342561-0.db.ondigitalocean.com",
 		"port": 25060,
 		"user": "doadmin",
@@ -82,7 +101,8 @@ var dbJSON = `
 		"pending": false,
 		"description": null
 	},
-	"size": "db-s-2vcpu-4gb"
+	"size": "db-s-2vcpu-4gb",
+    "private_network_uuid": "da4e0206-d019-41d7-b51f-deadbeefbb8f"
 }
 `
 
@@ -147,7 +167,16 @@ func TestDatabases_Create(t *testing.T) {
 		VersionSlug: "10",
 		Connection: &DatabaseConnection{
 			URI:      "postgres://doadmin:zt91mum075ofzyww@dbtest-do-user-3342561-0.db.ondigitalocean.com:25060/defaultdb?sslmode=require",
-			Database: "",
+			Database: "defaultdb",
+			Host:     "dbtest-do-user-3342561-0.db.ondigitalocean.com",
+			Port:     25060,
+			User:     "doadmin",
+			Password: "zt91mum075ofzyww",
+			SSL:      true,
+		},
+		PrivateConnection: &DatabaseConnection{
+			URI:      "postgres://doadmin:zt91mum075ofzyww@private-dbtest-do-user-3342561-0.db.ondigitalocean.com:25060/defaultdb?sslmode=require",
+			Database: "defaultdb",
 			Host:     "dbtest-do-user-3342561-0.db.ondigitalocean.com",
 			Port:     25060,
 			User:     "doadmin",
@@ -182,7 +211,16 @@ func TestDatabases_Create(t *testing.T) {
 		"version": "10",
 		"connection": {
 			"uri": "postgres://doadmin:zt91mum075ofzyww@dbtest-do-user-3342561-0.db.ondigitalocean.com:25060/defaultdb?sslmode=require",
-			"database": "",
+			"database": "defaultdb",
+			"host": "dbtest-do-user-3342561-0.db.ondigitalocean.com",
+			"port": 25060,
+			"user": "doadmin",
+			"password": "zt91mum075ofzyww",
+			"ssl": true
+		},
+        "private_connection": {
+			"uri": "postgres://doadmin:zt91mum075ofzyww@private-dbtest-do-user-3342561-0.db.ondigitalocean.com:25060/defaultdb?sslmode=require",
+			"database": "defaultdb",
 			"host": "dbtest-do-user-3342561-0.db.ondigitalocean.com",
 			"port": 25060,
 			"user": "doadmin",
@@ -604,6 +642,15 @@ func TestDatabases_ListPools(t *testing.T) {
 				SSL:      true,
 				Database: "db",
 			},
+			PrivateConnection: &DatabaseConnection{
+				URI:      "postgresql://user:pass@private-host.com/db",
+				Host:     "private-host.com",
+				Port:     1234,
+				User:     "user",
+				Password: "pass",
+				SSL:      true,
+				Database: "db",
+			},
 		},
 	}
 
@@ -618,6 +665,15 @@ func TestDatabases_ListPools(t *testing.T) {
     "connection": {
       "uri": "postgresql://user:pass@host.com/db",
       "host": "host.com",
+      "port": 1234,
+      "user": "user",
+      "password": "pass",
+      "database": "db",
+      "ssl": true
+    },
+    "private_connection": {
+      "uri": "postgresql://user:pass@private-host.com/db",
+      "host": "private-host.com",
       "port": 1234,
       "user": "user",
       "password": "pass",
@@ -660,6 +716,15 @@ func TestDatabases_CreatePool(t *testing.T) {
 			SSL:      true,
 			Database: "db",
 		},
+		PrivateConnection: &DatabaseConnection{
+			URI:      "postgresql://user:pass@private-host.com/db",
+			Host:     "private-host.com",
+			Port:     1234,
+			User:     "user",
+			Password: "pass",
+			SSL:      true,
+			Database: "db",
+		},
 	}
 
 	body := `
@@ -673,6 +738,15 @@ func TestDatabases_CreatePool(t *testing.T) {
     "connection": {
       "uri": "postgresql://user:pass@host.com/db",
       "host": "host.com",
+      "port": 1234,
+      "user": "user",
+      "password": "pass",
+      "database": "db",
+      "ssl": true
+    },
+    "private_connection": {
+      "uri": "postgresql://user:pass@private-host.com/db",
+      "host": "private-host.com",
       "port": 1234,
       "user": "user",
       "password": "pass",
@@ -721,6 +795,15 @@ func TestDatabases_GetPool(t *testing.T) {
 			SSL:      true,
 			Database: "db",
 		},
+		PrivateConnection: &DatabaseConnection{
+			URI:      "postgresql://user:pass@private-host.com/db",
+			Host:     "private-host.com",
+			Port:     1234,
+			User:     "user",
+			Password: "pass",
+			SSL:      true,
+			Database: "db",
+		},
 	}
 
 	body := `
@@ -734,6 +817,15 @@ func TestDatabases_GetPool(t *testing.T) {
     "connection": {
       "uri": "postgresql://user:pass@host.com/db",
       "host": "host.com",
+      "port": 1234,
+      "user": "user",
+      "password": "pass",
+      "database": "db",
+      "ssl": true
+    },
+    "private_connection": {
+      "uri": "postgresql://user:pass@private-host.com/db",
+      "host": "private-host.com",
       "port": 1234,
       "user": "user",
       "password": "pass",
@@ -793,6 +885,16 @@ func TestDatabases_GetReplica(t *testing.T) {
 			SSL:      true,
 			Database: "db",
 		},
+		PrivateConnection: &DatabaseConnection{
+			URI:      "postgresql://user:pass@private-host.com/db",
+			Host:     "private-host.com",
+			Port:     1234,
+			User:     "user",
+			Password: "pass",
+			SSL:      true,
+			Database: "db",
+		},
+		PrivateNetworkUUID: "deadbeef-dead-4aa5-beef-deadbeef347d",
 	}
 
 	body := `
@@ -810,7 +912,17 @@ func TestDatabases_GetReplica(t *testing.T) {
       "password": "pass",
       "database": "db",
       "ssl": true
-    }
+    },
+    "private_connection": {
+      "uri": "postgresql://user:pass@private-host.com/db",
+      "host": "private-host.com",
+      "port": 1234,
+      "user": "user",
+      "password": "pass",
+      "database": "db",
+      "ssl": true
+    },
+    "private_network_uuid": "deadbeef-dead-4aa5-beef-deadbeef347d"
   }
 }
 `
@@ -849,6 +961,16 @@ func TestDatabases_ListReplicas(t *testing.T) {
 				SSL:      true,
 				Database: "db",
 			},
+			PrivateConnection: &DatabaseConnection{
+				URI:      "postgresql://user:pass@private-host.com/db",
+				Host:     "private-host.com",
+				Port:     1234,
+				User:     "user",
+				Password: "pass",
+				SSL:      true,
+				Database: "db",
+			},
+			PrivateNetworkUUID: "deadbeef-dead-4aa5-beef-deadbeef347d",
 		},
 	}
 
@@ -867,7 +989,17 @@ func TestDatabases_ListReplicas(t *testing.T) {
       "password": "pass",
       "database": "db",
       "ssl": true
-    }
+    },
+    "private_connection": {
+      "uri": "postgresql://user:pass@private-host.com/db",
+      "host": "private-host.com",
+      "port": 1234,
+      "user": "user",
+      "password": "pass",
+      "database": "db",
+      "ssl": true
+    },
+    "private_network_uuid": "deadbeef-dead-4aa5-beef-deadbeef347d"
   }]
 }
 `
@@ -905,6 +1037,16 @@ func TestDatabases_CreateReplica(t *testing.T) {
 			SSL:      true,
 			Database: "db",
 		},
+		PrivateConnection: &DatabaseConnection{
+			URI:      "postgresql://user:pass@private-host.com/db",
+			Host:     "private-host.com",
+			Port:     1234,
+			User:     "user",
+			Password: "pass",
+			SSL:      true,
+			Database: "db",
+		},
+		PrivateNetworkUUID: "deadbeef-dead-4aa5-beef-deadbeef347d",
 	}
 
 	body := `
@@ -922,7 +1064,17 @@ func TestDatabases_CreateReplica(t *testing.T) {
       "password": "pass",
       "database": "db",
       "ssl": true
-    }
+    },
+    "private_connection": {
+      "uri": "postgresql://user:pass@private-host.com/db",
+      "host": "private-host.com",
+      "port": 1234,
+      "user": "user",
+      "password": "pass",
+      "database": "db",
+      "ssl": true
+    },
+    "private_network_uuid": "deadbeef-dead-4aa5-beef-deadbeef347d"
   }
 }
 `


### PR DESCRIPTION
Adds support for new `private_connection` and `private_network_uuid` fields exposed by VPC-enabled clusters, replicas and pools.