### PR TITLE
k8s/godo: remove ha field from update request

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -88,9 +88,6 @@ type KubernetesClusterUpdateRequest struct {
 	MaintenancePolicy *KubernetesMaintenancePolicy `json:"maintenance_policy,omitempty"`
 	AutoUpgrade       *bool                        `json:"auto_upgrade,omitempty"`
 	SurgeUpgrade      bool                         `json:"surge_upgrade,omitempty"`
-
-	// Convert cluster to run highly available control plane
-	HA bool `json:"ha,omitempty"`
 }
 
 // KubernetesClusterDeleteSelectiveRequest represents a delete selective request to delete a cluster and it's associated resources.

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -766,7 +766,6 @@ func TestKubernetesClusters_Update(t *testing.T) {
 		Tags:          []string{"cluster-tag-1", "cluster-tag-2"},
 		VPCUUID:       "880b7f98-f062-404d-b33c-458d545696f6",
 		SurgeUpgrade:  true,
-		HA:            true,
 		NodePools: []*KubernetesNodePool{
 			{
 				ID:    "8d91899c-0739-4a1a-acc5-deadbeefbb8a",
@@ -805,7 +804,7 @@ func TestKubernetesClusters_Update(t *testing.T) {
 			"cluster-tag-2"
 		],
 		"vpc_uuid": "880b7f98-f062-404d-b33c-458d545696f6",
-		"ha": true,
+		"ha": false,
 		"surge_upgrade": true,
 		"node_pools": [
 			{


### PR DESCRIPTION
This PR removes the `HA` field from the Update request for K8s.

This is a follow-up to the removal of `ha` from `doctl`. https://github.com/digitalocean/doctl/pull/1040

cc: @adamwg 
