### PR TITLE
Reuse TCP Connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v1.40.0] - 2020-07-15
+
+- #352, #351 Reuse underlying TCP connection - @itsksaurabh
+
 ## [v1.39.0] - 2020-07-14
 
 - #345, #346 Add app platform support [beta] - @nanzhong

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Change Log
 
-## [v1.40.0] - 2020-07-15
-
-- #352, #351 Reuse underlying TCP connection - @itsksaurabh
-
 ## [v1.39.0] - 2020-07-14
 
 - #345, #346 Add app platform support [beta] - @nanzhong

--- a/godo.go
+++ b/godo.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.40.0"
+	libraryVersion = "1.39.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/godo.go
+++ b/godo.go
@@ -336,11 +336,10 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*Res
 	defer func() {
 		// Ensure the response body is fully read and closed
 		// before we reconnect, so that we reuse the same TCPconnection.
-		// Close the previous response's body. But
-		// read at least some of the body so if it's
-		// small the underlying TCP connection will be
-		// re-used. No need to check for errors: if it
-		// fails, the Transport won't reuse it anyway.
+		// Close the previous response's body. But read at least some of
+		// the body so if it's small the underlying TCP connection will be
+		// re-used. No need to check for errors: if it fails, the Transport
+		// won't reuse it anyway.
 		const maxBodySlurpSize = 2 << 10
 		if resp.ContentLength == -1 || resp.ContentLength <= maxBodySlurpSize {
 			io.CopyN(ioutil.Discard, resp.Body, maxBodySlurpSize)

--- a/godo.go
+++ b/godo.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.39.0"
+	libraryVersion = "1.40.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"


### PR DESCRIPTION
Ensure the response body is fully read and closed before we reconnect to reuse the same underlying TCP connection.
https://golang.org/pkg/net/http/#Body

    // The http Client and Transport guarantee that Body is always
    // non-nil, even on responses without a body or responses with
    // a zero-length body. It is the caller's responsibility to
    // close Body. The default HTTP client's Transport may not
    // reuse HTTP/1.x "keep-alive" TCP connections if the Body is
    // not read to completion and closed.
To ensure http.Client connection reuse, I did the following things:

- Read until Response is complete (i.e. ioutil.ReadAll(resp.Body))
- Call Body.Close() ( resp.body.Close makes the connection available for reuse by others using the same http.Client. It doesn’t close the underlying http or tcp connection.)

Closes #351