### PR TITLE
Fix omitempty typos in JSON struct tags

### DIFF
--- a/tags.go
+++ b/tags.go
@@ -47,8 +47,8 @@ const (
 
 // Resource represent a single resource for associating/disassociating with tags
 type Resource struct {
-	ID   string       `json:"resource_id,omit_empty"`
-	Type ResourceType `json:"resource_type,omit_empty"`
+	ID   string       `json:"resource_id,omitempty"`
+	Type ResourceType `json:"resource_type,omitempty"`
 }
 
 // TaggedResources represent the set of resources a tag is attached to


### PR DESCRIPTION
These fields were incorrectly tagged with `omit_empty`, when the correct
tag is `omitempty`.