### PR TITLE
Prep v1.66.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [v1.66.0] - 2021-09-21
+
+- #473 - @andrewsomething - Add Go 1.17.x to test matrix and drop unsupported versions.
+- #472 - @bsnyder788 - insights: add private (in/out)bound and public inbound bandwidth aler…
+- #470 - @gottwald - domains: remove invalid json struct tag option
+
 ## [v1.65.0] - 2021-08-05
 
 - #468 - @notxarb - New alerts feature for App Platform

--- a/godo.go
+++ b/godo.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.65.0"
+	libraryVersion = "1.66.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"


### PR DESCRIPTION
It would be good to cut a release so the new consts added in https://github.com/digitalocean/godo/commit/f3fd6a4398b26c8b712d2c0b988387d8d7dd8805 can be used in https://github.com/digitalocean/terraform-provider-digitalocean/pull/679