### PR TITLE
Return []DatabaseFirewallRule in addition to raw response.

### DIFF
--- a/databases_test.go
+++ b/databases_test.go
@@ -1192,6 +1192,15 @@ func TestDatabases_GetFirewallRules(t *testing.T) {
 
 	path := fmt.Sprintf("/v2/databases/%s/firewall", dbID)
 
+	want := []DatabaseFirewallRule{
+		{
+			Type:        "ip_addr",
+			Value:       "192.168.1.1",
+			UUID:        "deadbeef-dead-4aa5-beef-deadbeef347d",
+			ClusterUUID: "deadbeef-dead-4aa5-beef-deadbeef347d",
+		},
+	}
+
 	body := ` {"rules": [{
 		"type": "ip_addr",
 		"value": "192.168.1.1",
@@ -1204,8 +1213,9 @@ func TestDatabases_GetFirewallRules(t *testing.T) {
 		fmt.Fprint(w, body)
 	})
 
-	_, err := client.Databases.GetFirewallRules(ctx, dbID)
+	got, _, err := client.Databases.GetFirewallRules(ctx, dbID)
 	require.NoError(t, err)
+	require.Equal(t, want, got)
 }
 
 func TestDatabases_UpdateFirewallRules(t *testing.T) {


### PR DESCRIPTION
Throughout godo and the `DatabasesService`, we return the object in addition  to the raw response. This updates `GetFirewallRules` to do this as well.

This is technically a breaking change. But as this API has not been publicized to users yet, I think it's the right thing to do.