### PR TITLE
Add some basic input cleaning to NewFromToken

### DIFF
--- a/godo.go
+++ b/godo.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"reflect"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -165,8 +166,9 @@ func addOptions(s string, opt interface{}) (string, error) {
 // NewFromToken returns a new DigitalOcean API client with the given API
 // token.
 func NewFromToken(token string) *Client {
+	cleanToken := strings.Trim(strings.TrimSpace(token), "'")
 	ctx := context.Background()
-	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: cleanToken})
 	return NewClient(oauth2.NewClient(ctx, ts))
 }
 


### PR DESCRIPTION
This PR adds some basic input cleaning to `NewFromToken`. I don't think we should be mucking around with an `http.Client` provided by a user, so other approaches to creating a client are not effected. We could potentially add further validation, but that would require adding a `panic`. I think the response from the API should be sufficient in most cases.