### PR TITLE
load balancers: add new size slug field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+- #373 load balancers: add LB size field, currently in closed beta - @anitgandhi
+
 ## [v1.45.0] - 2020-09-25
 
 **Note**: This release contains breaking changes to App Platform features currently in closed beta.

--- a/load_balancers.go
+++ b/load_balancers.go
@@ -31,6 +31,7 @@ type LoadBalancer struct {
 	ID                     string           `json:"id,omitempty"`
 	Name                   string           `json:"name,omitempty"`
 	IP                     string           `json:"ip,omitempty"`
+	SizeSlug               string           `json:"size,omitempty"`
 	Algorithm              string           `json:"algorithm,omitempty"`
 	Status                 string           `json:"status,omitempty"`
 	Created                string           `json:"created_at,omitempty"`
@@ -62,6 +63,7 @@ func (l LoadBalancer) AsRequest() *LoadBalancerRequest {
 	r := LoadBalancerRequest{
 		Name:                   l.Name,
 		Algorithm:              l.Algorithm,
+		SizeSlug:               l.SizeSlug,
 		ForwardingRules:        append([]ForwardingRule(nil), l.ForwardingRules...),
 		DropletIDs:             append([]int(nil), l.DropletIDs...),
 		Tag:                    l.Tag,
@@ -134,6 +136,7 @@ type LoadBalancerRequest struct {
 	Name                   string           `json:"name,omitempty"`
 	Algorithm              string           `json:"algorithm,omitempty"`
 	Region                 string           `json:"region,omitempty"`
+	SizeSlug               string           `json:"size,omitempty"`
 	ForwardingRules        []ForwardingRule `json:"forwarding_rules,omitempty"`
 	HealthCheck            *HealthCheck     `json:"health_check,omitempty"`
 	StickySessions         *StickySessions  `json:"sticky_sessions,omitempty"`

--- a/load_balancers_test.go
+++ b/load_balancers_test.go
@@ -809,6 +809,7 @@ func TestLoadBalancers_AsRequest(t *testing.T) {
 		ID:        "37e6be88-01ec-4ec7-9bc6-a514d4719057",
 		Name:      "test-loadbalancer",
 		IP:        "10.0.0.1",
+		SizeSlug:  "lb-small",
 		Algorithm: "least_connections",
 		Status:    "active",
 		Created:   "2011-06-24T12:00:00Z",
@@ -848,6 +849,7 @@ func TestLoadBalancers_AsRequest(t *testing.T) {
 		Name:      "test-loadbalancer",
 		Algorithm: "least_connections",
 		Region:    "lon1",
+		SizeSlug:  "lb-small",
 		ForwardingRules: []ForwardingRule{ForwardingRule{
 			EntryProtocol:  "http",
 			EntryPort:      80,


### PR DESCRIPTION
## Changes

This adds a new field for Load Balancers called `SizeSlug`. This feature is not released/generally available yet. 

I tried to follow the same pattern as other products w.r.t naming the field `Size` vs `SizeSlug`, etc. 

When this field is not present/empty, default behavior is maintained on the backend, just like all the other fields for Load Balancers (algorithm, health check, etc)

## Notes

Internal ticket number: LBAAS-1582

A release will be required for this, as I will be opening doctl, doccm, and the terraform provider. 