### PR TITLE
godo/load-balancers: add DisableLetsEncryptDNSRecords field for LBaaS

### DIFF
--- a/load_balancers.go
+++ b/load_balancers.go
@@ -34,21 +34,22 @@ type LoadBalancer struct {
 	// SizeSlug is mutually exclusive with SizeUnit. Only one should be specified
 	SizeSlug string `json:"size,omitempty"`
 	// SizeUnit is mutually exclusive with SizeSlug. Only one should be specified
-	SizeUnit               uint32           `json:"size_unit,omitempty"`
-	Algorithm              string           `json:"algorithm,omitempty"`
-	Status                 string           `json:"status,omitempty"`
-	Created                string           `json:"created_at,omitempty"`
-	ForwardingRules        []ForwardingRule `json:"forwarding_rules,omitempty"`
-	HealthCheck            *HealthCheck     `json:"health_check,omitempty"`
-	StickySessions         *StickySessions  `json:"sticky_sessions,omitempty"`
-	Region                 *Region          `json:"region,omitempty"`
-	DropletIDs             []int            `json:"droplet_ids,omitempty"`
-	Tag                    string           `json:"tag,omitempty"`
-	Tags                   []string         `json:"tags,omitempty"`
-	RedirectHttpToHttps    bool             `json:"redirect_http_to_https,omitempty"`
-	EnableProxyProtocol    bool             `json:"enable_proxy_protocol,omitempty"`
-	EnableBackendKeepalive bool             `json:"enable_backend_keepalive,omitempty"`
-	VPCUUID                string           `json:"vpc_uuid,omitempty"`
+	SizeUnit                     uint32           `json:"size_unit,omitempty"`
+	Algorithm                    string           `json:"algorithm,omitempty"`
+	Status                       string           `json:"status,omitempty"`
+	Created                      string           `json:"created_at,omitempty"`
+	ForwardingRules              []ForwardingRule `json:"forwarding_rules,omitempty"`
+	HealthCheck                  *HealthCheck     `json:"health_check,omitempty"`
+	StickySessions               *StickySessions  `json:"sticky_sessions,omitempty"`
+	Region                       *Region          `json:"region,omitempty"`
+	DropletIDs                   []int            `json:"droplet_ids,omitempty"`
+	Tag                          string           `json:"tag,omitempty"`
+	Tags                         []string         `json:"tags,omitempty"`
+	RedirectHttpToHttps          bool             `json:"redirect_http_to_https,omitempty"`
+	EnableProxyProtocol          bool             `json:"enable_proxy_protocol,omitempty"`
+	EnableBackendKeepalive       bool             `json:"enable_backend_keepalive,omitempty"`
+	VPCUUID                      string           `json:"vpc_uuid,omitempty"`
+	DisableLetsEncryptDNSRecords *bool            `json:"disable_lets_encrypt_dns_records,omitempty"`
 }
 
 // String creates a human-readable description of a LoadBalancer.
@@ -65,18 +66,23 @@ func (l LoadBalancer) URN() string {
 // Modifying the returned LoadBalancerRequest will not modify the original LoadBalancer.
 func (l LoadBalancer) AsRequest() *LoadBalancerRequest {
 	r := LoadBalancerRequest{
-		Name:                   l.Name,
-		Algorithm:              l.Algorithm,
-		SizeSlug:               l.SizeSlug,
-		SizeUnit:               l.SizeUnit,
-		ForwardingRules:        append([]ForwardingRule(nil), l.ForwardingRules...),
-		DropletIDs:             append([]int(nil), l.DropletIDs...),
-		Tag:                    l.Tag,
-		RedirectHttpToHttps:    l.RedirectHttpToHttps,
-		EnableProxyProtocol:    l.EnableProxyProtocol,
-		EnableBackendKeepalive: l.EnableBackendKeepalive,
-		HealthCheck:            l.HealthCheck,
-		VPCUUID:                l.VPCUUID,
+		Name:                         l.Name,
+		Algorithm:                    l.Algorithm,
+		SizeSlug:                     l.SizeSlug,
+		SizeUnit:                     l.SizeUnit,
+		ForwardingRules:              append([]ForwardingRule(nil), l.ForwardingRules...),
+		DropletIDs:                   append([]int(nil), l.DropletIDs...),
+		Tag:                          l.Tag,
+		RedirectHttpToHttps:          l.RedirectHttpToHttps,
+		EnableProxyProtocol:          l.EnableProxyProtocol,
+		EnableBackendKeepalive:       l.EnableBackendKeepalive,
+		HealthCheck:                  l.HealthCheck,
+		VPCUUID:                      l.VPCUUID,
+		DisableLetsEncryptDNSRecords: l.DisableLetsEncryptDNSRecords,
+	}
+
+	if l.DisableLetsEncryptDNSRecords != nil {
+		*r.DisableLetsEncryptDNSRecords = *l.DisableLetsEncryptDNSRecords
 	}
 
 	if l.HealthCheck != nil {
@@ -144,17 +150,18 @@ type LoadBalancerRequest struct {
 	// SizeSlug is mutually exclusive with SizeUnit. Only one should be specified
 	SizeSlug string `json:"size,omitempty"`
 	// SizeUnit is mutually exclusive with SizeSlug. Only one should be specified
-	SizeUnit               uint32           `json:"size_unit,omitempty"`
-	ForwardingRules        []ForwardingRule `json:"forwarding_rules,omitempty"`
-	HealthCheck            *HealthCheck     `json:"health_check,omitempty"`
-	StickySessions         *StickySessions  `json:"sticky_sessions,omitempty"`
-	DropletIDs             []int            `json:"droplet_ids,omitempty"`
-	Tag                    string           `json:"tag,omitempty"`
-	Tags                   []string         `json:"tags,omitempty"`
-	RedirectHttpToHttps    bool             `json:"redirect_http_to_https,omitempty"`
-	EnableProxyProtocol    bool             `json:"enable_proxy_protocol,omitempty"`
-	EnableBackendKeepalive bool             `json:"enable_backend_keepalive,omitempty"`
-	VPCUUID                string           `json:"vpc_uuid,omitempty"`
+	SizeUnit                     uint32           `json:"size_unit,omitempty"`
+	ForwardingRules              []ForwardingRule `json:"forwarding_rules,omitempty"`
+	HealthCheck                  *HealthCheck     `json:"health_check,omitempty"`
+	StickySessions               *StickySessions  `json:"sticky_sessions,omitempty"`
+	DropletIDs                   []int            `json:"droplet_ids,omitempty"`
+	Tag                          string           `json:"tag,omitempty"`
+	Tags                         []string         `json:"tags,omitempty"`
+	RedirectHttpToHttps          bool             `json:"redirect_http_to_https,omitempty"`
+	EnableProxyProtocol          bool             `json:"enable_proxy_protocol,omitempty"`
+	EnableBackendKeepalive       bool             `json:"enable_backend_keepalive,omitempty"`
+	VPCUUID                      string           `json:"vpc_uuid,omitempty"`
+	DisableLetsEncryptDNSRecords *bool            `json:"disable_lets_encrypt_dns_records,omitempty"`
 }
 
 // String creates a human-readable description of a LoadBalancerRequest.

--- a/load_balancers_test.go
+++ b/load_balancers_test.go
@@ -65,7 +65,8 @@ var lbListJSONResponse = `
             "droplet_ids":[
                 2,
                 21
-            ]
+            ],
+            "disable_lets_encrypt_dns_records": true
         }
     ],
     "links":{
@@ -145,7 +146,8 @@ var lbCreateJSONResponse = `
             21
         ],
         "redirect_http_to_https":true,
-        "vpc_uuid":"880b7f98-f062-404d-b33c-458d545696f6"
+        "vpc_uuid":"880b7f98-f062-404d-b33c-458d545696f6",
+        "disable_lets_encrypt_dns_records": true
     }
 }
 `
@@ -205,7 +207,8 @@ var lbGetJSONResponse = `
         "droplet_ids":[
             2,
             21
-        ]
+        ],
+        "disable_lets_encrypt_dns_records": false
     }
 }
 `
@@ -333,6 +336,9 @@ func TestLoadBalancers_Get(t *testing.T) {
 		DropletIDs: []int{2, 21},
 	}
 
+	disableLetsEncryptDNSRecords := false
+	expected.DisableLetsEncryptDNSRecords = &disableLetsEncryptDNSRecords
+
 	assert.Equal(t, expected, loadBalancer)
 }
 
@@ -444,6 +450,9 @@ func TestLoadBalancers_Create(t *testing.T) {
 		VPCUUID:             "880b7f98-f062-404d-b33c-458d545696f6",
 	}
 
+	disableLetsEncryptDNSRecords := true
+	expected.DisableLetsEncryptDNSRecords = &disableLetsEncryptDNSRecords
+
 	assert.Equal(t, expected, loadBalancer)
 }
 
@@ -550,7 +559,8 @@ func TestLoadBalancers_Update(t *testing.T) {
 			Available: true,
 			Features:  []string{"private_networking", "backups", "ipv6", "metadata", "storage"},
 		},
-		DropletIDs: []int{2, 21},
+		DropletIDs:                   []int{2, 21},
+		DisableLetsEncryptDNSRecords: nil,
 	}
 
 	assert.Equal(t, expected, loadBalancer)
@@ -613,6 +623,8 @@ func TestLoadBalancers_List(t *testing.T) {
 			DropletIDs: []int{2, 21},
 		},
 	}
+	disableLetsEncryptDNSRecords := true
+	expectedLBs[0].DisableLetsEncryptDNSRecords = &disableLetsEncryptDNSRecords
 
 	assert.Equal(t, expectedLBs, loadBalancers)
 


### PR DESCRIPTION
We are adding this new field which allows the user to turn off the current behavior where an A record is created from the apex domain in the cert pointing to the LB IP when added to the Load Balancer.