### PR TITLE
domains: Allow for SRV records with port 0.

### DIFF
--- a/domains.go
+++ b/domains.go
@@ -77,7 +77,7 @@ type DomainRecord struct {
 	Name     string `json:"name,omitempty"`
 	Data     string `json:"data,omitempty"`
 	Priority int    `json:"priority"`
-	Port     int    `json:"port,omitempty"`
+	Port     int    `json:"port"`
 	TTL      int    `json:"ttl,omitempty"`
 	Weight   int    `json:"weight"`
 	Flags    int    `json:"flags"`
@@ -90,7 +90,7 @@ type DomainRecordEditRequest struct {
 	Name     string `json:"name,omitempty"`
 	Data     string `json:"data,omitempty"`
 	Priority int    `json:"priority"`
-	Port     int    `json:"port,omitempty"`
+	Port     int    `json:"port"`
 	TTL      int    `json:"ttl,omitempty"`
 	Weight   int    `json:"weight"`
 	Flags    int    `json:"flags"`


### PR DESCRIPTION
According to [RFC 2782](https://tools.ietf.org/html/rfc2782), 0 is valid value for port in an SRV reccord:

> The port on this target host of this service. The range is 0-65535.

We currently have `omitempty` set for it which cause 0 to be discarded. Attempting to create a record with 0 for the port results in a 422 error with:

```
POST https://api.digitalocean.com/v2/domains/foobar-test-terraform-jg0j77x3ee.com/records: 422 Port is not a number and Port Port must be an integer between 0 and 65535
```

This is required for https://github.com/digitalocean/terraform-provider-digitalocean/issues/475