### PR TITLE
apps: Add tail_lines query parameter to GetLogs function

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -36,7 +36,7 @@ type AppsService interface {
 	ListDeployments(ctx context.Context, appID string, opts *ListOptions) ([]*Deployment, *Response, error)
 	CreateDeployment(ctx context.Context, appID string, create ...*DeploymentCreateRequest) (*Deployment, *Response, error)
 
-	GetLogs(ctx context.Context, appID, deploymentID, component string, logType AppLogType, follow bool) (*AppLogs, *Response, error)
+	GetLogs(ctx context.Context, appID, deploymentID, component string, logType AppLogType, follow bool, tailLines int) (*AppLogs, *Response, error)
 
 	ListRegions(ctx context.Context) ([]*AppRegion, *Response, error)
 
@@ -285,8 +285,8 @@ func (s *AppsServiceOp) CreateDeployment(ctx context.Context, appID string, crea
 }
 
 // GetLogs retrieves app logs.
-func (s *AppsServiceOp) GetLogs(ctx context.Context, appID, deploymentID, component string, logType AppLogType, follow bool) (*AppLogs, *Response, error) {
-	url := fmt.Sprintf("%s/%s/deployments/%s/logs?type=%s&follow=%t", appsBasePath, appID, deploymentID, logType, follow)
+func (s *AppsServiceOp) GetLogs(ctx context.Context, appID, deploymentID, component string, logType AppLogType, follow bool, tailLines int) (*AppLogs, *Response, error) {
+	url := fmt.Sprintf("%s/%s/deployments/%s/logs?type=%s&follow=%t&tail_lines=%d", appsBasePath, appID, deploymentID, logType, follow, tailLines)
 	if component != "" {
 		url = fmt.Sprintf("%s&component_name=%s", url, component)
 	}

--- a/apps_test.go
+++ b/apps_test.go
@@ -403,13 +403,14 @@ func TestApps_GetLogs(t *testing.T) {
 
 		assert.Equal(t, "RUN", r.URL.Query().Get("type"))
 		assert.Equal(t, "true", r.URL.Query().Get("follow"))
+		assert.Equal(t, "1", r.URL.Query().Get("tail_lines"))
 		_, hasComponent := r.URL.Query()["component_name"]
 		assert.False(t, hasComponent)
 
 		json.NewEncoder(w).Encode(&AppLogs{LiveURL: "https://live.logs.url"})
 	})
 
-	logs, _, err := client.Apps.GetLogs(ctx, testApp.ID, testDeployment.ID, "", AppLogTypeRun, true)
+	logs, _, err := client.Apps.GetLogs(ctx, testApp.ID, testDeployment.ID, "", AppLogTypeRun, true, 1)
 	require.NoError(t, err)
 	assert.NotEmpty(t, logs.LiveURL)
 }
@@ -425,12 +426,13 @@ func TestApps_GetLogs_component(t *testing.T) {
 
 		assert.Equal(t, "RUN", r.URL.Query().Get("type"))
 		assert.Equal(t, "true", r.URL.Query().Get("follow"))
+		assert.Equal(t, "1", r.URL.Query().Get("tail_lines"))
 		assert.Equal(t, "service-name", r.URL.Query().Get("component_name"))
 
 		json.NewEncoder(w).Encode(&AppLogs{LiveURL: "https://live.logs.url"})
 	})
 
-	logs, _, err := client.Apps.GetLogs(ctx, testApp.ID, testDeployment.ID, "service-name", AppLogTypeRun, true)
+	logs, _, err := client.Apps.GetLogs(ctx, testApp.ID, testDeployment.ID, "service-name", AppLogTypeRun, true, 1)
 	require.NoError(t, err)
 	assert.NotEmpty(t, logs.LiveURL)
 }


### PR DESCRIPTION
The API for fetching logs from an application now supports tailing live logs. This is helpful when applications generate a lot of logs, but only the latest logs are needed.

Once these changes are merged, getting them released as `v1.63.0` would be helpful — my next step is to update `doctl` to add the `doctl apps logs --tail` flag. I looked at `CONTRIBUTING.md` for releasing `godo` but I don't have permission to publish releases, so getting some help from a maintainer would be appreciated!