### PR TITLE
Prepare for release 1.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v1.21.1] - 2019-09-19
+
+- #257 Upgrade to Go 1.13 - @bentranter
+
 ## [v1.21.0] - 2019-09-16
 
 - #255 Add DropletID to Kubernetes Node instance - @snormore

--- a/godo.go
+++ b/godo.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.21.0"
+	libraryVersion = "1.21.1"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"


### PR DESCRIPTION
Bumps the library version to 1.21.1, so that I can pull in the Go 1.13 upgrade from `doctl`.