### PR TITLE
Fix VolumeSnapshotResourceType value volumesnapshot -> volume_snapshot

### DIFF
--- a/tags.go
+++ b/tags.go
@@ -42,7 +42,7 @@ const (
 	// LoadBalancerResourceType holds the string representing our ResourceType of LoadBalancer.
 	LoadBalancerResourceType ResourceType = "load_balancer"
 	// VolumeSnapshotResourceType holds the string representing our ResourceType for storage Snapshots.
-	VolumeSnapshotResourceType ResourceType = "volumesnapshot"
+	VolumeSnapshotResourceType ResourceType = "volume_snapshot"
 )
 
 // Resource represent a single resource for associating/disassociating with tags


### PR DESCRIPTION
Noticed that `VolumeSnapshotResourceType` was incorrectly set to `"volumesnapshot"` instead of `"volume_snapshot"` when unsuccessfully trying to use the constant in a `TagCreateRequest`, so opened this small PR to correct the value.