### PR TITLE
Return balance values from Balance.Get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- #288 Add Balance Get method - @rbutler
 - #286 Deserialize meta - @timoreimann
 
 ## [v1.28.0] - 2019-12-04

--- a/balance.go
+++ b/balance.go
@@ -1,0 +1,52 @@
+package godo
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// BalanceService is an interface for interfacing with the Balance
+// endpoints of the DigitalOcean API
+// See: https://developers.digitalocean.com/documentation/v2/#balance
+type BalanceService interface {
+	Get(context.Context) (*Balance, *Response, error)
+}
+
+// BalanceServiceOp handles communication with the Balance related methods of
+// the DigitalOcean API.
+type BalanceServiceOp struct {
+	client *Client
+}
+
+var _ BalanceService = &BalanceServiceOp{}
+
+// Balance represents a DigitalOcean Balance
+type Balance struct {
+	MonthToDateBalance string    `json:"month_to_date_balance"`
+	AccountBalance     string    `json:"account_balance"`
+	MonthToDateUsage   string    `json:"month_to_date_usage"`
+	GeneratedAt        time.Time `json:"generated_at"`
+}
+
+func (r Balance) String() string {
+	return Stringify(r)
+}
+
+// Get DigitalOcean balance info
+func (s *BalanceServiceOp) Get(ctx context.Context) (*Balance, *Response, error) {
+	path := "v2/customers/my/balance"
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(Balance)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}

--- a/balance_test.go
+++ b/balance_test.go
@@ -1,0 +1,44 @@
+package godo
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestBalanceGet(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/customers/my/balance", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+
+		response := `
+		{
+			"month_to_date_balance": "23.44",
+			"account_balance": "12.23",
+			"month_to_date_usage": "11.21",
+			"generated_at": "2018-06-21T08:44:38Z"
+		}
+		`
+
+		fmt.Fprint(w, response)
+	})
+
+	bal, _, err := client.Balance.Get(ctx)
+	if err != nil {
+		t.Errorf("Balance.Get returned error: %v", err)
+	}
+
+	expected := &Balance{
+		MonthToDateBalance: "23.44",
+		AccountBalance:     "12.23",
+		MonthToDateUsage:   "11.21",
+		GeneratedAt:        time.Date(2018, 6, 21, 8, 44, 38, 0, time.UTC),
+	}
+	if !reflect.DeepEqual(bal, expected) {
+		t.Errorf("Balance.Get returned %+v, expected %+v", bal, expected)
+	}
+}

--- a/godo.go
+++ b/godo.go
@@ -45,6 +45,7 @@ type Client struct {
 	// Services used for communicating with the API
 	Account           AccountService
 	Actions           ActionsService
+	Balance           BalanceService
 	CDNs              CDNService
 	Domains           DomainsService
 	Droplets          DropletsService
@@ -165,6 +166,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c := &Client{client: httpClient, BaseURL: baseURL, UserAgent: userAgent}
 	c.Account = &AccountServiceOp{client: c}
 	c.Actions = &ActionsServiceOp{client: c}
+	c.Balance = &BalanceServiceOp{client: c}
 	c.CDNs = &CDNServiceOp{client: c}
 	c.Certificates = &CertificatesServiceOp{client: c}
 	c.Domains = &DomainsServiceOp{client: c}

--- a/godo_test.go
+++ b/godo_test.go
@@ -74,6 +74,7 @@ func testClientServices(t *testing.T, c *Client) {
 	services := []string{
 		"Account",
 		"Actions",
+		"Balance",
 		"CDNs",
 		"Domains",
 		"Droplets",


### PR DESCRIPTION
Adds `balance.go` with a `Balance.Get` method.  This currently hard codes the path with `my` as a customer identifier.
