### PR TITLE
Remove duplicate entry from the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 # Change Log
 
 ## unreleased
-- #300 Add reset database user auth method - @zbarahal-do
 
-## {v1.32.0] -2020-03-04
+## [v1.32.0] -2020-03-04
 
 - #300 Add reset database user auth method - @zbarahal-do
 


### PR DESCRIPTION
Removes the duplicate entry from the changelog, so that the `unreleased` section is empty.