### PR TITLE
kubernetes: add support for HA control plane

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -71,6 +71,9 @@ type KubernetesClusterCreateRequest struct {
 	Tags        []string `json:"tags,omitempty"`
 	VPCUUID     string   `json:"vpc_uuid,omitempty"`
 
+	// Create cluster with highly available control plane
+	HA bool `json:"ha"`
+
 	NodePools []*KubernetesNodePoolCreateRequest `json:"node_pools,omitempty"`
 
 	MaintenancePolicy *KubernetesMaintenancePolicy `json:"maintenance_policy"`
@@ -85,6 +88,9 @@ type KubernetesClusterUpdateRequest struct {
 	MaintenancePolicy *KubernetesMaintenancePolicy `json:"maintenance_policy,omitempty"`
 	AutoUpgrade       *bool                        `json:"auto_upgrade,omitempty"`
 	SurgeUpgrade      bool                         `json:"surge_upgrade,omitempty"`
+
+	// Convert cluster to run highly available control plane
+	HA bool `json:"ha,omitempty"`
 }
 
 // KubernetesClusterDeleteSelectiveRequest represents a delete selective request to delete a cluster and it's associated resources.
@@ -189,6 +195,9 @@ type KubernetesCluster struct {
 	Endpoint      string   `json:"endpoint,omitempty"`
 	Tags          []string `json:"tags,omitempty"`
 	VPCUUID       string   `json:"vpc_uuid,omitempty"`
+
+	// Cluster runs a highly available control plane
+	HA bool `json:"ha,omitempty"`
 
 	NodePools []*KubernetesNodePool `json:"node_pools,omitempty"`
 

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -552,6 +552,7 @@ func TestKubernetesClusters_Create(t *testing.T) {
 		ServiceSubnet: "10.245.0.0/16",
 		Tags:          []string{"cluster-tag-1", "cluster-tag-2"},
 		VPCUUID:       "880b7f98-f062-404d-b33c-458d545696f6",
+		HA:            true,
 		SurgeUpgrade:  true,
 		NodePools: []*KubernetesNodePool{
 			{
@@ -575,6 +576,7 @@ func TestKubernetesClusters_Create(t *testing.T) {
 		Tags:         want.Tags,
 		VPCUUID:      want.VPCUUID,
 		SurgeUpgrade: true,
+		HA:           true,
 		NodePools: []*KubernetesNodePoolCreateRequest{
 			{
 				Size:      want.NodePools[0].Size,
@@ -604,6 +606,7 @@ func TestKubernetesClusters_Create(t *testing.T) {
 			"cluster-tag-2"
 		],
 		"vpc_uuid": "880b7f98-f062-404d-b33c-458d545696f6",
+		"ha": true,
 		"surge_upgrade": true,
 		"node_pools": [
 			{
@@ -763,6 +766,7 @@ func TestKubernetesClusters_Update(t *testing.T) {
 		Tags:          []string{"cluster-tag-1", "cluster-tag-2"},
 		VPCUUID:       "880b7f98-f062-404d-b33c-458d545696f6",
 		SurgeUpgrade:  true,
+		HA:            true,
 		NodePools: []*KubernetesNodePool{
 			{
 				ID:    "8d91899c-0739-4a1a-acc5-deadbeefbb8a",
@@ -801,6 +805,7 @@ func TestKubernetesClusters_Update(t *testing.T) {
 			"cluster-tag-2"
 		],
 		"vpc_uuid": "880b7f98-f062-404d-b33c-458d545696f6",
+		"ha": true,
 		"surge_upgrade": true,
 		"node_pools": [
 			{


### PR DESCRIPTION
This PR adds support for the `HA` field for the Create and Update requests for Kubernetes. This will allow users to create and update their K8s clusters to highly available control planes.

cc: @andrewsomething @adamwg 