### PR TITLE
images: Support updating distribution and description.

### DIFF
--- a/images.go
+++ b/images.go
@@ -52,7 +52,9 @@ type Image struct {
 
 // ImageUpdateRequest represents a request to update an image.
 type ImageUpdateRequest struct {
-	Name string `json:"name"`
+	Name         string `json:"name,omitempty"`
+	Distribution string `json:"distribution,omitempty"`
+	Description  string `json:"description,omitempty"`
 }
 
 // CustomImageCreateRequest represents a request to create a custom image.

--- a/images_test.go
+++ b/images_test.go
@@ -353,12 +353,16 @@ func TestImages_Update(t *testing.T) {
 	defer teardown()
 
 	updateRequest := &ImageUpdateRequest{
-		Name: "name",
+		Name:         "name",
+		Distribution: "Fedora",
+		Description:  "Just testing...",
 	}
 
 	mux.HandleFunc("/v2/images/12345", func(w http.ResponseWriter, r *http.Request) {
 		expected := map[string]interface{}{
-			"name": "name",
+			"name":         "name",
+			"distribution": "Fedora",
+			"description":  "Just testing...",
 		}
 
 		var v map[string]interface{}


### PR DESCRIPTION
When reviewing https://github.com/digitalocean/terraform-provider-digitalocean/pull/517, I noticed that godo does not currently support updating an image's distribution or description. The API does: https://developers.digitalocean.com/documentation/v2/#update-an-image