### PR TITLE
dbaas: handle ca certificates as base64 encoded

### DIFF
--- a/databases.go
+++ b/databases.go
@@ -158,7 +158,7 @@ type Database struct {
 
 // DatabaseCA represents a database ca.
 type DatabaseCA struct {
-	Certificate string `json:"certificate"`
+	Certificate []byte `json:"certificate"`
 }
 
 // DatabaseConnection represents a database connection

--- a/databases_test.go
+++ b/databases_test.go
@@ -169,7 +169,7 @@ func TestDatabases_GetCA(t *testing.T) {
 	body := `
 {
   "ca": {
-    "certificate": "fake_ca_cert"
+    "certificate": "ZmFrZQpjYQpjZXJ0"
   }
 }
 `
@@ -183,7 +183,7 @@ func TestDatabases_GetCA(t *testing.T) {
 
 	got, _, err := client.Databases.GetCA(ctx, dbID)
 	require.NoError(t, err)
-	require.Equal(t, &DatabaseCA{Certificate: "fake_ca_cert"}, got)
+	require.Equal(t, &DatabaseCA{Certificate: []byte("fake\nca\ncert")}, got)
 }
 
 func TestDatabases_Create(t *testing.T) {


### PR DESCRIPTION
PEM encoded certificates include new lines and json does not handle them well natively. Instead we expect the certificates to now be returned in base64 encoded form. This updates godo to also support that.