### PR TITLE
Fix bug in rate limit race test

### DIFF
--- a/godo_test.go
+++ b/godo_test.go
@@ -402,7 +402,7 @@ func TestDo_rateLimitRace(t *testing.T) {
 			req, _ := client.NewRequest(ctx, http.MethodGet, "/", nil)
 			_, err := client.Do(context.Background(), req, nil)
 			if err != nil {
-				t.Fatalf("Do(): %v", err)
+				t.Errorf("Do(): %v", err)
 			}
 			wg.Done()
 		}()


### PR DESCRIPTION
According to the Go testing package documentation FailNow must be called
from the goroutine running the test, not from other goroutines created
during the test.
A simple error without fatal seems to be sufficient for this test.