### PR TITLE
Export the DO registry hostname as a const

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -10,6 +10,8 @@ import (
 
 const (
 	registryPath = "/v2/registry"
+	// RegistryServer is the hostname of the DigitalOcean registry service
+	RegistryServer = "registry.digitalocean.com"
 )
 
 // RegistryService is an interface for interfacing with the Registry endpoints


### PR DESCRIPTION
Following [Docker's own terminology](https://docs.docker.com/engine/reference/commandline/login/#login-to-a-self-hosted-registry), this exports the DO registry hostname `registry.digitalocean.com` as a const so users of `godo` can reference it.