### PR TITLE
Add Go 1.16.x to the testing matrix.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [ 1.12.x, 1.13.x, 1.14.x, 1.15.x ]
+        go-version: [ 1.12.x, 1.13.x, 1.14.x, 1.15.x, 1.16.x ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
@@ -27,7 +27,7 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-    - name: Format  
+    - name: Format
       run: if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then exit 1; fi
       if: matrix.os == 'ubuntu-latest'
     - name: Test


### PR DESCRIPTION
Go 1.16 has been released: https://golang.org/doc/go1.16