### PR TITLE
reuse same TCP connection

### DIFF
--- a/godo.go
+++ b/godo.go
@@ -334,6 +334,18 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*Res
 	}
 
 	defer func() {
+		// Ensure the response body is fully read and closed
+		// before we reconnect, so that we reuse the same TCPconnection.
+		// Close the previous response's body. But
+		// read at least some of the body so if it's
+		// small the underlying TCP connection will be
+		// re-used. No need to check for errors: if it
+		// fails, the Transport won't reuse it anyway.
+		const maxBodySlurpSize = 2 << 10
+		if resp.ContentLength == -1 || resp.ContentLength <= maxBodySlurpSize {
+			io.CopyN(ioutil.Discard, resp.Body, maxBodySlurpSize)
+		}
+
 		if rerr := resp.Body.Close(); err == nil {
 			err = rerr
 		}


### PR DESCRIPTION
Ensure the response body is fully read and closed before we reconnect so that we reuse the same TCP connection.