### PR TITLE
apps: add support for following logs

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -36,7 +36,7 @@ type AppsService interface {
 	ListDeployments(ctx context.Context, appID string, opts *ListOptions) ([]*Deployment, *Response, error)
 	CreateDeployment(ctx context.Context, appID string) (*Deployment, *Response, error)
 
-	GetLogs(ctx context.Context, appID, deploymentID, component string, logType AppLogType) (*AppLogs, *Response, error)
+	GetLogs(ctx context.Context, appID, deploymentID, component string, logType AppLogType, follow bool) (*AppLogs, *Response, error)
 }
 
 // App represents an app.
@@ -263,8 +263,8 @@ func (s *AppsServiceOp) CreateDeployment(ctx context.Context, appID string) (*De
 }
 
 // GetLogs retrieves app logs.
-func (s *AppsServiceOp) GetLogs(ctx context.Context, appID, deploymentID, component string, logType AppLogType) (*AppLogs, *Response, error) {
-	url := fmt.Sprintf("%s/%s/deployments/%s/components/%s/logs?type=%s", appsBasePath, appID, deploymentID, component, logType)
+func (s *AppsServiceOp) GetLogs(ctx context.Context, appID, deploymentID, component string, logType AppLogType, follow bool) (*AppLogs, *Response, error) {
+	url := fmt.Sprintf("%s/%s/deployments/%s/components/%s/logs?type=%s&follow=%t", appsBasePath, appID, deploymentID, component, logType, follow)
 	req, err := s.client.NewRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, nil, err

--- a/apps_test.go
+++ b/apps_test.go
@@ -234,10 +234,13 @@ func TestApps_GetLogs(t *testing.T) {
 	mux.HandleFunc(fmt.Sprintf("/v2/apps/%s/deployments/%s/components/%s/logs", testApp.ID, testDeployment.ID, "service-name"), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 
+		assert.Equal(t, "RUN", r.URL.Query().Get("type"))
+		assert.Equal(t, "true", r.URL.Query().Get("follow"))
+
 		json.NewEncoder(w).Encode(&AppLogs{LiveURL: "https://live.logs.url"})
 	})
 
-	logs, _, err := client.Apps.GetLogs(ctx, testApp.ID, testDeployment.ID, "service-name", AppLogTypeRun)
+	logs, _, err := client.Apps.GetLogs(ctx, testApp.ID, testDeployment.ID, "service-name", AppLogTypeRun, true)
 	require.NoError(t, err)
 	assert.NotEmpty(t, logs.LiveURL)
 }


### PR DESCRIPTION
This adds support for requesting a live log url that follows the logs.