### PR TITLE
Deprecate Name field in godo.DropletCreateVolume

### DIFF
--- a/droplets.go
+++ b/droplets.go
@@ -177,25 +177,25 @@ func (d DropletCreateImage) MarshalJSON() ([]byte, error) {
 	return json.Marshal(d.ID)
 }
 
-// DropletCreateVolume identifies a volume to attach for the create request. It
-// prefers Name over ID,
+// DropletCreateVolume identifies a volume to attach for the create request.
 type DropletCreateVolume struct {
-	ID   string
+	ID string
+	// Deprecated: You must pass a the volume's ID when creating a Droplet.
 	Name string
 }
 
-// MarshalJSON returns an object with either the name or id of the volume. It
-// returns the id if the name is empty.
+// MarshalJSON returns an object with either the ID or name of the volume. It
+// prefers the ID over the name.
 func (d DropletCreateVolume) MarshalJSON() ([]byte, error) {
-	if d.Name != "" {
+	if d.ID != "" {
 		return json.Marshal(struct {
-			Name string `json:"name"`
-		}{Name: d.Name})
+			ID string `json:"id"`
+		}{ID: d.ID})
 	}
 
 	return json.Marshal(struct {
-		ID string `json:"id"`
-	}{ID: d.ID})
+		Name string `json:"name"`
+	}{Name: d.Name})
 }
 
 // DropletCreateSSHKey identifies a SSH Key for the create request. It prefers fingerprint over ID.

--- a/droplets_test.go
+++ b/droplets_test.go
@@ -180,9 +180,8 @@ func TestDroplets_Create(t *testing.T) {
 			ID: 1,
 		},
 		Volumes: []DropletCreateVolume{
-			{Name: "hello-im-a-volume"},
 			{ID: "hello-im-another-volume"},
-			{Name: "hello-im-still-a-volume", ID: "should be ignored due to Name"},
+			{Name: "should be ignored due to Name", ID: "aaa-111-bbb-222-ccc"},
 		},
 		Tags:    []string{"one", "two"},
 		VPCUUID: "880b7f98-f062-404d-b33c-458d545696f6",
@@ -200,9 +199,8 @@ func TestDroplets_Create(t *testing.T) {
 			"private_networking": false,
 			"monitoring":         false,
 			"volumes": []interface{}{
-				map[string]interface{}{"name": "hello-im-a-volume"},
 				map[string]interface{}{"id": "hello-im-another-volume"},
-				map[string]interface{}{"name": "hello-im-still-a-volume"},
+				map[string]interface{}{"id": "aaa-111-bbb-222-ccc"},
 			},
 			"tags":     []interface{}{"one", "two"},
 			"vpc_uuid": "880b7f98-f062-404d-b33c-458d545696f6",


### PR DESCRIPTION
godo has code that suggests that volumes can be attached to Droplets as part of Droplet create by including the volume name. However, is not something actually supported by the API. It has never been documented as part of the API.

Rather than removing it completely, to prevent existing code from failing to compile this PR adds a comment deprecating it. It also reverses the behavior of `DropletCreateVolume.MarshalJSON()` to prefer ID over Name.