### PR TITLE
k8s: Add URN method to KubernetesCluster.

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -202,6 +202,11 @@ type KubernetesCluster struct {
 	UpdatedAt time.Time                `json:"updated_at,omitempty"`
 }
 
+// URN returns the Kubernetes cluster's ID in the format of DigitalOcean URN.
+func (kc KubernetesCluster) URN() string {
+	return ToURN("Kubernetes", kc.ID)
+}
+
 // KubernetesClusterUser represents a Kubernetes cluster user.
 type KubernetesClusterUser struct {
 	Username string   `json:"username,omitempty"`

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -367,6 +367,16 @@ func TestKubernetesClusters_Get(t *testing.T) {
 	require.Equal(t, want, got)
 }
 
+func TestKubernetesCluster_ToURN(t *testing.T) {
+	cluster := &KubernetesCluster{
+		ID: "deadbeef-dead-4aa5-beef-deadbeef347d",
+	}
+	want := "do:kubernetes:deadbeef-dead-4aa5-beef-deadbeef347d"
+	got := cluster.URN()
+
+	require.Equal(t, want, got)
+}
+
 func TestKubernetesClusters_GetUser(t *testing.T) {
 	setup()
 	defer teardown()
@@ -1034,21 +1044,21 @@ func TestKubernetesClusters_ListAssociatedResourcesForDeletion(t *testing.T) {
 	}
 	jBlob := `
 {
-	"volumes": 
+	"volumes":
 	[
 		{
 		  "id": "2241",
 		  "name":"test-volume-1"
 		}
 	],
-	"volume_snapshots": 
+	"volume_snapshots":
 	[
 		{
 		  "id":"2425",
 		  "name":"test-volume-snapshot-1"
 		}
 	],
-	"load_balancers": 
+	"load_balancers":
 	[
 		{
 		  "id":"4235",


### PR DESCRIPTION
Now that there is better support for Kubernetes clusters in projects, we should expose an URN method for `KubernetesCluster` to simplify assignment.

Related: https://github.com/digitalocean/terraform-provider-digitalocean/issues/469