### PR TITLE
Deserialize meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## unreleased
+
+- #286 Deserialize meta - @timoreimann
+
 ## [v1.28.0] - 2019-12-04
 
 - #282 Add valid Redis eviction policy constants - @bentranter

--- a/godo.go
+++ b/godo.go
@@ -94,6 +94,9 @@ type Response struct {
 	// request body and not the header.
 	Links *Links
 
+	// Meta describes generic information about the response.
+	Meta *Meta
+
 	// Monitoring URI
 	Monitor string
 

--- a/meta.go
+++ b/meta.go
@@ -1,0 +1,6 @@
+package godo
+
+// Meta describes generic information about the response.
+type Meta struct {
+	Total int `json:"total"`
+}

--- a/meta.go
+++ b/meta.go
@@ -1,6 +1,6 @@
 package godo
 
-// Meta describes generic information about the response.
+// Meta describes generic information about a response.
 type Meta struct {
 	Total int `json:"total"`
 }

--- a/snapshots.go
+++ b/snapshots.go
@@ -47,6 +47,7 @@ type snapshotRoot struct {
 type snapshotsRoot struct {
 	Snapshots []Snapshot `json:"snapshots"`
 	Links     *Links     `json:"links,omitempty"`
+	Meta      *Meta      `json:"meta,omitempty"`
 }
 
 type listSnapshotOptions struct {

--- a/storage.go
+++ b/storage.go
@@ -67,6 +67,7 @@ func (f Volume) URN() string {
 type storageVolumesRoot struct {
 	Volumes []Volume `json:"volumes"`
 	Links   *Links   `json:"links"`
+	Meta    *Meta    `json:"meta"`
 }
 
 type storageVolumeRoot struct {
@@ -121,6 +122,9 @@ func (svc *StorageServiceOp) ListVolumes(ctx context.Context, params *ListVolume
 
 	if l := root.Links; l != nil {
 		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
 	}
 
 	return root.Volumes, resp, nil
@@ -202,6 +206,9 @@ func (svc *StorageServiceOp) ListSnapshots(ctx context.Context, volumeID string,
 
 	if l := root.Links; l != nil {
 		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
 	}
 
 	return root.Snapshots, resp, nil

--- a/storage_test.go
+++ b/storage_test.go
@@ -58,12 +58,12 @@ func TestStorageVolumes_ListStorageVolumes(t *testing.T) {
 		fmt.Fprint(w, jBlob)
 	})
 
-	volumes, _, err := client.Storage.ListVolumes(ctx, nil)
+	volumes, resp, err := client.Storage.ListVolumes(ctx, nil)
 	if err != nil {
 		t.Errorf("Storage.ListVolumes returned error: %v", err)
 	}
 
-	expected := []Volume{
+	expectedVolume := []Volume{
 		{
 			Region:        &Region{Slug: "nyc3"},
 			ID:            "80d414c6-295e-4e3a-ac58-eb9456c1e1d1",
@@ -86,8 +86,15 @@ func TestStorageVolumes_ListStorageVolumes(t *testing.T) {
 			Tags:            []string{},
 		},
 	}
-	if !reflect.DeepEqual(volumes, expected) {
-		t.Errorf("Storage.ListVolumes returned %+v, expected %+v", volumes, expected)
+	if !reflect.DeepEqual(volumes, expectedVolume) {
+		t.Errorf("Storage.ListVolumes returned volumes %+v, expected %+v", volumes, expectedVolume)
+	}
+
+	expectedMeta := &Meta{
+		Total: 28,
+	}
+	if !reflect.DeepEqual(resp.Meta, expectedMeta) {
+		t.Errorf("Storage.ListVolumes returned meta %+v, expected %+v", resp.Meta, expectedMeta)
 	}
 }
 
@@ -169,7 +176,7 @@ func TestStorageVolumes_ListVolumesByName(t *testing.T) {
 			}
 		}`
 
-	expected := []Volume{
+	expectedVolumes := []Volume{
 		{
 			Region:        &Region{Slug: "nyc3"},
 			ID:            "80d414c6-295e-4e3a-ac58-eb9456c1e1d1",
@@ -193,13 +200,20 @@ func TestStorageVolumes_ListVolumesByName(t *testing.T) {
 	options := &ListVolumeParams{
 		Name: "myvolume",
 	}
-	volumes, _, err := client.Storage.ListVolumes(ctx, options)
+	volumes, resp, err := client.Storage.ListVolumes(ctx, options)
 	if err != nil {
 		t.Errorf("Storage.ListVolumeByName returned error: %v", err)
 	}
 
-	if !reflect.DeepEqual(volumes, expected) {
-		t.Errorf("Storage.ListVolumeByName returned %+v, expected %+v", volumes, expected)
+	if !reflect.DeepEqual(volumes, expectedVolumes) {
+		t.Errorf("Storage.ListVolumeByName returned volumes %+v, expected %+v", volumes, expectedVolumes)
+	}
+
+	expectedMeta := &Meta{
+		Total: 1,
+	}
+	if !reflect.DeepEqual(resp.Meta, expectedMeta) {
+		t.Errorf("Storage.ListVolumeByName returned meta %+v, expected %+v", resp.Meta, expectedMeta)
 	}
 }
 
@@ -229,7 +243,7 @@ func TestStorageVolumes_ListVolumesByRegion(t *testing.T) {
 			}
 		}`
 
-	expected := []Volume{
+	expectedVolumes := []Volume{
 		{
 			Region:        &Region{Slug: "nyc3"},
 			ID:            "80d414c6-295e-4e3a-ac58-eb9456c1e1d1",
@@ -253,13 +267,20 @@ func TestStorageVolumes_ListVolumesByRegion(t *testing.T) {
 	options := &ListVolumeParams{
 		Region: "nyc3",
 	}
-	volumes, _, err := client.Storage.ListVolumes(ctx, options)
+	volumes, resp, err := client.Storage.ListVolumes(ctx, options)
 	if err != nil {
 		t.Errorf("Storage.ListVolumeByName returned error: %v", err)
 	}
 
-	if !reflect.DeepEqual(volumes, expected) {
-		t.Errorf("Storage.ListVolumeByName returned %+v, expected %+v", volumes, expected)
+	if !reflect.DeepEqual(volumes, expectedVolumes) {
+		t.Errorf("Storage.ListVolumeByName returned volumes %+v, expected %+v", volumes, expectedVolumes)
+	}
+
+	expectedMeta := &Meta{
+		Total: 1,
+	}
+	if !reflect.DeepEqual(resp.Meta, expectedMeta) {
+		t.Errorf("Storage.ListVolumeByName returned meta %+v, expected %+v", resp.Meta, expectedMeta)
 	}
 }
 
@@ -289,7 +310,7 @@ func TestStorageVolumes_ListVolumesByNameAndRegion(t *testing.T) {
 			}
 		}`
 
-	expected := []Volume{
+	expectedVolumes := []Volume{
 		{
 			Region:        &Region{Slug: "nyc3"},
 			ID:            "80d414c6-295e-4e3a-ac58-eb9456c1e1d1",
@@ -314,13 +335,20 @@ func TestStorageVolumes_ListVolumesByNameAndRegion(t *testing.T) {
 		Region: "nyc3",
 		Name:   "myvolume",
 	}
-	volumes, _, err := client.Storage.ListVolumes(ctx, options)
+	volumes, resp, err := client.Storage.ListVolumes(ctx, options)
 	if err != nil {
 		t.Errorf("Storage.ListVolumeByName returned error: %v", err)
 	}
 
-	if !reflect.DeepEqual(volumes, expected) {
-		t.Errorf("Storage.ListVolumeByName returned %+v, expected %+v", volumes, expected)
+	if !reflect.DeepEqual(volumes, expectedVolumes) {
+		t.Errorf("Storage.ListVolumeByName returned volumes %+v, expected %+v", volumes, expectedVolumes)
+	}
+
+	expectedMeta := &Meta{
+		Total: 1,
+	}
+	if !reflect.DeepEqual(resp.Meta, expectedMeta) {
+		t.Errorf("Storage.ListVolumeByName returned meta %+v, expected %+v", resp.Meta, expectedMeta)
 	}
 }
 
@@ -554,12 +582,12 @@ func TestStorageSnapshots_ListStorageSnapshots(t *testing.T) {
 		fmt.Fprint(w, jBlob)
 	})
 
-	volumes, _, err := client.Storage.ListSnapshots(ctx, "98d414c6-295e-4e3a-ac58-eb9456c1e1d1", nil)
+	volumes, resp, err := client.Storage.ListSnapshots(ctx, "98d414c6-295e-4e3a-ac58-eb9456c1e1d1", nil)
 	if err != nil {
 		t.Errorf("Storage.ListSnapshots returned error: %v", err)
 	}
 
-	expected := []Snapshot{
+	expectedSnapshots := []Snapshot{
 		{
 			Regions:       []string{"nyc3"},
 			ID:            "80d414c6-295e-4e3a-ac58-eb9456c1e1d1",
@@ -575,8 +603,15 @@ func TestStorageSnapshots_ListStorageSnapshots(t *testing.T) {
 			Created:       "2012-10-03T15:00:01.05Z",
 		},
 	}
-	if !reflect.DeepEqual(volumes, expected) {
-		t.Errorf("Storage.ListSnapshots returned %+v, expected %+v", volumes, expected)
+	if !reflect.DeepEqual(volumes, expectedSnapshots) {
+		t.Errorf("Storage.ListSnapshots returned snapshots %+v, expected %+v", volumes, expectedSnapshots)
+	}
+
+	expectedMeta := &Meta{
+		Total: 28,
+	}
+	if !reflect.DeepEqual(resp.Meta, expectedMeta) {
+		t.Errorf("Storage.ListSnapshots returned meta %+v, expected %+v", resp.Meta, expectedMeta)
 	}
 }
 

--- a/storage_test.go
+++ b/storage_test.go
@@ -124,16 +124,7 @@ func TestStorageVolumes_Get(t *testing.T) {
 			"filesystem_type": "xfs",
 			"filesystem_label": "my-vol",
 			"tags": ["tag1", "tag2"]
-		},
-		"links": {
-	    "pages": {
-	      "last": "https://api.digitalocean.com/v2/volumes?page=2",
-	      "next": "https://api.digitalocean.com/v2/volumes?page=2"
-	    }
-	  },
-	  "meta": {
-	    "total": 28
-	  }
+		}
 	}`
 
 	mux.HandleFunc("/v2/volumes/80d414c6-295e-4e3a-ac58-eb9456c1e1d1", func(w http.ResponseWriter, r *http.Request) {
@@ -632,16 +623,7 @@ func TestStorageSnapshots_Get(t *testing.T) {
 			"name": "my snapshot",
 			"size_gigabytes": 100,
 			"created_at": "2002-10-02T15:00:00.05Z"
-		},
-		"links": {
-	    "pages": {
-				"last": "https://api.digitalocean.com/v2/volumes/98d414c6-295e-4e3a-ac58-eb9456c1e1d1/snapshots?page=2",
-				"next": "https://api.digitalocean.com/v2/volumes/98d414c6-295e-4e3a-ac58-eb9456c1e1d1/snapshots?page=2"
-	    }
-	  },
-	  "meta": {
-	    "total": 28
-	  }
+		}
 	}`
 
 	mux.HandleFunc("/v2/snapshots/80d414c6-295e-4e3a-ac58-eb9456c1e1d1", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This change deserializes [the meta field](https://developers.digitalocean.com/documentation/v2/#meta) into the response, allowing easy access to the total number of objects returned by API operations yielding collections.

We also remove links and meta fields from stubbed getters that do not return collections: according to the respective documentations, [links](https://developers.digitalocean.com/documentation/v2/#links) and meta fields won't be included for single element responses.

For now, I have only implemented the change for storage (volumes and snapshots). I'd appreciate getting some initial feedback on the approach, after which I'm more than happy to support all other collection-returning API operations as well.