### PR TITLE
Prepare to release v1.35.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## unreleased
 
+## [v1.35.1] - 2020-04-21
+
+= #328 Update vulnerable x/crypto dependency - @bentranter
+
 ## [v1.35.0] - 2020-04-20
 
 - #326 Add TagCount field to registry/Repository - @nicktate

--- a/godo.go
+++ b/godo.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.35.0"
+	libraryVersion = "1.35.1"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"


### PR DESCRIPTION
Prepares to release v1.35.1, which includes a fix for CVE-2019-11840.