### PR TITLE
flip: Set omitempty for Region in FloatingIPCreateRequest.

### DIFF
--- a/floating_ips.go
+++ b/floating_ips.go
@@ -54,10 +54,10 @@ type floatingIPRoot struct {
 }
 
 // FloatingIPCreateRequest represents a request to create a floating IP.
-// If DropletID is not empty, the floating IP will be assigned to the
-// droplet.
+// Specify DropletID to assign the floating IP to a Droplet or Region
+// to reserve it to the region.
 type FloatingIPCreateRequest struct {
-	Region    string `json:"region"`
+	Region    string `json:"region,omitempty"`
 	DropletID int    `json:"droplet_id,omitempty"`
 }
 


### PR DESCRIPTION
Currently, when assigning a FLIP to a Droplet, we send a payload like : `{"region":"","droplet_id":243862467}` The service tolerates this, but it is incorrect. `region` and `droplet_id` are mutually exclusive.  Sending any other value besides a blank string results in a 422:

    {"id":"unprocessable_entity","message":"Cannot specify Droplet and region, they are mutually exclusive."}

We should avoid it all together by setting `omitempty`