### PR TITLE
update apps types to latest

### DIFF
--- a/apps.gen.go
+++ b/apps.gen.go
@@ -3,7 +3,24 @@
 
 package godo
 
-import ()
+import (
+	"time"
+)
+
+// App An application's configuration and status.
+type App struct {
+	ID                      string      `json:"id,omitempty"`
+	OwnerUUID               string      `json:"owner_uuid,omitempty"`
+	Spec                    *AppSpec    `json:"spec"`
+	DefaultIngress          string      `json:"default_ingress,omitempty"`
+	CreatedAt               time.Time   `json:"created_at,omitempty"`
+	UpdatedAt               time.Time   `json:"updated_at,omitempty"`
+	ActiveDeployment        *Deployment `json:"active_deployment,omitempty"`
+	InProgressDeployment    *Deployment `json:"in_progress_deployment,omitempty"`
+	LastDeploymentCreatedAt time.Time   `json:"last_deployment_created_at,omitempty"`
+	LiveURL                 string      `json:"live_url,omitempty"`
+	Region                  *AppRegion  `json:"region,omitempty"`
+}
 
 // AppDatabaseSpec struct for AppDatabaseSpec
 type AppDatabaseSpec struct {
@@ -30,10 +47,10 @@ type AppDatabaseSpecEngine string
 
 // List of AppDatabaseSpecEngine
 const (
-	APPDATABASESPECENGINE_UNSET AppDatabaseSpecEngine = "UNSET"
-	APPDATABASESPECENGINE_MYSQL AppDatabaseSpecEngine = "MYSQL"
-	APPDATABASESPECENGINE_PG    AppDatabaseSpecEngine = "PG"
-	APPDATABASESPECENGINE_REDIS AppDatabaseSpecEngine = "REDIS"
+	AppDatabaseSpecEngine_Unset AppDatabaseSpecEngine = "UNSET"
+	AppDatabaseSpecEngine_MySQL AppDatabaseSpecEngine = "MYSQL"
+	AppDatabaseSpecEngine_PG    AppDatabaseSpecEngine = "PG"
+	AppDatabaseSpecEngine_Redis AppDatabaseSpecEngine = "REDIS"
 )
 
 // AppDomainSpec struct for AppDomainSpec
@@ -48,10 +65,10 @@ type AppDomainSpecType string
 
 // List of AppDomainSpecType
 const (
-	APPDOMAINSPECTYPE_UNSPECIFIED AppDomainSpecType = "UNSPECIFIED"
-	APPDOMAINSPECTYPE_DEFAULT     AppDomainSpecType = "DEFAULT"
-	APPDOMAINSPECTYPE_PRIMARY     AppDomainSpecType = "PRIMARY"
-	APPDOMAINSPECTYPE_ALIAS       AppDomainSpecType = "ALIAS"
+	AppDomainSpecType_Unspecified AppDomainSpecType = "UNSPECIFIED"
+	AppDomainSpecType_Default     AppDomainSpecType = "DEFAULT"
+	AppDomainSpecType_Primary     AppDomainSpecType = "PRIMARY"
+	AppDomainSpecType_Alias       AppDomainSpecType = "ALIAS"
 )
 
 // AppJobSpec struct for AppJobSpec
@@ -180,8 +197,8 @@ type AppVariableDefinition struct {
 	Key string `json:"key"`
 	// The value. If the type is SECRET, the value will be encrypted on first submission. On following submissions, the encrypted value must be used.
 	Value string        `json:"value,omitempty"`
-	Scope VariableScope `json:"scope,omitempty"`
-	Type  VariableType  `json:"type,omitempty"`
+	Scope AppVariableScope `json:"scope,omitempty"`
+	Type  AppVariableType  `json:"type,omitempty"`
 }
 
 // AppWorkerSpec struct for AppWorkerSpec
@@ -207,6 +224,74 @@ type AppWorkerSpec struct {
 	InstanceCount    int64  `json:"instance_count,omitempty"`
 }
 
+// Deployment struct for Deployment
+type Deployment struct {
+	ID                 string                  `json:"id,omitempty"`
+	Spec               *AppSpec                `json:"spec,omitempty"`
+	Services           []*DeploymentService    `json:"services,omitempty"`
+	StaticSites        []*DeploymentStaticSite `json:"static_sites,omitempty"`
+	Workers            []*DeploymentWorker     `json:"workers,omitempty"`
+	Jobs               []*DeploymentJob        `json:"jobs,omitempty"`
+	PhaseLastUpdatedAt time.Time               `json:"phase_last_updated_at,omitempty"`
+	CreatedAt          time.Time               `json:"created_at,omitempty"`
+	UpdatedAt          time.Time               `json:"updated_at,omitempty"`
+	Cause              string                  `json:"cause,omitempty"`
+	ClonedFrom         string                  `json:"cloned_from,omitempty"`
+	Progress           *DeploymentProgress     `json:"progress,omitempty"`
+	Phase              DeploymentPhase         `json:"phase,omitempty"`
+}
+
+// DeploymentJob struct for DeploymentJob
+type DeploymentJob struct {
+	Name             string `json:"name,omitempty"`
+	SourceCommitHash string `json:"source_commit_hash,omitempty"`
+}
+
+// DeploymentPhase the model 'DeploymentPhase'
+type DeploymentPhase string
+
+// List of DeploymentPhase
+const (
+	DeploymentPhase_Unknown       DeploymentPhase = "UNKNOWN"
+	DeploymentPhase_PendingBuild  DeploymentPhase = "PENDING_BUILD"
+	DeploymentPhase_Building      DeploymentPhase = "BUILDING"
+	DeploymentPhase_PendingDeploy DeploymentPhase = "PENDING_DEPLOY"
+	DeploymentPhase_Deploying     DeploymentPhase = "DEPLOYING"
+	DeploymentPhase_Active        DeploymentPhase = "ACTIVE"
+	DeploymentPhase_Superseded    DeploymentPhase = "SUPERSEDED"
+	DeploymentPhase_Error         DeploymentPhase = "ERROR"
+	DeploymentPhase_Canceled      DeploymentPhase = "CANCELED"
+)
+
+// DeploymentProgress struct for DeploymentProgress
+type DeploymentProgress struct {
+	PendingSteps int32           `json:"pending_steps,omitempty"`
+	RunningSteps int32           `json:"running_steps,omitempty"`
+	SuccessSteps int32           `json:"success_steps,omitempty"`
+	ErrorSteps   int32           `json:"error_steps,omitempty"`
+	TotalSteps   int32           `json:"total_steps,omitempty"`
+	Steps        []*DeploymentProgressStep `json:"steps,omitempty"`
+	SummarySteps []*DeploymentProgressStep `json:"summary_steps,omitempty"`
+}
+
+// DeploymentService struct for DeploymentService
+type DeploymentService struct {
+	Name             string `json:"name,omitempty"`
+	SourceCommitHash string `json:"source_commit_hash,omitempty"`
+}
+
+// DeploymentStaticSite struct for DeploymentStaticSite
+type DeploymentStaticSite struct {
+	Name             string `json:"name,omitempty"`
+	SourceCommitHash string `json:"source_commit_hash,omitempty"`
+}
+
+// DeploymentWorker struct for DeploymentWorker
+type DeploymentWorker struct {
+	Name             string `json:"name,omitempty"`
+	SourceCommitHash string `json:"source_commit_hash,omitempty"`
+}
+
 // GitHubSourceSpec struct for GitHubSourceSpec
 type GitHubSourceSpec struct {
 	Repo         string `json:"repo,omitempty"`
@@ -216,28 +301,68 @@ type GitHubSourceSpec struct {
 
 // GitSourceSpec struct for GitSourceSpec
 type GitSourceSpec struct {
-	Repo         string `json:"repo,omitempty"`
-	RequiresAuth bool   `json:"requires_auth,omitempty"`
 	RepoCloneURL string `json:"repo_clone_url,omitempty"`
 	Branch       string `json:"branch,omitempty"`
 }
 
-// VariableScope the model 'VariableScope'
-type VariableScope string
+// DeploymentProgressStep struct for DeploymentProgressStep
+type DeploymentProgressStep struct {
+	Name          string             `json:"name,omitempty"`
+	Status        DeploymentProgressStepStatus `json:"status,omitempty"`
+	Steps         []*DeploymentProgressStep    `json:"steps,omitempty"`
+	StartedAt     time.Time          `json:"started_at,omitempty"`
+	EndedAt       time.Time          `json:"ended_at,omitempty"`
+	Reason        *DeploymentProgressStepReason        `json:"reason,omitempty"`
+	ComponentName string             `json:"component_name,omitempty"`
+	// The base of a human-readable description of the step intended to be combined with the component name for presentation. For example:  message_base = \"Building service\" component_name = \"api\"
+	MessageBase string `json:"message_base,omitempty"`
+}
 
-// List of VariableScope
+// DeploymentProgressStepStatus the model 'DeploymentProgressStepStatus'
+type DeploymentProgressStepStatus string
+
+// List of DeploymentProgressStepStatus
 const (
-	VARIABLESCOPE_UNSET              VariableScope = "UNSET"
-	VARIABLESCOPE_RUN_TIME           VariableScope = "RUN_TIME"
-	VARIABLESCOPE_BUILD_TIME         VariableScope = "BUILD_TIME"
-	VARIABLESCOPE_RUN_AND_BUILD_TIME VariableScope = "RUN_AND_BUILD_TIME"
+	DeploymentProgressStepStatus_Unknown DeploymentProgressStepStatus = "UNKNOWN"
+	DeploymentProgressStepStatus_Pending DeploymentProgressStepStatus = "PENDING"
+	DeploymentProgressStepStatus_Running DeploymentProgressStepStatus = "RUNNING"
+	DeploymentProgressStepStatus_Error   DeploymentProgressStepStatus = "ERROR"
+	DeploymentProgressStepStatus_Success DeploymentProgressStepStatus = "SUCCESS"
 )
 
-// VariableType the model 'VariableType'
-type VariableType string
+// AppRegion struct for AppRegion
+type AppRegion struct {
+	Slug        string   `json:"slug,omitempty"`
+	Label       string   `json:"label,omitempty"`
+	Flag        string   `json:"flag,omitempty"`
+	Continent   string   `json:"continent,omitempty"`
+	Disabled    bool     `json:"disabled,omitempty"`
+	DataCenters []string `json:"data_centers,omitempty"`
+	Reason      string   `json:"reason,omitempty"`
+}
 
-// List of VariableType
+// DeploymentProgressStepReason struct for DeploymentProgressStepReason
+type DeploymentProgressStepReason struct {
+	Code    string `json:"code,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+// AppVariableScope the model 'AppVariableScope'
+type AppVariableScope string
+
+// List of AppVariableScope
 const (
-	VARIABLETYPE_GENERAL VariableType = "GENERAL"
-	VARIABLETYPE_SECRET  VariableType = "SECRET"
+	AppVariableScope_Unset           AppVariableScope = "UNSET"
+	AppVariableScope_RunTime         AppVariableScope = "RUN_TIME"
+	AppVariableScope_BuildTime       AppVariableScope = "BUILD_TIME"
+	AppVariableScope_RunAndBuildTime AppVariableScope = "RUN_AND_BUILD_TIME"
+)
+
+// AppVariableType the model 'AppVariableType'
+type AppVariableType string
+
+// List of AppVariableType
+const (
+	AppVariableType_General AppVariableType = "GENERAL"
+	AppVariableType_Secret  AppVariableType = "SECRET"
 )

--- a/apps.go
+++ b/apps.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"time"
 )
 
 const (
@@ -37,78 +36,6 @@ type AppsService interface {
 	CreateDeployment(ctx context.Context, appID string) (*Deployment, *Response, error)
 
 	GetLogs(ctx context.Context, appID, deploymentID, component string, logType AppLogType, follow bool) (*AppLogs, *Response, error)
-}
-
-// App represents an app.
-type App struct {
-	ID                   string      `json:"id"`
-	Spec                 *AppSpec    `json:"spec"`
-	DefaultIngress       string      `json:"default_ingress"`
-	CreatedAt            time.Time   `json:"created_at"`
-	UpdatedAt            time.Time   `json:"updated_at,omitempty"`
-	ActiveDeployment     *Deployment `json:"active_deployment,omitempty"`
-	InProgressDeployment *Deployment `json:"in_progress_deployment,omitempty"`
-}
-
-// Deployment represents a deployment for an app.
-type Deployment struct {
-	ID          string                  `json:"id"`
-	Spec        *AppSpec                `json:"spec"`
-	Services    []*DeploymentService    `json:"services,omitempty"`
-	Workers     []*DeploymentWorker     `json:"workers,omitempty"`
-	StaticSites []*DeploymentStaticSite `json:"static_sites,omitempty"`
-	Jobs        []*DeploymentJob        `json:"jobs,omitempty"`
-
-	Cause    string              `json:"cause"`
-	Progress *DeploymentProgress `json:"progress"`
-
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
-}
-
-// DeploymentService represents a service component in a deployment.
-type DeploymentService struct {
-	Name             string `json:"name,omitempty"`
-	SourceCommitHash string `json:"source_commit_hash"`
-}
-
-// DeploymentWorker represents a worker component in a deployment.
-type DeploymentWorker struct {
-	Name             string `json:"name,omitempty"`
-	SourceCommitHash string `json:"source_commit_hash"`
-}
-
-// DeploymentStaticSite represents a static site component in a deployment.
-type DeploymentStaticSite struct {
-	Name             string `json:"name,omitempty"`
-	SourceCommitHash string `json:"source_commit_hash"`
-}
-
-// DeploymentJob represents a job component in a deployment.
-type DeploymentJob struct {
-	Name             string `json:"name,omitempty"`
-	SourceCommitHash string `json:"source_commit_hash"`
-}
-
-// DeploymentProgress represents the total progress of a deployment.
-type DeploymentProgress struct {
-	PendingSteps int `json:"pending_steps"`
-	RunningSteps int `json:"running_steps"`
-	SuccessSteps int `json:"success_steps"`
-	ErrorSteps   int `json:"error_steps"`
-	TotalSteps   int `json:"total_steps"`
-
-	Steps []*DeploymentProgressStep `json:"steps"`
-}
-
-// DeploymentProgressStep represents the progress of a deployment step.
-type DeploymentProgressStep struct {
-	Name      string                    `json:"name"`
-	Status    string                    `json:"status"`
-	Steps     []*DeploymentProgressStep `json:"steps,omitempty"`
-	Attempts  uint32                    `json:"attempts"`
-	StartedAt time.Time                 `json:"started_at,omitempty"`
-	EndedAt   time.Time                 `json:"ended_at,omitempty"`
 }
 
 // AppLogs represent app logs.

--- a/apps_test.go
+++ b/apps_test.go
@@ -66,7 +66,7 @@ var (
 		}},
 		Databases: []*AppDatabaseSpec{{
 			Name:        "db",
-			Engine:      APPDATABASESPECENGINE_MYSQL,
+			Engine:      AppDatabaseSpecEngine_MySQL,
 			Version:     "8",
 			Size:        "size",
 			NumNodes:    1,
@@ -75,9 +75,12 @@ var (
 			DBName:      "app",
 			DBUser:      "appuser",
 		}},
-		Domains: []*AppDomainSpec{{
-			Domain: "example.com",
-		}},
+		Domains: []*AppDomainSpec{
+			{
+				Domain: "example.com",
+				Type:   AppDomainSpecType_Primary,
+			},
+		},
 	}
 
 	testDeployment = Deployment{
@@ -99,16 +102,47 @@ var (
 			Name:             "job-name",
 			SourceCommitHash: "job-hash",
 		}},
+		CreatedAt:          time.Unix(1595959200, 0).UTC(),
+		UpdatedAt:          time.Unix(1595959200, 0).UTC(),
+		PhaseLastUpdatedAt: time.Unix(1595959200, 0).UTC(),
+		Phase:              DeploymentPhase_Active,
+		Progress: &DeploymentProgress{
+			SuccessSteps: 1,
+			TotalSteps:   1,
+			Steps: []*DeploymentProgressStep{{
+				Name:      "step",
+				Status:    DeploymentProgressStepStatus_Success,
+				StartedAt: time.Unix(1595959200, 0).UTC(),
+				EndedAt:   time.Unix(1595959200, 0).UTC(),
+				Steps: []*DeploymentProgressStep{{
+					Name:      "sub",
+					Status:    DeploymentProgressStepStatus_Success,
+					StartedAt: time.Unix(1595959200, 0).UTC(),
+					EndedAt:   time.Unix(1595959200, 0).UTC(),
+				}},
+			}},
+		},
 	}
 
 	testApp = App{
-		ID:                   "1c70f8f3-106e-428b-ae6d-bfc693c77536",
-		Spec:                 testAppSpec,
-		DefaultIngress:       "test.ingress.com",
-		ActiveDeployment:     &testDeployment,
-		InProgressDeployment: &testDeployment,
-		CreatedAt:            time.Unix(1, 0).UTC(),
-		UpdatedAt:            time.Unix(1, 0).UTC(),
+		ID:                      "1c70f8f3-106e-428b-ae6d-bfc693c77536",
+		Spec:                    testAppSpec,
+		DefaultIngress:          "example.com",
+		LiveURL:                 "https://example.com",
+		ActiveDeployment:        &testDeployment,
+		InProgressDeployment:    &testDeployment,
+		LastDeploymentCreatedAt: time.Unix(1595959200, 0).UTC(),
+		CreatedAt:               time.Unix(1595959200, 0).UTC(),
+		UpdatedAt:               time.Unix(1595959200, 0).UTC(),
+		Region: &AppRegion{
+			Slug:        "ams",
+			Label:       "Amsterdam",
+			Continent:   "Europe",
+			Disabled:    true,
+			Reason:      "Scheduled maintenance",
+			DataCenters: []string{"ams3"},
+			Flag:        "nl",
+		},
 	}
 )
 


### PR DESCRIPTION
⚠️ This is a breaking change.

Update the apps types to the latest version, replace some of the hand-written ones with autogenerated types that include the latest fields.

Rename constants to align more closely with Go conventions (e.g. `DeploymentPhase_PendingBuild` instead of `DEPLOYMENTPHASE_PENDING_BUILD`)

I haven't merged this PR's counterpart on our end yet—I'd be happy to make any changes.