### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ go get -u github.com/stretchr/testify/assert
 If outside `$GOPATH`, just clone the repository:
 
 ```sh
-git clone github.com/digitalocean/godo
+git clone https://github.com/digitalocean/godo
 ```
 
 ## Running tests


### PR DESCRIPTION
fix git clone example, excluding the protocol results in an error `fatal: repository 'github.com/digitalocean/godo' does not exist`