### PR TITLE
VPC: adds option to set a VPC as the regional default

### DIFF
--- a/vpcs.go
+++ b/vpcs.go
@@ -39,6 +39,7 @@ type VPCCreateRequest struct {
 type VPCUpdateRequest struct {
 	Name        string `json:"name,omitempty"`
 	Description string `json:"description,omitempty"`
+	Default     *bool  `json:"default,omitempty"`
 }
 
 // VPCSetField allows one to set individual fields within a VPC configuration.
@@ -53,6 +54,16 @@ type VPCSetName string
 // VPCSetDescription is used when one want to set the `description` field of a VPC.
 // Ex.: VPCs.Set(..., VPCSetDescription("vpc description"))
 type VPCSetDescription string
+
+// VPCSetDefault is used when one wants to enable the `default` field of a VPC, to
+// set a VPC as the default one in the region
+// Ex.: VPCs.Set(..., VPCSetDefault())
+func VPCSetDefault() VPCSetField {
+	return &vpcSetDefault{}
+}
+
+// vpcSetDefault satisfies the VPCSetField interface
+type vpcSetDefault struct{}
 
 // VPC represents a DigitalOcean Virtual Private Cloud configuration.
 type VPC struct {
@@ -159,6 +170,10 @@ func (n VPCSetName) vpcSetField(in map[string]interface{}) {
 
 func (n VPCSetDescription) vpcSetField(in map[string]interface{}) {
 	in["description"] = n
+}
+
+func (*vpcSetDefault) vpcSetField(in map[string]interface{}) {
+	in["default"] = true
 }
 
 // Set updates specific properties of a Virtual Private Cloud.

--- a/vpcs_test.go
+++ b/vpcs_test.go
@@ -1,9 +1,11 @@
 package godo
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -176,46 +178,76 @@ func TestVPCs_Update(t *testing.T) {
 }
 
 func TestVPCs_Set(t *testing.T) {
-	setup()
-	defer teardown()
 
-	type setRequest struct {
-		Name        string `json:"name"`
-		Description string `json:"description"`
+	tests := []struct {
+		desc                string
+		id                  string
+		updateFields        []VPCSetField
+		mockResponse        string
+		expectedRequestBody string
+		expectedUpdatedVPC  *VPC
+	}{
+		{
+			desc: "setting name and description",
+			id:   "880b7f98-f062-404d-b33c-458d545696f6",
+			updateFields: []VPCSetField{
+				VPCSetName("my-new-vpc"),
+				VPCSetDescription("vpc description"),
+			},
+			mockResponse: `
+			{
+			  "vpc":
+			` + vTestJSON + `
+			}
+			`,
+			expectedRequestBody: `{"description":"vpc description","name":"my-new-vpc"}`,
+			expectedUpdatedVPC:  vTestObj,
+		},
+
+		{
+			desc: "setting the default vpc option",
+			id:   "880b7f98-f062-404d-b33c-458d545696f6",
+			updateFields: []VPCSetField{
+				VPCSetName("my-new-vpc"),
+				VPCSetDescription("vpc description"),
+				VPCSetDefault(),
+			},
+			mockResponse: `
+			{
+			  "vpc":
+			` + vTestJSON + `
+			}
+			`,
+			expectedRequestBody: `{"default":true,"description":"vpc description","name":"my-new-vpc"}`,
+			expectedUpdatedVPC:  vTestObj,
+		},
 	}
 
-	svc := client.VPCs
-	path := "/v2/vpcs"
-	want := vTestObj
-	id := "880b7f98-f062-404d-b33c-458d545696f6"
-	name := "my-new-vpc"
-	desc := "vpc description"
-	req := &setRequest{
-		Name:        name,
-		Description: desc,
+	for _, tt := range tests {
+		setup()
+
+		mux.HandleFunc("/v2/vpcs/"+tt.id, func(w http.ResponseWriter, r *http.Request) {
+			buf := new(bytes.Buffer)
+			buf.ReadFrom(r.Body)
+			require.Equal(t, tt.expectedRequestBody, strings.TrimSpace(buf.String()))
+
+			v := new(VPCUpdateRequest)
+			err := json.NewDecoder(buf).Decode(v)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			testMethod(t, r, http.MethodPatch)
+			fmt.Fprint(w, tt.mockResponse)
+		})
+
+		got, _, err := client.VPCs.Set(ctx, tt.id, tt.updateFields...)
+
+		teardown()
+
+		require.NoError(t, err)
+		require.Equal(t, tt.expectedUpdatedVPC, got)
 	}
-	jsonBlob := `
-{
-  "vpc":
-` + vTestJSON + `
-}
-`
-
-	mux.HandleFunc(path+"/"+id, func(w http.ResponseWriter, r *http.Request) {
-		c := new(setRequest)
-		err := json.NewDecoder(r.Body).Decode(c)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		testMethod(t, r, http.MethodPatch)
-		require.Equal(t, c, req)
-		fmt.Fprint(w, jsonBlob)
-	})
-
-	got, _, err := svc.Set(ctx, id, VPCSetName(name), VPCSetDescription(desc))
-	require.NoError(t, err)
-	require.Equal(t, want, got)
 }
 
 func TestVPCs_Delete(t *testing.T) {


### PR DESCRIPTION
Adds the `VPCSetDefault()` option, that can be passed in to the `Set` method to set the subject VPC to be a default VPC.

1.) The new `VPCSetDefault ` this PR introduces option only supports setting the `default` boolean value to `true` in the request body, since setting it to `false` is meaningless. Each region must have a default VPC, and un-defaulting a default VPC is an illegal op - the API returns a `403` in this case. 

2.) I changed the style of test significantly for this method, the previous implementation didn't quite test the request body, and the test of the unmarshalled request object seemed redundant.  If this looks good, I can change the other VPC tests to follow a similar approach.

 