### PR TITLE
registry: Support subscription options

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -45,7 +45,8 @@ type RegistryServiceOp struct {
 
 // RegistryCreateRequest represents a request to create a registry.
 type RegistryCreateRequest struct {
-	Name string `json:"name,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	SubscriptionTierSlug string `json:"subscription_tier_slug,omitempty"`
 }
 
 // RegistryDockerCredentialsRequest represents a request to retrieve docker

--- a/registry.go
+++ b/registry.go
@@ -33,6 +33,7 @@ type RegistryService interface {
 	ListGarbageCollections(context.Context, string, *ListOptions) ([]*GarbageCollection, *Response, error)
 	UpdateGarbageCollection(context.Context, string, string, *UpdateGarbageCollectionRequest) (*GarbageCollection, *Response, error)
 	GetOptions(context.Context) (*RegistryOptions, *Response, error)
+	GetSubscription(context.Context) (*RegistrySubscription, *Response, error)
 }
 
 var _ RegistryService = &RegistryServiceOp{}
@@ -144,6 +145,17 @@ type RegistrySubscriptionTier struct {
 	// EligibilityReaons is included when Eligible is false, and indicates the
 	// reasons why this tier is not availble to the user.
 	EligibilityReasons []string `json:"eligibility_reasons,omitempty"`
+}
+
+// RegistrySubscription is a user's subscription.
+type RegistrySubscription struct {
+	Tier      *RegistrySubscriptionTier `json:"tier"`
+	CreatedAt time.Time                 `json:"created_at"`
+	UpdatedAt time.Time                 `json:"updated_at"`
+}
+
+type registrySubscriptionRoot struct {
+	Subscription *RegistrySubscription `json:"subscription"`
 }
 
 // Get retrieves the details of a Registry.
@@ -413,4 +425,19 @@ func (svc *RegistryServiceOp) GetOptions(ctx context.Context) (*RegistryOptions,
 	}
 
 	return root.Options, resp, nil
+}
+
+// GetSubscription retrieves the user's subscription.
+func (svc *RegistryServiceOp) GetSubscription(ctx context.Context) (*RegistrySubscription, *Response, error) {
+	path := fmt.Sprintf("%s/subscription", registryPath)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(registrySubscriptionRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Subscription, resp, nil
 }

--- a/registry.go
+++ b/registry.go
@@ -32,6 +32,7 @@ type RegistryService interface {
 	GetGarbageCollection(context.Context, string) (*GarbageCollection, *Response, error)
 	ListGarbageCollections(context.Context, string, *ListOptions) ([]*GarbageCollection, *Response, error)
 	UpdateGarbageCollection(context.Context, string, string, *UpdateGarbageCollectionRequest) (*GarbageCollection, *Response, error)
+	GetOptions(context.Context) (*RegistryOptions, *Response, error)
 }
 
 var _ RegistryService = &RegistryServiceOp{}
@@ -119,6 +120,30 @@ type garbageCollectionsRoot struct {
 // collection.
 type UpdateGarbageCollectionRequest struct {
 	Cancel bool `json:"cancel"`
+}
+
+// RegistryOptions are options for users when creating or updating a registry.
+type RegistryOptions struct {
+	SubscriptionTiers []*RegistrySubscriptionTier `json:"subscription_tiers,omitempty"`
+}
+
+type registryOptionsRoot struct {
+	Options *RegistryOptions `json:"options"`
+}
+
+// RegistrySubscriptionTier is a subscription tier for container registry.
+type RegistrySubscriptionTier struct {
+	Name                   string `json:"name"`
+	Slug                   string `json:"slug"`
+	IncludedRepositories   uint64 `json:"included_repositories"`
+	IncludedStorageBytes   uint64 `json:"included_storage_bytes"`
+	AllowStorageOverage    bool   `json:"allow_storage_overage"`
+	IncludedBandwidthBytes uint64 `json:"included_bandwidth_bytes"`
+	MonthlyPriceInCents    uint64 `json:"monthly_price_in_cents"`
+	Eligible               bool   `json:"eligible,omitempty"`
+	// EligibilityReaons is included when Eligible is false, and indicates the
+	// reasons why this tier is not availble to the user.
+	EligibilityReasons []string `json:"eligibility_reasons,omitempty"`
 }
 
 // Get retrieves the details of a Registry.
@@ -321,7 +346,7 @@ func (svc *RegistryServiceOp) GetGarbageCollection(ctx context.Context, registry
 	return root.GarbageCollection, resp, nil
 }
 
-// ListGarbageCollection retrieves all garbage collections (active and
+// ListGarbageCollections retrieves all garbage collections (active and
 // inactive) for the specified registry.
 func (svc *RegistryServiceOp) ListGarbageCollections(ctx context.Context, registry string, opts *ListOptions) ([]*GarbageCollection, *Response, error) {
 	path := fmt.Sprintf("%s/%s/garbage-collections", registryPath, registry)
@@ -370,4 +395,22 @@ func (svc *RegistryServiceOp) UpdateGarbageCollection(ctx context.Context, regis
 	}
 
 	return root.GarbageCollection, resp, nil
+}
+
+// GetOptions returns options the user can use when creating or updating a
+// registry.
+func (svc *RegistryServiceOp) GetOptions(ctx context.Context) (*RegistryOptions, *Response, error) {
+	path := fmt.Sprintf("%s/options", registryPath)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(registryOptionsRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Options, resp, nil
 }

--- a/registry_test.go
+++ b/registry_test.go
@@ -51,7 +51,8 @@ func TestRegistry_Create(t *testing.T) {
 	}
 
 	createRequest := &RegistryCreateRequest{
-		Name: want.Name,
+		Name:                 want.Name,
+		SubscriptionTierSlug: "basic",
 	}
 
 	createResponseJSON := `
@@ -59,7 +60,20 @@ func TestRegistry_Create(t *testing.T) {
 	"registry": {
 		"name": "` + testRegistry + `",
         "created_at": "` + testTimeString + `"
-	}
+	},
+    "subscription": {
+      "tier": {
+        "name": "Basic",
+        "slug": "basic",
+        "included_repositories": 5,
+        "included_storage_bytes": 5368709120,
+        "allow_storage_overage": true,
+        "included_bandwidth_bytes": 5368709120,
+        "monthly_price_in_cents": 500
+      },
+      "created_at": "` + testTimeString + `",
+      "updated_at": "` + testTimeString + `"
+    }
 }`
 
 	mux.HandleFunc("/v2/registry", func(w http.ResponseWriter, r *http.Request) {

--- a/registry_test.go
+++ b/registry_test.go
@@ -494,3 +494,103 @@ func TestGarbageCollection_Update(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, want, got)
 }
+
+func TestRegistry_GetOptions(t *testing.T) {
+	responseJSON := `
+{
+  "options": {
+    "subscription_tiers": [
+      {
+        "name": "Starter",
+        "slug": "starter",
+        "included_repositories": 1,
+        "included_storage_bytes": 524288000,
+        "allow_storage_overage": false,
+        "included_bandwidth_bytes": 524288000,
+        "monthly_price_in_cents": 0,
+        "eligible": false,
+        "eligibility_reasons": [
+          "OverStorageLimit",
+          "OverRepositoryLimit"
+        ]
+      },
+      {
+        "name": "Basic",
+        "slug": "basic",
+        "included_repositories": 5,
+        "included_storage_bytes": 5368709120,
+        "allow_storage_overage": true,
+        "included_bandwidth_bytes": 5368709120,
+        "monthly_price_in_cents": 500,
+        "eligible": false,
+        "eligibility_reasons": [
+          "OverRepositoryLimit"
+        ]
+      },
+      {
+        "name": "Professional",
+        "slug": "professional",
+        "included_repositories": 0,
+        "included_storage_bytes": 107374182400,
+        "allow_storage_overage": true,
+        "included_bandwidth_bytes": 107374182400,
+        "monthly_price_in_cents": 2000,
+        "eligible": true
+      }
+    ]
+  }
+}`
+	want := &RegistryOptions{
+		SubscriptionTiers: []*RegistrySubscriptionTier{
+			{
+				Name:                   "Starter",
+				Slug:                   "starter",
+				IncludedRepositories:   1,
+				IncludedStorageBytes:   524288000,
+				AllowStorageOverage:    false,
+				IncludedBandwidthBytes: 524288000,
+				MonthlyPriceInCents:    0,
+				Eligible:               false,
+				EligibilityReasons: []string{
+					"OverStorageLimit",
+					"OverRepositoryLimit",
+				},
+			},
+			{
+				Name:                   "Basic",
+				Slug:                   "basic",
+				IncludedRepositories:   5,
+				IncludedStorageBytes:   5368709120,
+				AllowStorageOverage:    true,
+				IncludedBandwidthBytes: 5368709120,
+				MonthlyPriceInCents:    500,
+				Eligible:               false,
+				EligibilityReasons: []string{
+					"OverRepositoryLimit",
+				},
+			},
+			{
+				Name:                   "Professional",
+				Slug:                   "professional",
+				IncludedRepositories:   0,
+				IncludedStorageBytes:   107374182400,
+				AllowStorageOverage:    true,
+				IncludedBandwidthBytes: 107374182400,
+				MonthlyPriceInCents:    2000,
+				Eligible:               true,
+			},
+		},
+	}
+
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/registry/options", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, responseJSON)
+	})
+
+	got, _, err := client.Registry.GetOptions(ctx)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}

--- a/registry_test.go
+++ b/registry_test.go
@@ -594,3 +594,48 @@ func TestRegistry_GetOptions(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, want, got)
 }
+
+func TestRegistry_GetSubscription(t *testing.T) {
+	setup()
+	defer teardown()
+
+	want := &RegistrySubscription{
+		Tier: &RegistrySubscriptionTier{
+			Name:                   "Basic",
+			Slug:                   "basic",
+			IncludedRepositories:   5,
+			IncludedStorageBytes:   5368709120,
+			AllowStorageOverage:    true,
+			IncludedBandwidthBytes: 5368709120,
+			MonthlyPriceInCents:    500,
+		},
+		CreatedAt: testTime,
+		UpdatedAt: testTime,
+	}
+
+	getResponseJSON := `
+{
+  "subscription": {
+    "tier": {
+      "name": "Basic",
+      "slug": "basic",
+      "included_repositories": 5,
+      "included_storage_bytes": 5368709120,
+      "allow_storage_overage": true,
+      "included_bandwidth_bytes": 5368709120,
+      "monthly_price_in_cents": 500
+    },
+    "created_at": "` + testTimeString + `",
+    "updated_at": "` + testTimeString + `"
+  }
+}
+`
+
+	mux.HandleFunc("/v2/registry/subscription", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, getResponseJSON)
+	})
+	got, _, err := client.Registry.GetSubscription(ctx)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}


### PR DESCRIPTION
As of GA, users are now required to specify a subscription tier when creating a registry, and can query their subscription. Add support for this to godo. Later, we'll add support for switching tiers as well.