### PR TITLE
Add TagCount field to registry/Repository

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -57,6 +57,7 @@ type Repository struct {
 	RegistryName string         `json:"registry_name,omitempty"`
 	Name         string         `json:"name,omitempty"`
 	LatestTag    *RepositoryTag `json:"latest_tag,omitempty"`
+	TagCount     uint64         `json:"tag_count,omitempty"`
 }
 
 // RepositoryTag represents a repository tag

--- a/registry_test.go
+++ b/registry_test.go
@@ -144,6 +144,7 @@ func TestRepository_List(t *testing.T) {
 		{
 			RegistryName: testRegistry,
 			Name:         testRepository,
+			TagCount:     1,
 			LatestTag: &RepositoryTag{
 				RegistryName:        testRegistry,
 				Repository:          testRepository,
@@ -160,6 +161,7 @@ func TestRepository_List(t *testing.T) {
 		{
 			"registry_name": "` + testRegistry + `",
 			"name": "` + testRepository + `",
+			"tag_count": 1,
 			"latest_tag": {
 				"registry_name": "` + testRegistry + `",
 				"repository": "` + testRepository + `",


### PR DESCRIPTION
### Description

#### What does this pull request accomplish

* The DOCR API now includes `TagCount` as a returned field with `repository`. This adds support to `godo` for the new field