### PR TITLE
registry: URL encode repository names when building URLs

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 )
@@ -195,7 +196,7 @@ func (svc *RegistryServiceOp) ListRepositories(ctx context.Context, registry str
 
 // ListRepositoryTags returns a list of the RepositoryTags available within the given repository.
 func (svc *RegistryServiceOp) ListRepositoryTags(ctx context.Context, registry, repository string, opts *ListOptions) ([]*RepositoryTag, *Response, error) {
-	path := fmt.Sprintf("%s/%s/repositories/%s/tags", registryPath, registry, repository)
+	path := fmt.Sprintf("%s/%s/repositories/%s/tags", registryPath, registry, url.PathEscape(repository))
 	path, err := addOptions(path, opts)
 	if err != nil {
 		return nil, nil, err
@@ -223,7 +224,7 @@ func (svc *RegistryServiceOp) ListRepositoryTags(ctx context.Context, registry, 
 
 // DeleteTag deletes a tag within a given repository.
 func (svc *RegistryServiceOp) DeleteTag(ctx context.Context, registry, repository, tag string) (*Response, error) {
-	path := fmt.Sprintf("%s/%s/repositories/%s/tags/%s", registryPath, registry, repository, tag)
+	path := fmt.Sprintf("%s/%s/repositories/%s/tags/%s", registryPath, registry, url.PathEscape(repository), tag)
 	req, err := svc.client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, err
@@ -238,7 +239,7 @@ func (svc *RegistryServiceOp) DeleteTag(ctx context.Context, registry, repositor
 
 // DeleteManifest deletes a manifest by its digest within a given repository.
 func (svc *RegistryServiceOp) DeleteManifest(ctx context.Context, registry, repository, digest string) (*Response, error) {
-	path := fmt.Sprintf("%s/%s/repositories/%s/digests/%s", registryPath, registry, repository, digest)
+	path := fmt.Sprintf("%s/%s/repositories/%s/digests/%s", registryPath, registry, url.PathEscape(repository), digest)
 	req, err := svc.client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, err

--- a/registry_test.go
+++ b/registry_test.go
@@ -12,12 +12,13 @@ import (
 )
 
 const (
-	testRegistry       = "test-registry"
-	testRepository     = "test-repository"
-	testTag            = "test-tag"
-	testDigest         = "sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f"
-	testCompressedSize = 2789669
-	testSize           = 5843968
+	testRegistry          = "test-registry"
+	testRepository        = "test/repository"
+	testEncodedRepository = "test%2Frepository"
+	testTag               = "test-tag"
+	testDigest            = "sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f"
+	testCompressedSize    = 2789669
+	testSize              = 5843968
 )
 
 var (
@@ -252,8 +253,8 @@ func TestRepository_ListTags(t *testing.T) {
 	],
 	"links": {
 	    "pages": {
-			"next": "https://api.digitalocean.com/v2/registry/` + testRegistry + `/repositories/` + testRepository + `/tags?page=2",
-			"last": "https://api.digitalocean.com/v2/registry/` + testRegistry + `/repositories/` + testRepository + `/tags?page=2"
+			"next": "https://api.digitalocean.com/v2/registry/` + testRegistry + `/repositories/` + testEncodedRepository + `/tags?page=2",
+			"last": "https://api.digitalocean.com/v2/registry/` + testRegistry + `/repositories/` + testEncodedRepository + `/tags?page=2"
 		}
 	},
 	"meta": {
@@ -273,8 +274,8 @@ func TestRepository_ListTags(t *testing.T) {
 	gotRespLinks := response.Links
 	wantRespLinks := &Links{
 		Pages: &Pages{
-			Next: fmt.Sprintf("https://api.digitalocean.com/v2/registry/%s/repositories/%s/tags?page=2", testRegistry, testRepository),
-			Last: fmt.Sprintf("https://api.digitalocean.com/v2/registry/%s/repositories/%s/tags?page=2", testRegistry, testRepository),
+			Next: fmt.Sprintf("https://api.digitalocean.com/v2/registry/%s/repositories/%s/tags?page=2", testRegistry, testEncodedRepository),
+			Last: fmt.Sprintf("https://api.digitalocean.com/v2/registry/%s/repositories/%s/tags?page=2", testRegistry, testEncodedRepository),
 		},
 	}
 	assert.Equal(t, wantRespLinks, gotRespLinks)


### PR DESCRIPTION
It's legal for image repositories to have `/` characters in their names. Our API handles this by allowing for URL-encoded repository names - i.e., to fetch tags for a repository called `bar/baz` in registry `foo` you make a request to `/v2/registry/foo/repositories/bar%2Fbaz/tags`.