### PR TITLE
Prep v1.56.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v1.56.0] - 2021-01-08
+
+- #422 - @kamaln7 - apps: add ProposeApp method
+
 ## [v1.55.0] - 2021-01-07
 
 - #425 - @adamwg - registry: Support the storage usage indicator

--- a/godo.go
+++ b/godo.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.55.0"
+	libraryVersion = "1.56.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"


### PR DESCRIPTION
The changes from https://github.com/digitalocean/godo/pull/422 are needed to support App Platform global env vars in doctl (https://github.com/digitalocean/doctl/issues/934)