### PR TITLE
Update isLast to check p.Next

### DIFF
--- a/links.go
+++ b/links.go
@@ -59,7 +59,7 @@ func (l *Links) IsLastPage() bool {
 }
 
 func (p *Pages) isLast() bool {
-	return p.Last == ""
+	return p.Next == ""
 }
 
 func pageForURL(urlText string) (int, error) {

--- a/links_test.go
+++ b/links_test.go
@@ -32,6 +32,15 @@ var (
 			}
 		}
 	}`)
+	projectslastPageLinksJSONBlob = []byte(`{
+		"links": {
+			"pages": {
+				"first": "https://api.digitalocean.com/v2/projects?page=1",
+				"prev": "https://api.digitalocean.com/v2/projects?page=2",
+				"last": "https://api.digitalocean.com/v2/projects?page=3"
+			}
+		}
+	}`)
 
 	missingLinksJSONBlob = []byte(`{ }`)
 )
@@ -82,6 +91,20 @@ func TestLinks_ParseMiddle(t *testing.T) {
 
 func TestLinks_ParseLast(t *testing.T) {
 	links := loadLinksJSON(t, lastPageLinksJSONBlob)
+	_, err := links.CurrentPage()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := &Response{Links: &links}
+	checkCurrentPage(t, r, 3)
+	if !links.IsLastPage() {
+		t.Fatalf("expected last page")
+	}
+}
+
+func TestLinks_ParseProjectsLast(t *testing.T) {
+	links := loadLinksJSON(t, projectslastPageLinksJSONBlob)
 	_, err := links.CurrentPage()
 	if err != nil {
 		t.Fatal(err)

--- a/links_test.go
+++ b/links_test.go
@@ -32,7 +32,7 @@ var (
 			}
 		}
 	}`)
-	projectslastPageLinksJSONBlob = []byte(`{
+	projectsLastPageLinksJSONBlob = []byte(`{
 		"links": {
 			"pages": {
 				"first": "https://api.digitalocean.com/v2/projects?page=1",
@@ -104,7 +104,7 @@ func TestLinks_ParseLast(t *testing.T) {
 }
 
 func TestLinks_ParseProjectsLast(t *testing.T) {
-	links := loadLinksJSON(t, projectslastPageLinksJSONBlob)
+	links := loadLinksJSON(t, projectsLastPageLinksJSONBlob)
 	_, err := links.CurrentPage()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
A proposed solution for issue #263 where the `client.Projects.List` function's returned `resp.Links.Pages.Last` value will have a URI and not an empty value despite being on the last page leading to `resp.Links.IsLastPage()` always returning `false`. The `resp.Links.Pages.Next` value is empty on the last page so we can check that value instead to properly determine the last page. 