### PR TITLE
Add gofmt to CI GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,8 @@ jobs:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
       uses: actions/checkout@v2
+    - name: Format
+      run: if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then exit 1; fi
+      if: matrix.os == 'ubuntu-latest'
     - name: Test
       run: go test -race ./...


### PR DESCRIPTION
Closes #393 

This PR adds `gofmt` to CI GitHub Action. Running `gofmt -s -w ./` locally applied no changes so code should already be `gofmt`-compliant.