### PR TITLE
Add size unit to LB API.

### DIFF
--- a/load_balancers.go
+++ b/load_balancers.go
@@ -28,10 +28,12 @@ type LoadBalancersService interface {
 // LoadBalancer represents a DigitalOcean load balancer configuration.
 // Tags can only be provided upon the creation of a Load Balancer.
 type LoadBalancer struct {
-	ID                     string           `json:"id,omitempty"`
-	Name                   string           `json:"name,omitempty"`
-	IP                     string           `json:"ip,omitempty"`
-	SizeSlug               string           `json:"size,omitempty"`
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+	IP   string `json:"ip,omitempty"`
+	// SizeSlug is mutually exclusive with SizeUnit. Only one should be specified
+	SizeSlug string `json:"size,omitempty"`
+	// SizeUnit is mutually exclusive with SizeSlug. Only one should be specified
 	SizeUnit               uint32           `json:"size_unit,omitempty"`
 	Algorithm              string           `json:"algorithm,omitempty"`
 	Status                 string           `json:"status,omitempty"`
@@ -136,10 +138,12 @@ func (s StickySessions) String() string {
 
 // LoadBalancerRequest represents the configuration to be applied to an existing or a new load balancer.
 type LoadBalancerRequest struct {
-	Name                   string           `json:"name,omitempty"`
-	Algorithm              string           `json:"algorithm,omitempty"`
-	Region                 string           `json:"region,omitempty"`
-	SizeSlug               string           `json:"size,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Algorithm string `json:"algorithm,omitempty"`
+	Region    string `json:"region,omitempty"`
+	// SizeSlug is mutually exclusive with SizeUnit. Only one should be specified
+	SizeSlug string `json:"size,omitempty"`
+	// SizeUnit is mutually exclusive with SizeSlug. Only one should be specified
 	SizeUnit               uint32           `json:"size_unit,omitempty"`
 	ForwardingRules        []ForwardingRule `json:"forwarding_rules,omitempty"`
 	HealthCheck            *HealthCheck     `json:"health_check,omitempty"`

--- a/load_balancers.go
+++ b/load_balancers.go
@@ -32,6 +32,7 @@ type LoadBalancer struct {
 	Name                   string           `json:"name,omitempty"`
 	IP                     string           `json:"ip,omitempty"`
 	SizeSlug               string           `json:"size,omitempty"`
+	SizeUnit               uint32           `json:"size_unit,omitempty"`
 	Algorithm              string           `json:"algorithm,omitempty"`
 	Status                 string           `json:"status,omitempty"`
 	Created                string           `json:"created_at,omitempty"`
@@ -65,6 +66,7 @@ func (l LoadBalancer) AsRequest() *LoadBalancerRequest {
 		Name:                   l.Name,
 		Algorithm:              l.Algorithm,
 		SizeSlug:               l.SizeSlug,
+		SizeUnit:               l.SizeUnit,
 		ForwardingRules:        append([]ForwardingRule(nil), l.ForwardingRules...),
 		DropletIDs:             append([]int(nil), l.DropletIDs...),
 		Tag:                    l.Tag,
@@ -138,6 +140,7 @@ type LoadBalancerRequest struct {
 	Algorithm              string           `json:"algorithm,omitempty"`
 	Region                 string           `json:"region,omitempty"`
 	SizeSlug               string           `json:"size,omitempty"`
+	SizeUnit               uint32           `json:"size_unit,omitempty"`
 	ForwardingRules        []ForwardingRule `json:"forwarding_rules,omitempty"`
 	HealthCheck            *HealthCheck     `json:"health_check,omitempty"`
 	StickySessions         *StickySessions  `json:"sticky_sessions,omitempty"`

--- a/load_balancers_test.go
+++ b/load_balancers_test.go
@@ -218,7 +218,7 @@ var lbUpdateJSONResponse = `
         "ip":"12.34.56.78",
         "algorithm":"least_connections",
         "status":"active",
-		"size_unit":2,
+        "size_unit":2,
         "created_at":"2016-12-15T14:19:09Z",
         "forwarding_rules":[
             {

--- a/load_balancers_test.go
+++ b/load_balancers_test.go
@@ -218,6 +218,7 @@ var lbUpdateJSONResponse = `
         "ip":"12.34.56.78",
         "algorithm":"least_connections",
         "status":"active",
+		"size_unit":2,
         "created_at":"2016-12-15T14:19:09Z",
         "forwarding_rules":[
             {
@@ -454,6 +455,7 @@ func TestLoadBalancers_Update(t *testing.T) {
 		Name:      "example-lb-01",
 		Algorithm: "least_connections",
 		Region:    "nyc1",
+		SizeUnit:  2,
 		ForwardingRules: []ForwardingRule{
 			{
 				EntryProtocol:  "http",
@@ -512,6 +514,7 @@ func TestLoadBalancers_Update(t *testing.T) {
 		IP:        "12.34.56.78",
 		Algorithm: "least_connections",
 		Status:    "active",
+		SizeUnit:  2,
 		Created:   "2016-12-15T14:19:09Z",
 		ForwardingRules: []ForwardingRule{
 			{


### PR DESCRIPTION
Load balancers is changing its sizing model from a size slug to a size unit.