### PR TITLE
apps: update proto to support dockerhub registry type

### DIFF
--- a/apps.gen.go
+++ b/apps.gen.go
@@ -437,7 +437,7 @@ type GitSourceSpec struct {
 // ImageSourceSpec struct for ImageSourceSpec
 type ImageSourceSpec struct {
 	RegistryType ImageSourceSpecRegistryType `json:"registry_type,omitempty"`
-	// The registry name. Must be left empty for the `DOCR` registry type.
+	// The registry name. Must be left empty for the `DOCR` registry type. Required for the `DOCKER_HUB` registry type.
 	Registry string `json:"registry,omitempty"`
 	// The repository name.
 	Repository string `json:"repository,omitempty"`
@@ -445,13 +445,14 @@ type ImageSourceSpec struct {
 	Tag string `json:"tag,omitempty"`
 }
 
-// ImageSourceSpecRegistryType  - UNSPECIFIED: Represents an unspecified registry type.  - DOCR: The DigitalOcean container registry type.
+// ImageSourceSpecRegistryType  - DOCR: The DigitalOcean container registry type.  - DOCKER_HUB: The DockerHub container registry type.
 type ImageSourceSpecRegistryType string
 
 // List of ImageSourceSpecRegistryType
 const (
 	ImageSourceSpecRegistryType_Unspecified ImageSourceSpecRegistryType = "UNSPECIFIED"
 	ImageSourceSpecRegistryType_DOCR        ImageSourceSpecRegistryType = "DOCR"
+	ImageSourceSpecRegistryType_DockerHub   ImageSourceSpecRegistryType = "DOCKER_HUB"
 )
 
 // AppInstanceSize struct for AppInstanceSize


### PR DESCRIPTION
### Description

#### What does this pull request accomplish

* Updates apps.gen.go with `DOCKER_HUB` registry type