### PR TITLE
apps: add unspecified type to image source registry types

### DIFF
--- a/apps.gen.go
+++ b/apps.gen.go
@@ -348,12 +348,13 @@ type ImageSourceSpec struct {
 	Tag string `json:"tag,omitempty"`
 }
 
-// ImageSourceSpecRegistryType  - DOCR: The DigitalOcean container registry type.
+// ImageSourceSpecRegistryType  - UNSPECIFIED: Represents an unspecified registry type.  - DOCR: The DigitalOcean container registry type.
 type ImageSourceSpecRegistryType string
 
 // List of ImageSourceSpecRegistryType
 const (
-	ImageSourceSpecRegistryType_DOCR ImageSourceSpecRegistryType = "DOCR"
+	ImageSourceSpecRegistryType_Unspecified ImageSourceSpecRegistryType = "UNSPECIFIED"
+	ImageSourceSpecRegistryType_DOCR        ImageSourceSpecRegistryType = "DOCR"
 )
 
 // AppInstanceSize struct for AppInstanceSize


### PR DESCRIPTION
### Description

#### What does this pull request accomplish

* We updated the proto to add `UNSPECIFIED` as the default enum for registry type.