### PR TITLE
CheckResponse: Add RequestID from header to ErrorResponse when missing from body.

### DIFF
--- a/godo.go
+++ b/godo.go
@@ -433,6 +433,7 @@ func (r *ErrorResponse) Error() string {
 // CheckResponse checks the API response for errors, and returns them if present. A response is considered an
 // error if it has a status code outside the 200 range. API error responses are expected to have either no response
 // body, or a JSON response body that maps to ErrorResponse. Any other response body will be silently ignored.
+// If the API error response does not include the request ID in its body, the one from its header will be used.
 func CheckResponse(r *http.Response) error {
 	if c := r.StatusCode; c >= 200 && c <= 299 {
 		return nil
@@ -445,6 +446,10 @@ func CheckResponse(r *http.Response) error {
 		if err != nil {
 			errorResponse.Message = string(data)
 		}
+	}
+
+	if errorResponse.RequestID == "" {
+		errorResponse.RequestID = r.Header.Get("x-request-id")
 	}
 
 	return errorResponse

--- a/godo_test.go
+++ b/godo_test.go
@@ -403,6 +403,22 @@ func TestCheckResponse(t *testing.T) {
 				RequestID: "dead-beef",
 			},
 		},
+		// This tests that the ID in the body takes precedence to ensure we maintain the current
+		// behavior. In practice, the IDs in the header and body should always be the same.
+		{
+			title: "request_id in both",
+			input: &http.Response{
+				Request:    &http.Request{},
+				StatusCode: http.StatusBadRequest,
+				Header:     testHeaders,
+				Body: ioutil.NopCloser(strings.NewReader(`{"message":"m", "request_id": "dead-beef-body",
+			"errors": [{"resource": "r", "field": "f", "code": "c"}]}`)),
+			},
+			expected: &ErrorResponse{
+				Message:   "m",
+				RequestID: "dead-beef-body",
+			},
+		},
 		// ensure that we properly handle API errors that do not contain a
 		// response body
 		{


### PR DESCRIPTION
Error responses from the API can optionally include a `request_id` that can be used to debug issues. This is also included in the `x-request-id` response header.

When no ID is included in the body, this will use the one in the header. This will bubble up the request ID in error messaging for clients like doctl even when it is not included in the response body.