### PR TITLE
Add reset database user auth method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## unreleased
+- #300 Add reset database user auth method - @zbarahal-do
 
 ## [v1.29.0] - 2019-12-13
 

--- a/databases_test.go
+++ b/databases_test.go
@@ -542,12 +542,12 @@ func TestDatabases_ResetUserAuth(t *testing.T) {
 	body := `
 {
   "user": {
-    "name": "name",
-    "role": "foo",
-    "password": "pass",
-	"mysql_settings": {
-		"auth_plugin": "caching_sha2_password"
-	}
+     "name": "name",
+     "role": "foo",
+     "password": "pass",
+     "mysql_settings": {
+       "auth_plugin": "caching_sha2_password"
+     }
   }
 }
 `

--- a/databases_test.go
+++ b/databases_test.go
@@ -533,6 +533,45 @@ func TestDatabases_DeleteUser(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestDatabases_ResetUserAuth(t *testing.T) {
+	setup()
+	defer teardown()
+	dbID := "deadbeef-dead-4aa5-beef-deadbeef347d"
+	path := fmt.Sprintf("/v2/databases/%s/users/user/reset_auth", dbID)
+
+	body := `
+{
+  "user": {
+    "name": "name",
+    "role": "foo",
+    "password": "pass",
+	"mysql_settings": {
+		"auth_plugin": "caching_sha2_password"
+	}
+  }
+}
+`
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		fmt.Fprint(w, body)
+	})
+
+	want := &DatabaseUser{
+		Name:          "name",
+		Role:          "foo",
+		Password:      "pass",
+		MySQLSettings: &DatabaseMySQLUserSettings{AuthPlugin: SQLAuthPluginCachingSHA2},
+	}
+
+	got, _, err := client.Databases.ResetUserAuth(ctx, dbID, "user", &DatabaseResetUserAuthRequest{
+		MySQLSettings: &DatabaseMySQLUserSettings{
+			AuthPlugin: SQLAuthPluginCachingSHA2,
+		}})
+
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
 func TestDatabases_ListDBs(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
This PR adds a method to allow a user to reset the auth method used by a MySQL DBaaS user. The corresponding public API feature is not released yet.

This is my first PR to godo so let me know if I've missed anything.

There will be a corresponding PR to droplet-kit and doctl as well.

The new endpoint is
/databases/$UUID/users/$NAME/reset_auth and expects a body

```
{
    "mysql_settings": {
        "auth_plugin": "NEW_AUTH_TYPE",
    }
}
```

DropletKit: https://github.com/digitalocean/droplet_kit/pull/231
doctl: https://github.com/digitalocean/doctl/pull/736
