### PR TITLE
docs: Update links to API documentation.

### DIFF
--- a/1-click.go
+++ b/1-click.go
@@ -10,7 +10,7 @@ const oneClickBasePath = "v2/1-clicks"
 
 // OneClickService is an interface for interacting with 1-clicks with the
 // DigitalOcean API.
-// See: https://developers.digitalocean.com/documentation/v2/#1-click-applications
+// See: https://docs.digitalocean.com/reference/api/api-reference/#tag/1-Click-Applications
 type OneClickService interface {
 	List(context.Context, string) ([]*OneClick, *Response, error)
 	InstallKubernetes(context.Context, *InstallKubernetesAppsRequest) (*InstallKubernetesAppsResponse, *Response, error)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Godo is a Go client library for accessing the DigitalOcean V2 API.
 
 You can view the client API docs here: [http://godoc.org/github.com/digitalocean/godo](http://godoc.org/github.com/digitalocean/godo)
 
-You can view DigitalOcean API docs here: [https://developers.digitalocean.com/documentation/v2/](https://developers.digitalocean.com/documentation/v2/)
+You can view DigitalOcean API docs here: [https://docs.digitalocean.com/reference/api/api-reference/](https://docs.digitalocean.com/reference/api/api-reference/)
 
 ## Install
 ```sh
@@ -127,7 +127,7 @@ To see the list of past versions, run `git tag`.
 
 ## Documentation
 
-For a comprehensive list of examples, check out the [API documentation](https://developers.digitalocean.com/documentation/v2/).
+For a comprehensive list of examples, check out the [API documentation](https://docs.digitalocean.com/reference/api/api-reference/#tag/SSH-Keys).
 
 For details on all the functionality in this library, see the [GoDoc](http://godoc.org/github.com/digitalocean/godo) documentation.
 

--- a/account.go
+++ b/account.go
@@ -7,7 +7,7 @@ import (
 
 // AccountService is an interface for interfacing with the Account
 // endpoints of the DigitalOcean API
-// See: https://developers.digitalocean.com/documentation/v2/#account
+// See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Account
 type AccountService interface {
 	Get(context.Context) (*Account, *Response, error)
 }

--- a/action.go
+++ b/action.go
@@ -17,7 +17,7 @@ const (
 )
 
 // ActionsService handles communction with action related methods of the
-// DigitalOcean API: https://developers.digitalocean.com/documentation/v2#actions
+// DigitalOcean API: https://docs.digitalocean.com/reference/api/api-reference/#tag/Actions
 type ActionsService interface {
 	List(context.Context, *ListOptions) ([]Action, *Response, error)
 	Get(context.Context, int) (*Action, *Response, error)

--- a/balance.go
+++ b/balance.go
@@ -8,7 +8,7 @@ import (
 
 // BalanceService is an interface for interfacing with the Balance
 // endpoints of the DigitalOcean API
-// See: https://developers.digitalocean.com/documentation/v2/#balance
+// See: https://docs.digitalocean.com/reference/api/api-reference/#operation/get_customer_balance
 type BalanceService interface {
 	Get(context.Context) (*Balance, *Response, error)
 }

--- a/billing_history.go
+++ b/billing_history.go
@@ -10,7 +10,7 @@ const billingHistoryBasePath = "v2/customers/my/billing_history"
 
 // BillingHistoryService is an interface for interfacing with the BillingHistory
 // endpoints of the DigitalOcean API
-// See: https://developers.digitalocean.com/documentation/v2/#billing_history
+// See: https://docs.digitalocean.com/reference/api/api-reference/#operation/list_billing_history
 type BillingHistoryService interface {
 	List(context.Context, *ListOptions) (*BillingHistory, *Response, error)
 }

--- a/certificates.go
+++ b/certificates.go
@@ -9,7 +9,7 @@ import (
 const certificatesBasePath = "/v2/certificates"
 
 // CertificatesService is an interface for managing certificates with the DigitalOcean API.
-// See: https://developers.digitalocean.com/documentation/v2/#certificates
+// See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Certificates
 type CertificatesService interface {
 	Get(context.Context, string) (*Certificate, *Response, error)
 	List(context.Context, *ListOptions) ([]Certificate, *Response, error)

--- a/databases.go
+++ b/databases.go
@@ -88,7 +88,7 @@ const (
 // help make these entities distinct from Databases in godo, we refer to them
 // here as DatabaseDBs.
 //
-// See: https://developers.digitalocean.com/documentation/v2#databases
+// See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Databases
 type DatabasesService interface {
 	List(context.Context, *ListOptions) ([]Database, *Response, error)
 	Get(context.Context, string) (*Database, *Response, error)

--- a/domains.go
+++ b/domains.go
@@ -9,8 +9,8 @@ import (
 const domainsBasePath = "v2/domains"
 
 // DomainsService is an interface for managing DNS with the DigitalOcean API.
-// See: https://developers.digitalocean.com/documentation/v2#domains and
-// https://developers.digitalocean.com/documentation/v2#domain-records
+// See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Domains and
+// https://docs.digitalocean.com/reference/api/api-reference/#tag/Domain-Records
 type DomainsService interface {
 	List(context.Context, *ListOptions) ([]Domain, *Response, error)
 	Get(context.Context, string) (*Domain, *Response, error)

--- a/droplet_actions.go
+++ b/droplet_actions.go
@@ -12,7 +12,7 @@ type ActionRequest map[string]interface{}
 
 // DropletActionsService is an interface for interfacing with the Droplet actions
 // endpoints of the DigitalOcean API
-// See: https://developers.digitalocean.com/documentation/v2#droplet-actions
+// See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Droplet-Actions
 type DropletActionsService interface {
 	Shutdown(context.Context, int) (*Action, *Response, error)
 	ShutdownByTag(context.Context, string) ([]Action, *Response, error)

--- a/droplets.go
+++ b/droplets.go
@@ -14,7 +14,7 @@ var errNoNetworks = errors.New("no networks have been defined")
 
 // DropletsService is an interface for interfacing with the Droplet
 // endpoints of the DigitalOcean API
-// See: https://developers.digitalocean.com/documentation/v2#droplets
+// See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Droplets
 type DropletsService interface {
 	List(context.Context, *ListOptions) ([]Droplet, *Response, error)
 	ListByTag(context.Context, string, *ListOptions) ([]Droplet, *Response, error)

--- a/firewalls.go
+++ b/firewalls.go
@@ -10,7 +10,7 @@ import (
 const firewallsBasePath = "/v2/firewalls"
 
 // FirewallsService is an interface for managing Firewalls with the DigitalOcean API.
-// See: https://developers.digitalocean.com/documentation/v2/#firewalls
+// See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Firewalls
 type FirewallsService interface {
 	Get(context.Context, string) (*Firewall, *Response, error)
 	Create(context.Context, *FirewallRequest) (*Firewall, *Response, error)

--- a/floating_ips.go
+++ b/floating_ips.go
@@ -10,7 +10,7 @@ const floatingBasePath = "v2/floating_ips"
 
 // FloatingIPsService is an interface for interfacing with the floating IPs
 // endpoints of the Digital Ocean API.
-// See: https://developers.digitalocean.com/documentation/v2#floating-ips
+// See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Floating-IPs
 type FloatingIPsService interface {
 	List(context.Context, *ListOptions) ([]FloatingIP, *Response, error)
 	Get(context.Context, string) (*FloatingIP, *Response, error)

--- a/floating_ips_actions.go
+++ b/floating_ips_actions.go
@@ -8,7 +8,7 @@ import (
 
 // FloatingIPActionsService is an interface for interfacing with the
 // floating IPs actions endpoints of the Digital Ocean API.
-// See: https://developers.digitalocean.com/documentation/v2#floating-ips-action
+// See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Floating-IP-Actions
 type FloatingIPActionsService interface {
 	Assign(ctx context.Context, ip string, dropletID int) (*Action, *Response, error)
 	Unassign(ctx context.Context, ip string) (*Action, *Response, error)

--- a/image_actions.go
+++ b/image_actions.go
@@ -8,7 +8,7 @@ import (
 
 // ImageActionsService is an interface for interfacing with the image actions
 // endpoints of the DigitalOcean API
-// See: https://developers.digitalocean.com/documentation/v2#image-actions
+// See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Image-Actions
 type ImageActionsService interface {
 	Get(context.Context, int, int) (*Action, *Response, error)
 	Transfer(context.Context, int, *ActionRequest) (*Action, *Response, error)

--- a/images.go
+++ b/images.go
@@ -10,7 +10,7 @@ const imageBasePath = "v2/images"
 
 // ImagesService is an interface for interfacing with the images
 // endpoints of the DigitalOcean API
-// See: https://developers.digitalocean.com/documentation/v2#images
+// See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Images
 type ImagesService interface {
 	List(context.Context, *ListOptions) ([]Image, *Response, error)
 	ListDistribution(ctx context.Context, opt *ListOptions) ([]Image, *Response, error)

--- a/invoices.go
+++ b/invoices.go
@@ -12,7 +12,7 @@ const invoicesBasePath = "v2/customers/my/invoices"
 
 // InvoicesService is an interface for interfacing with the Invoice
 // endpoints of the DigitalOcean API
-// See: https://developers.digitalocean.com/documentation/v2/#invoices
+// See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Billing
 type InvoicesService interface {
 	Get(context.Context, string, *ListOptions) (*Invoice, *Response, error)
 	GetPDF(context.Context, string) ([]byte, *Response, error)

--- a/keys.go
+++ b/keys.go
@@ -10,7 +10,7 @@ const keysBasePath = "v2/account/keys"
 
 // KeysService is an interface for interfacing with the keys
 // endpoints of the DigitalOcean API
-// See: https://developers.digitalocean.com/documentation/v2#keys
+// See: https://docs.digitalocean.com/reference/api/api-reference/#tag/SSH-Keys
 type KeysService interface {
 	List(context.Context, *ListOptions) ([]Key, *Response, error)
 	GetByID(context.Context, int) (*Key, *Response, error)

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -21,7 +21,7 @@ const (
 
 // KubernetesService is an interface for interfacing with the Kubernetes endpoints
 // of the DigitalOcean API.
-// See: https://developers.digitalocean.com/documentation/v2#kubernetes
+// See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Kubernetes
 type KubernetesService interface {
 	Create(context.Context, *KubernetesClusterCreateRequest) (*KubernetesCluster, *Response, error)
 	Get(context.Context, string) (*KubernetesCluster, *Response, error)

--- a/load_balancers.go
+++ b/load_balancers.go
@@ -12,7 +12,7 @@ const forwardingRulesPath = "forwarding_rules"
 const dropletsPath = "droplets"
 
 // LoadBalancersService is an interface for managing load balancers with the DigitalOcean API.
-// See: https://developers.digitalocean.com/documentation/v2#load-balancers
+// See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Load-Balancers
 type LoadBalancersService interface {
 	Get(context.Context, string) (*LoadBalancer, *Response, error)
 	List(context.Context, *ListOptions) ([]LoadBalancer, *Response, error)

--- a/monitoring.go
+++ b/monitoring.go
@@ -23,7 +23,7 @@ const (
 
 // MonitoringService is an interface for interfacing with the
 // monitoring endpoints of the DigitalOcean API
-// See: https://developers.digitalocean.com/documentation/v2#monitoring
+// See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Monitoring
 type MonitoringService interface {
 	ListAlertPolicies(context.Context, *ListOptions) ([]AlertPolicy, *Response, error)
 	GetAlertPolicy(context.Context, string) (*AlertPolicy, *Response, error)

--- a/projects.go
+++ b/projects.go
@@ -17,7 +17,7 @@ const (
 )
 
 // ProjectsService is an interface for creating and managing Projects with the DigitalOcean API.
-// See: https://developers.digitalocean.com/documentation/v2/#projects
+// See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Projects
 type ProjectsService interface {
 	List(context.Context, *ListOptions) ([]Project, *Response, error)
 	GetDefault(context.Context) (*Project, *Response, error)

--- a/regions.go
+++ b/regions.go
@@ -7,7 +7,7 @@ import (
 
 // RegionsService is an interface for interfacing with the regions
 // endpoints of the DigitalOcean API
-// See: https://developers.digitalocean.com/documentation/v2#regions
+// See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Regions
 type RegionsService interface {
 	List(context.Context, *ListOptions) ([]Region, *Response, error)
 }

--- a/registry.go
+++ b/registry.go
@@ -18,7 +18,7 @@ const (
 
 // RegistryService is an interface for interfacing with the Registry endpoints
 // of the DigitalOcean API.
-// See: https://developers.digitalocean.com/documentation/v2#registry
+// See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Container-Registry
 type RegistryService interface {
 	Create(context.Context, *RegistryCreateRequest) (*Registry, *Response, error)
 	Get(context.Context) (*Registry, *Response, error)

--- a/sizes.go
+++ b/sizes.go
@@ -7,7 +7,7 @@ import (
 
 // SizesService is an interface for interfacing with the size
 // endpoints of the DigitalOcean API
-// See: https://developers.digitalocean.com/documentation/v2#sizes
+// See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Sizes
 type SizesService interface {
 	List(context.Context, *ListOptions) ([]Size, *Response, error)
 }

--- a/snapshots.go
+++ b/snapshots.go
@@ -10,7 +10,7 @@ const snapshotBasePath = "v2/snapshots"
 
 // SnapshotsService is an interface for interfacing with the snapshots
 // endpoints of the DigitalOcean API
-// See: https://developers.digitalocean.com/documentation/v2#snapshots
+// See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Snapshots
 type SnapshotsService interface {
 	List(context.Context, *ListOptions) ([]Snapshot, *Response, error)
 	ListVolume(context.Context, *ListOptions) ([]Snapshot, *Response, error)

--- a/storage.go
+++ b/storage.go
@@ -15,7 +15,7 @@ const (
 
 // StorageService is an interface for interfacing with the storage
 // endpoints of the Digital Ocean API.
-// See: https://developers.digitalocean.com/documentation/v2/#block-storage
+// See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Block-Storage
 type StorageService interface {
 	ListVolumes(context.Context, *ListVolumeParams) ([]Volume, *Response, error)
 	GetVolume(context.Context, string) (*Volume, *Response, error)

--- a/storage_actions.go
+++ b/storage_actions.go
@@ -8,7 +8,7 @@ import (
 
 // StorageActionsService is an interface for interfacing with the
 // storage actions endpoints of the Digital Ocean API.
-// See: https://developers.digitalocean.com/documentation/v2#storage-actions
+// See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Block-Storage-Actions
 type StorageActionsService interface {
 	Attach(ctx context.Context, volumeID string, dropletID int) (*Action, *Response, error)
 	DetachByDropletID(ctx context.Context, volumeID string, dropletID int) (*Action, *Response, error)

--- a/tags.go
+++ b/tags.go
@@ -10,7 +10,7 @@ const tagsBasePath = "v2/tags"
 
 // TagsService is an interface for interfacing with the tags
 // endpoints of the DigitalOcean API
-// See: https://developers.digitalocean.com/documentation/v2#tags
+// See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Tags
 type TagsService interface {
 	List(context.Context, *ListOptions) ([]Tag, *Response, error)
 	Get(context.Context, string) (*Tag, *Response, error)

--- a/vpcs.go
+++ b/vpcs.go
@@ -10,7 +10,7 @@ const vpcsBasePath = "/v2/vpcs"
 
 // VPCsService is an interface for managing Virtual Private Cloud configurations with the
 // DigitalOcean API.
-// See: https://developers.digitalocean.com/documentation/v2#vpcs
+// See: https://docs.digitalocean.com/reference/api/api-reference/#tag/VPCs
 type VPCsService interface {
 	Create(context.Context, *VPCCreateRequest) (*VPC, *Response, error)
 	Get(context.Context, string) (*VPC, *Response, error)


### PR DESCRIPTION
The redirects to the new API docs do not map the anchor links. So we need to update these.