### PR TITLE
remove ResolveReference call

### DIFF
--- a/godo.go
+++ b/godo.go
@@ -227,12 +227,10 @@ func SetUserAgent(ua string) ClientOpt {
 // BaseURL of the Client. Relative URLS should always be specified without a preceding slash. If specified, the
 // value pointed to by body is JSON encoded and included in as the request body.
 func (c *Client) NewRequest(ctx context.Context, method, urlStr string, body interface{}) (*http.Request, error) {
-	rel, err := url.Parse(urlStr)
+	u, err := c.BaseURL.Parse(urlStr)
 	if err != nil {
 		return nil, err
 	}
-
-	u := c.BaseURL.ResolveReference(rel)
 
 	buf := new(bytes.Buffer)
 	if body != nil {


### PR DESCRIPTION
Removes `u.ResolveReference` call as I think it's cleaner if we just parse from the client's `BaseURL`. 