### PR TITLE
Update README to use NewFromToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,33 +43,11 @@ You can then use your token to create a new client:
 package main
 
 import (
-	"context"
-	"github.com/digitalocean/godo"
-	"golang.org/x/oauth2"
+    "github.com/digitalocean/godo"
 )
-
-const (
-    pat = "mytoken"
-)
-
-type TokenSource struct {
-	AccessToken string
-}
-
-func (t *TokenSource) Token() (*oauth2.Token, error) {
-	token := &oauth2.Token{
-		AccessToken: t.AccessToken,
-	}
-	return token, nil
-}
 
 func main() {
-	tokenSource := &TokenSource{
-		AccessToken: pat,
-	}
-
-	oauthClient := oauth2.NewClient(context.Background(), tokenSource)
-	client := godo.NewClient(oauthClient)
+    client := NewFromToken("my-digitalocean-api-token")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ import (
 )
 
 func main() {
-    client := NewFromToken("my-digitalocean-api-token")
+    client := godo.NewFromToken("my-digitalocean-api-token")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ func main() {
 }
 ```
 
+If you need to provide a `context.Context` to your new client, you should use [`godo.NewClient`](https://godoc.org/github.com/digitalocean/godo#NewClient) to manually construct a client instead.
+
 ## Examples
 
 

--- a/godo.go
+++ b/godo.go
@@ -169,7 +169,12 @@ func NewFromToken(token string) *Client {
 	return NewClient(oauth2.NewClient(ctx, ts))
 }
 
-// NewClient returns a new DigitalOcean API client.
+// NewClient returns a new DigitalOcean API client, using the given
+// http.Client to perform all requests.
+//
+// Users who wish to pass their own http.Client should use this method. If
+// you're in need of further customization, the godo.New method allows more
+// options, such as setting a custom URL or a custom user agent string.
 func NewClient(httpClient *http.Client) *Client {
 	if httpClient == nil {
 		httpClient = http.DefaultClient


### PR DESCRIPTION
Updates the README to use the new `godo.NewFromToken("my-token")` method.

Specifically looking for @andrewsomething's feedback on this documentation change, since I'm not sure if there's any risk to changing this that I'm not aware of.

This also updates the previously weird 7-space indentation used in the previous code example to use a more common 4-space indentation.