### PR TITLE
kubernetes: add supported_features field to the kubernetes/options response

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -422,8 +422,9 @@ type KubernetesOptions struct {
 
 // KubernetesVersion is a DigitalOcean Kubernetes release.
 type KubernetesVersion struct {
-	Slug              string `json:"slug,omitempty"`
-	KubernetesVersion string `json:"kubernetes_version,omitempty"`
+	Slug              string   `json:"slug,omitempty"`
+	KubernetesVersion string   `json:"kubernetes_version,omitempty"`
+	SupportedFeatures []string `json:"supported_features,omitempty"`
 }
 
 // KubernetesNodeSize is a node sizes supported for Kubernetes clusters.

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -1572,7 +1572,16 @@ func TestKubernetesVersions_List(t *testing.T) {
 
 	want := &KubernetesOptions{
 		Versions: []*KubernetesVersion{
-			{Slug: "1.10.0-gen0", KubernetesVersion: "1.10.0"},
+			{
+				Slug:              "1.10.0-gen0",
+				KubernetesVersion: "1.10.0",
+				SupportedFeatures: []string{
+					"cluster-autoscaler",
+					"docr-integration",
+					"ha-control-plane",
+					"token-authentication",
+				},
+			},
 		},
 		Regions: []*KubernetesRegion{
 			{Name: "New York 3", Slug: "nyc3"},
@@ -1587,7 +1596,13 @@ func TestKubernetesVersions_List(t *testing.T) {
 		"versions": [
 			{
 				"slug": "1.10.0-gen0",
-				"kubernetes_version": "1.10.0"
+				"kubernetes_version": "1.10.0",
+				"supported_features": [
+					"cluster-autoscaler",
+					"docr-integration",
+					"ha-control-plane",
+					"token-authentication"
+				]
 			}
 		],
 		"regions": [


### PR DESCRIPTION
`supported_features` is a new field available in the `kubernetes/options` response object. This PR adds support for it.

cc: @adamwg @andrewsomething 