### PR TITLE
Remove databases info from top-level godoc string

### DIFF
--- a/databases.go
+++ b/databases.go
@@ -68,8 +68,14 @@ const (
 	SQLAuthPluginCachingSHA2 = "caching_sha2_password"
 )
 
-// DatabasesService is an interface for interfacing with the databases endpoints
-// of the DigitalOcean API.
+// The DatabasesService provides access to the DigitalOcean managed database
+// suite of products through the public API. Customers can create new database
+// clusters, migrate them  between regions, create replicas and interact with
+// their configurations. Each database service is refered to as a Database. A
+// SQL database service can have multiple databases residing in the system. To
+// help make these entities distinct from Databases in godo, we refer to them
+// here as DatabaseDBs.
+//
 // See: https://developers.digitalocean.com/documentation/v2#databases
 type DatabasesService interface {
 	List(context.Context, *ListOptions) ([]Database, *Response, error)

--- a/doc.go
+++ b/doc.go
@@ -1,11 +1,2 @@
-// Package godo is the DigtalOcean API v2 client for Go
-//
-// Databases
-//
-// The Databases service provides access to the DigitalOcean managed database
-// suite of products. Customers can create new database clusters, migrate them
-// between regions, create replicas and interact with their configurations.
-// Each database service is refered to as a Database. A SQL database service
-// can have multiple databases residing in the system. To help make these
-// entities distinct from Databases in godo, we refer to them here as DatabaseDBs.
+// Package godo is the DigtalOcean API v2 client for Go.
 package godo


### PR DESCRIPTION
Removes the managed databases info from the top-level godoc string. Having this string there, when no other product specific info is there, is confusing. This PR moves this down to the `DatabaseService` godoc string instead in order to be more consistent with the rest of the library.