### PR TITLE
kubernetes - change docr integration api routes

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -774,7 +774,7 @@ func (svc *KubernetesServiceOp) GetOptions(ctx context.Context) (*KubernetesOpti
 
 // AddRegistry integrates docr registry with all the specified clusters
 func (svc *KubernetesServiceOp) AddRegistry(ctx context.Context, req *KubernetesClusterRegistryRequest) (*Response, error) {
-	path := fmt.Sprintf("%s/registry", kubernetesClustersPath)
+	path := fmt.Sprintf("%s/registry", kubernetesBasePath)
 	request, err := svc.client.NewRequest(ctx, http.MethodPost, path, req)
 	if err != nil {
 		return nil, err
@@ -788,7 +788,7 @@ func (svc *KubernetesServiceOp) AddRegistry(ctx context.Context, req *Kubernetes
 
 // RemoveRegistry removes docr registry support for all the specified clusters
 func (svc *KubernetesServiceOp) RemoveRegistry(ctx context.Context, req *KubernetesClusterRegistryRequest) (*Response, error) {
-	path := fmt.Sprintf("%s/registry", kubernetesClustersPath)
+	path := fmt.Sprintf("%s/registry", kubernetesBasePath)
 	request, err := svc.client.NewRequest(ctx, http.MethodDelete, path, req)
 	if err != nil {
 		return nil, err

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -1512,7 +1512,7 @@ func TestKubernetesClusterRegistry_Add(t *testing.T) {
 	"cluster_uuids": ["8d91899c-0739-4a1a-acc5-deadbeefbb8f"]
 }`
 
-	mux.HandleFunc("/v2/kubernetes/clusters/registry", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/v2/kubernetes/registry", func(w http.ResponseWriter, r *http.Request) {
 		v := new(KubernetesClusterRegistryRequest)
 		err := json.NewDecoder(r.Body).Decode(v)
 		if err != nil {
@@ -1543,7 +1543,7 @@ func TestKubernetesClusterRegistry_Remove(t *testing.T) {
 	"cluster_uuids": ["8d91899c-0739-4a1a-acc5-deadbeefbb8f"]
 }`
 
-	mux.HandleFunc("/v2/kubernetes/clusters/registry", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/v2/kubernetes/registry", func(w http.ResponseWriter, r *http.Request) {
 		v := new(KubernetesClusterRegistryRequest)
 		err := json.NewDecoder(r.Body).Decode(v)
 		if err != nil {


### PR DESCRIPTION
@andrewsomething - we decided to change routes for the docr integration APIs. Sorry about the inconvenience. 