### PR TITLE
Prep v1.39.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v1.39.0] - 2020-07-14
+
+- #345, #346 Add app platform support [beta] - @nanzhong
+
 ## [v1.38.0] - 2020-06-18
 
 - #341 Install 1-click applications on a Kubernetes cluster - @keladhruv

--- a/godo.go
+++ b/godo.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.38.0"
+	libraryVersion = "1.39.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"


### PR DESCRIPTION
I'd like to get a new release out so that I can reference the app platform support in a digitalocean/doctl PR that adds support for it.

I've followed the steps outlined @ https://github.com/digitalocean/godo/blob/main/CONTRIBUTING.md#releasing.