### PR TITLE
[NOMERGE] domains: change port to nullable int

### DIFF
--- a/domains.go
+++ b/domains.go
@@ -73,7 +73,7 @@ type DomainRecord struct {
 	Name     string `json:"name,omitempty"`
 	Data     string `json:"data,omitempty"`
 	Priority int    `json:"priority"`
-	Port     int    `json:"port,omitempty"`
+	Port     *int   `json:"port"`
 	TTL      int    `json:"ttl,omitempty"`
 	Weight   int    `json:"weight"`
 	Flags    int    `json:"flags"`
@@ -86,7 +86,7 @@ type DomainRecordEditRequest struct {
 	Name     string `json:"name,omitempty"`
 	Data     string `json:"data,omitempty"`
 	Priority int    `json:"priority"`
-	Port     int    `json:"port,omitempty"`
+	Port     *int   `json:"port"`
 	TTL      int    `json:"ttl,omitempty"`
 	Weight   int    `json:"weight"`
 	Flags    int    `json:"flags"`

--- a/domains.go
+++ b/domains.go
@@ -72,11 +72,11 @@ type DomainRecord struct {
 	Type     string `json:"type,omitempty"`
 	Name     string `json:"name,omitempty"`
 	Data     string `json:"data,omitempty"`
-	Priority int    `json:"priority"`
+	Priority *int   `json:"priority"`
 	Port     *int   `json:"port"`
 	TTL      int    `json:"ttl,omitempty"`
-	Weight   int    `json:"weight"`
-	Flags    int    `json:"flags"`
+	Weight   *int   `json:"weight"`
+	Flags    *int   `json:"flags"`
 	Tag      string `json:"tag,omitempty"`
 }
 
@@ -85,11 +85,11 @@ type DomainRecordEditRequest struct {
 	Type     string `json:"type,omitempty"`
 	Name     string `json:"name,omitempty"`
 	Data     string `json:"data,omitempty"`
-	Priority int    `json:"priority"`
+	Priority *int   `json:"priority"`
 	Port     *int   `json:"port"`
 	TTL      int    `json:"ttl,omitempty"`
-	Weight   int    `json:"weight"`
-	Flags    int    `json:"flags"`
+	Weight   *int   `json:"weight"`
+	Flags    *int   `json:"flags"`
 	Tag      string `json:"tag,omitempty"`
 }
 


### PR DESCRIPTION
- this is stated in our API spec
- should be nullable INT as we need to send null not omit
the field for every record besides a SRV
- SRV records can have a valid port of 0 so omit empty
fails us in this situation as 0 on an int field is
removed
- this is obviously a breaking change but feels most correct