### PR TITLE
Support unset fields on Kubernetes cluster and node pool updates

### DIFF
--- a/godo_test.go
+++ b/godo_test.go
@@ -543,3 +543,7 @@ func TestCustomBaseURL_badURL(t *testing.T) {
 func intPtr(val int) *int {
 	return &val
 }
+
+func boolPtr(val bool) *bool {
+	return &val
+}

--- a/godo_test.go
+++ b/godo_test.go
@@ -539,3 +539,7 @@ func TestCustomBaseURL_badURL(t *testing.T) {
 
 	testURLParseError(t, err)
 }
+
+func intPtr(val int) *int {
+	return &val
+}

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -69,8 +69,8 @@ type KubernetesClusterCreateRequest struct {
 type KubernetesClusterUpdateRequest struct {
 	Name              string                       `json:"name,omitempty"`
 	Tags              []string                     `json:"tags,omitempty"`
-	MaintenancePolicy *KubernetesMaintenancePolicy `json:"maintenance_policy"`
-	AutoUpgrade       bool                         `json:"auto_upgrade"`
+	MaintenancePolicy *KubernetesMaintenancePolicy `json:"maintenance_policy,omitempty"`
+	AutoUpgrade       *bool                        `json:"auto_upgrade,omitempty"`
 }
 
 // KubernetesClusterUpgradeRequest represents a request to upgrade a Kubernetes cluster.

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -91,7 +91,7 @@ type KubernetesNodePoolCreateRequest struct {
 // Kubernetes cluster.
 type KubernetesNodePoolUpdateRequest struct {
 	Name  string   `json:"name,omitempty"`
-	Count int      `json:"count,omitempty"`
+	Count *int     `json:"count,omitempty"`
 	Tags  []string `json:"tags,omitempty"`
 }
 

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -534,12 +534,104 @@ func TestKubernetesClusters_Update(t *testing.T) {
 	}
 }`
 
+	expectedReqJSON := `{"name":"antoine-test-cluster","tags":["cluster-tag-1","cluster-tag-2"],"maintenance_policy":{"start_time":"00:00","duration":"","day":"monday"}}
+`
+
 	mux.HandleFunc("/v2/kubernetes/clusters/8d91899c-0739-4a1a-acc5-deadbeefbb8f", func(w http.ResponseWriter, r *http.Request) {
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(r.Body)
+		require.Equal(t, expectedReqJSON, buf.String())
+
 		v := new(KubernetesClusterUpdateRequest)
-		err := json.NewDecoder(r.Body).Decode(v)
-		if err != nil {
-			t.Fatal(err)
+		err := json.NewDecoder(buf).Decode(v)
+		require.NoError(t, err)
+
+		testMethod(t, r, http.MethodPut)
+		require.Equal(t, v, updateRequest)
+		fmt.Fprint(w, jBlob)
+	})
+
+	got, _, err := kubeSvc.Update(ctx, "8d91899c-0739-4a1a-acc5-deadbeefbb8f", updateRequest)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestKubernetesClusters_Update_FalseAutoUpgrade(t *testing.T) {
+	setup()
+	defer teardown()
+
+	kubeSvc := client.Kubernetes
+
+	want := &KubernetesCluster{
+		ID:            "8d91899c-0739-4a1a-acc5-deadbeefbb8f",
+		Name:          "antoine-test-cluster",
+		RegionSlug:    "s2r1",
+		VersionSlug:   "1.10.0-gen0",
+		ClusterSubnet: "10.244.0.0/16",
+		ServiceSubnet: "10.245.0.0/16",
+		Tags:          []string{"cluster-tag-1", "cluster-tag-2"},
+		VPCUUID:       "880b7f98-f062-404d-b33c-458d545696f6",
+		NodePools: []*KubernetesNodePool{
+			&KubernetesNodePool{
+				ID:    "8d91899c-0739-4a1a-acc5-deadbeefbb8a",
+				Size:  "s-1vcpu-1gb",
+				Count: 2,
+				Name:  "pool-a",
+				Tags:  []string{"tag-1"},
+			},
+		},
+		MaintenancePolicy: &KubernetesMaintenancePolicy{
+			StartTime: "00:00",
+			Day:       KubernetesMaintenanceDayMonday,
+		},
+	}
+	updateRequest := &KubernetesClusterUpdateRequest{
+		AutoUpgrade: boolPtr(false),
+	}
+
+	jBlob := `
+{
+	"kubernetes_cluster": {
+		"id": "8d91899c-0739-4a1a-acc5-deadbeefbb8f",
+		"name": "antoine-test-cluster",
+		"region": "s2r1",
+		"version": "1.10.0-gen0",
+		"cluster_subnet": "10.244.0.0/16",
+		"service_subnet": "10.245.0.0/16",
+		"tags": [
+			"cluster-tag-1",
+			"cluster-tag-2"
+		],
+		"vpc_uuid": "880b7f98-f062-404d-b33c-458d545696f6",
+		"node_pools": [
+			{
+				"id": "8d91899c-0739-4a1a-acc5-deadbeefbb8a",
+				"size": "s-1vcpu-1gb",
+				"count": 2,
+				"name": "pool-a",
+				"tags": [
+					"tag-1"
+				]
+			}
+		],
+		"maintenance_policy": {
+			"start_time": "00:00",
+			"day": "monday"
 		}
+	}
+}`
+
+	expectedReqJSON := `{"auto_upgrade":false}
+`
+
+	mux.HandleFunc("/v2/kubernetes/clusters/8d91899c-0739-4a1a-acc5-deadbeefbb8f", func(w http.ResponseWriter, r *http.Request) {
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(r.Body)
+		require.Equal(t, expectedReqJSON, buf.String())
+
+		v := new(KubernetesClusterUpdateRequest)
+		err := json.NewDecoder(buf).Decode(v)
+		require.NoError(t, err)
 
 		testMethod(t, r, http.MethodPut)
 		require.Equal(t, v, updateRequest)
@@ -830,7 +922,8 @@ func TestKubernetesClusters_UpdateNodePool_ZeroCount(t *testing.T) {
 	}
 }`
 
-	expectedReqJSON := "{\"count\":0}\n"
+	expectedReqJSON := `{"count":0}
+`
 
 	mux.HandleFunc("/v2/kubernetes/clusters/8d91899c-0739-4a1a-acc5-deadbeefbb8f/node_pools/8d91899c-nodepool-4a1a-acc5-deadbeefbb8a", func(w http.ResponseWriter, r *http.Request) {
 		buf := new(bytes.Buffer)


### PR DESCRIPTION
## Problem

The DOKS API relies on presence/non-nil of fields on the incoming request to determine which fields should be patched/updated. If the fields are not present, then they are ignored and not updated.

The `godo.KubernetesNodePoolUpdateRequest` looks like this today:
```go
type KubernetesNodePoolUpdateRequest struct {
	Name  string   `json:"name,omitempty"`
	Count int      `json:"count,omitempty"`
	Tags  []string `json:"tags,omitempty"`
}
```
We define `Count int json:"count,omitempty"`. This means that 1. the field can't be `nil`, and 2. if the field is `0`, because we have `omitempty`, the serialized JSON will exclude this field as "empty" (https://play.golang.org/p/x95nu9gd6FN). So it's not possible to set `Count = 0` for node pools via `godo`.

The `godo.KubernetesClusterUpdateRequest` looks like this today:

```go
type KubernetesClusterUpdateRequest struct {
	Name              string                       `json:"name,omitempty"`
	Tags              []string                     `json:"tags,omitempty"`
	MaintenancePolicy *KubernetesMaintenancePolicy `json:"maintenance_policy,omitempty"`
	AutoUpgrade       bool                         `json:"auto_upgrade"`
}
```
We define `AutoUpgrade bool json:"auto_upgrade"`. This means that if `AutoUpgrade` is not specified, it will default to `false`, and because there is no `omitempty`, it will always get serialized this way and sent to the DO API. So unless explicitly specified, the cluster will always revert to `AutoUpgrade = false` on every cluster update request.

## Solution

Define these fields as pointers with `omitempty` so that they can be `nil`, and if they are then they will not be included in the serialized JSON to the DO API on these requests, and will be interpreted as "not to be updated".

This will allow `Count = 0` on node pool updates, and will allow `AutoUpgrade` to not be set on cluster updates without always reverting it back to `false`.

Note that this is a breaking change for existing uses of `KubernetesClusterUpdateRequest` and `KubernetesNodePoolUpdateRequest`.