### PR TITLE
Prep v1.65.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [v1.65.0] - 2021-08-05
+
+- #468 - @notxarb - New alerts feature for App Platform
+- #467 - @andrewsomething - docs: Update links to API documentation.
+- #466 - @andrewsomething - Mark Response.Monitor as deprecated.
+
 ## [v1.64.2] - 2021-07-23
 
 - #464 - @bsnyder788 - insights: update HTTP method for alert policy update

--- a/godo.go
+++ b/godo.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.64.2"
+	libraryVersion = "1.65.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"


### PR DESCRIPTION
## [v1.65.0] - 2021-08-05

- #468 - @notxarb - New alerts feature for App Platform
- #467 - @andrewsomething - docs: Update links to API documentation.
- #466 - @andrewsomething - Mark Response.Monitor as deprecated.
