### PR TITLE
Refactor tests: replace t.Errorf with assert/require

### DIFF
--- a/certificates_test.go
+++ b/certificates_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var certJSONResponse = `
@@ -75,9 +76,7 @@ func TestCertificates_Get(t *testing.T) {
 	})
 
 	certificate, _, err := client.Certificates.Get(ctx, cID)
-	if err != nil {
-		t.Errorf("Certificates.Get returned error: %v", err)
-	}
+	require.NoError(t, err)
 
 	expected := &Certificate{
 		ID:              "892071a0-bb95-49bc-8021-3afd67a210bf",
@@ -105,9 +104,7 @@ func TestCertificates_List(t *testing.T) {
 
 	certificates, resp, err := client.Certificates.List(ctx, nil)
 
-	if err != nil {
-		t.Errorf("Certificates.List returned error: %v", err)
-	}
+	require.NoError(t, err)
 
 	expectedCertificates := []Certificate{
 		{
@@ -230,10 +227,8 @@ func TestCertificates_Create(t *testing.T) {
 			})
 
 			certificate, _, err := client.Certificates.Create(ctx, test.createRequest)
-			if err != nil {
-				t.Errorf("Certificates.Create returned error: %v", err)
-			}
 
+			require.NoError(t, err)
 			assert.Equal(t, test.expectedCertificate, certificate)
 		})
 	}
@@ -252,7 +247,5 @@ func TestCertificates_Delete(t *testing.T) {
 
 	_, err := client.Certificates.Delete(ctx, cID)
 
-	if err != nil {
-		t.Errorf("Certificates.Delete returned error: %v", err)
-	}
+	assert.NoError(t, err)
 }

--- a/domains_test.go
+++ b/domains_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"strconv"
 	"testing"
 
@@ -34,19 +33,13 @@ func TestDomains_ListDomains(t *testing.T) {
 	})
 
 	domains, resp, err := client.Domains.List(ctx, nil)
-	if err != nil {
-		t.Errorf("Domains.List returned error: %v", err)
-	}
+	require.NoError(t, err)
 
 	expectedDomains := []Domain{{Name: "foo.com"}, {Name: "bar.com"}}
-	if !reflect.DeepEqual(domains, expectedDomains) {
-		t.Errorf("Domains.List returned domains %+v, expected %+v", domains, expectedDomains)
-	}
+	assert.Equal(t, expectedDomains, domains)
 
 	expectedMeta := &Meta{Total: 2}
-	if !reflect.DeepEqual(resp.Meta, expectedMeta) {
-		t.Errorf("Domains.List returned meta %+v, expected %+v", resp.Meta, expectedMeta)
-	}
+	assert.Equal(t, expectedMeta, resp.Meta)
 }
 
 func TestDomains_ListDomainsMultiplePages(t *testing.T) {
@@ -110,14 +103,10 @@ func TestDomains_GetDomain(t *testing.T) {
 	})
 
 	domains, _, err := client.Domains.Get(ctx, "example.com")
-	if err != nil {
-		t.Errorf("domain.Get returned error: %v", err)
-	}
+	require.NoError(t, err)
 
 	expected := &Domain{Name: "example.com"}
-	if !reflect.DeepEqual(domains, expected) {
-		t.Errorf("domains.Get returned %+v, expected %+v", domains, expected)
-	}
+	assert.Equal(t, expected, domains)
 }
 
 func TestDomains_Create(t *testing.T) {
@@ -137,22 +126,16 @@ func TestDomains_Create(t *testing.T) {
 		}
 
 		testMethod(t, r, http.MethodPost)
-		if !reflect.DeepEqual(v, createRequest) {
-			t.Errorf("Request body = %+v, expected %+v", v, createRequest)
-		}
+		assert.Equal(t, createRequest, v)
 
 		fmt.Fprint(w, `{"domain":{"name":"example.com"}}`)
 	})
 
 	domain, _, err := client.Domains.Create(ctx, createRequest)
-	if err != nil {
-		t.Errorf("Domains.Create returned error: %v", err)
-	}
+	require.NoError(t, err)
 
 	expected := &Domain{Name: "example.com"}
-	if !reflect.DeepEqual(domain, expected) {
-		t.Errorf("Domains.Create returned %+v, expected %+v", domain, expected)
-	}
+	assert.Equal(t, expected, domain)
 }
 
 func TestDomains_Destroy(t *testing.T) {
@@ -164,9 +147,8 @@ func TestDomains_Destroy(t *testing.T) {
 	})
 
 	_, err := client.Domains.Delete(ctx, "example.com")
-	if err != nil {
-		t.Errorf("Domains.Delete returned error: %v", err)
-	}
+
+	assert.NoError(t, err)
 }
 
 func TestDomains_AllRecordsForDomainName(t *testing.T) {
@@ -179,14 +161,10 @@ func TestDomains_AllRecordsForDomainName(t *testing.T) {
 	})
 
 	records, _, err := client.Domains.Records(ctx, "example.com", nil)
-	if err != nil {
-		t.Errorf("Domains.List returned error: %v", err)
-	}
+	require.NoError(t, err)
 
 	expected := []DomainRecord{{ID: 1}, {ID: 2}}
-	if !reflect.DeepEqual(records, expected) {
-		t.Errorf("Domains.Records returned %+v, expected %+v", records, expected)
-	}
+	assert.Equal(t, expected, records)
 }
 
 func TestDomains_AllRecordsForDomainName_PerPage(t *testing.T) {
@@ -204,14 +182,10 @@ func TestDomains_AllRecordsForDomainName_PerPage(t *testing.T) {
 
 	dro := &ListOptions{PerPage: 2}
 	records, _, err := client.Domains.Records(ctx, "example.com", dro)
-	if err != nil {
-		t.Errorf("Domains.List returned error: %v", err)
-	}
+	require.NoError(t, err)
 
 	expected := []DomainRecord{{ID: 1}, {ID: 2}}
-	if !reflect.DeepEqual(records, expected) {
-		t.Errorf("Domains.Records returned %+v, expected %+v", records, expected)
-	}
+	assert.Equal(t, expected, records)
 }
 
 func TestDomains_RecordsByType(t *testing.T) {
@@ -256,9 +230,7 @@ func TestDomains_RecordsByType(t *testing.T) {
 				assert.Equal(t, tt.expectedErr, err)
 			} else {
 				expected := []DomainRecord{{ID: 1}, {ID: 2}}
-				if !reflect.DeepEqual(records, expected) {
-					t.Errorf("Domains.RecordsByType returned %+v, expected %+v", records, expected)
-				}
+				assert.Equal(t, expected, records)
 			}
 		})
 	}
@@ -306,9 +278,7 @@ func TestDomains_RecordsByName(t *testing.T) {
 				assert.Equal(t, tt.expectedErr, err)
 			} else {
 				expected := []DomainRecord{{ID: 1}, {ID: 2}}
-				if !reflect.DeepEqual(records, expected) {
-					t.Errorf("Domains.RecordsByName returned %+v, expected %+v", records, expected)
-				}
+				assert.Equal(t, expected, records)
 			}
 		})
 	}
@@ -366,9 +336,7 @@ func TestDomains_RecordsByTypeAndName(t *testing.T) {
 				assert.Equal(t, tt.expectedErr, err)
 			} else {
 				expected := []DomainRecord{{ID: 1}, {ID: 2}}
-				if !reflect.DeepEqual(records, expected) {
-					t.Errorf("Domains.RecordsByTypeAndName returned %+v, expected %+v", records, expected)
-				}
+				assert.Equal(t, expected, records)
 			}
 		})
 	}
@@ -384,14 +352,10 @@ func TestDomains_GetRecordforDomainName(t *testing.T) {
 	})
 
 	record, _, err := client.Domains.Record(ctx, "example.com", 1)
-	if err != nil {
-		t.Errorf("Domains.GetRecord returned error: %v", err)
-	}
+	require.NoError(t, err)
 
 	expected := &DomainRecord{ID: 1}
-	if !reflect.DeepEqual(record, expected) {
-		t.Errorf("Domains.GetRecord returned %+v, expected %+v", record, expected)
-	}
+	assert.Equal(t, expected, record)
 }
 
 func TestDomains_DeleteRecordForDomainName(t *testing.T) {
@@ -403,9 +367,8 @@ func TestDomains_DeleteRecordForDomainName(t *testing.T) {
 	})
 
 	_, err := client.Domains.DeleteRecord(ctx, "example.com", 1)
-	if err != nil {
-		t.Errorf("Domains.RecordDelete returned error: %v", err)
-	}
+
+	assert.NoError(t, err)
 }
 
 func TestDomains_CreateRecordForDomainName(t *testing.T) {
@@ -429,27 +392,19 @@ func TestDomains_CreateRecordForDomainName(t *testing.T) {
 			v := new(DomainRecordEditRequest)
 			err := json.NewDecoder(r.Body).Decode(v)
 
-			if err != nil {
-				t.Fatalf("decode json: %v", err)
-			}
+			require.NoError(t, err)
 
 			testMethod(t, r, http.MethodPost)
-			if !reflect.DeepEqual(v, createRequest) {
-				t.Errorf("Request body = %+v, expected %+v", v, createRequest)
-			}
+			assert.Equal(t, createRequest, v)
 
 			fmt.Fprintf(w, `{"domain_record": {"id":1}}`)
 		})
 
 	record, _, err := client.Domains.CreateRecord(ctx, "example.com", createRequest)
-	if err != nil {
-		t.Errorf("Domains.CreateRecord returned error: %v", err)
-	}
+	require.NoError(t, err)
 
 	expected := &DomainRecord{ID: 1}
-	if !reflect.DeepEqual(record, expected) {
-		t.Errorf("Domains.CreateRecord returned %+v, expected %+v", record, expected)
-	}
+	assert.Equal(t, expected, record)
 }
 
 func TestDomains_EditRecordForDomainName(t *testing.T) {
@@ -476,22 +431,16 @@ func TestDomains_EditRecordForDomainName(t *testing.T) {
 		}
 
 		testMethod(t, r, http.MethodPut)
-		if !reflect.DeepEqual(v, editRequest) {
-			t.Errorf("Request body = %+v, expected %+v", v, editRequest)
-		}
+		assert.Equal(t, editRequest, v)
 
 		fmt.Fprintf(w, `{"domain_record": {"id":1, "type": "CNAME", "name": "example"}}`)
 	})
 
 	record, _, err := client.Domains.EditRecord(ctx, "example.com", 1, editRequest)
-	if err != nil {
-		t.Errorf("Domains.EditRecord returned error: %v", err)
-	}
+	require.NoError(t, err)
 
 	expected := &DomainRecord{ID: 1, Type: "CNAME", Name: "example"}
-	if !reflect.DeepEqual(record, expected) {
-		t.Errorf("Domains.EditRecord returned %+v, expected %+v", record, expected)
-	}
+	assert.Equal(t, expected, record)
 }
 
 func TestDomainRecord_String(t *testing.T) {
@@ -510,9 +459,7 @@ func TestDomainRecord_String(t *testing.T) {
 
 	stringified := record.String()
 	expected := `godo.DomainRecord{ID:1, Type:"CNAME", Name:"example", Data:"@", Priority:10, Port:10, TTL:1800, Weight:10, Flags:1, Tag:"test"}`
-	if expected != stringified {
-		t.Errorf("DomainRecord.String returned %+v, expected %+v", stringified, expected)
-	}
+	assert.Equal(t, expected, stringified)
 }
 
 func TestDomainRecordEditRequest_String(t *testing.T) {
@@ -530,7 +477,5 @@ func TestDomainRecordEditRequest_String(t *testing.T) {
 
 	stringified := record.String()
 	expected := `godo.DomainRecordEditRequest{Type:"CNAME", Name:"example", Data:"@", Priority:10, Port:10, TTL:1800, Weight:10, Flags:1, Tag:"test"}`
-	if expected != stringified {
-		t.Errorf("DomainRecordEditRequest.String returned %+v, expected %+v", stringified, expected)
-	}
+	assert.Equal(t, expected, stringified)
 }

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -1878,13 +1878,9 @@ func TestWeekday_UnmarshalJSON(t *testing.T) {
 			var got KubernetesMaintenancePolicyDay
 			err := json.Unmarshal([]byte(ts.json), &got)
 			valid := err == nil
-			if valid != ts.valid {
-				t.Errorf("valid unmarshal case\n\tgot: %+v\n\twant : %+v", valid, ts.valid)
-			}
-
-			if valid && got != ts.day {
-				t.Errorf("\ninput: %s\ngot : %+v\nwant  : %+v\n",
-					ts.day, got, ts.day)
+			assert.Equal(t, ts.valid, valid)
+			if valid {
+				assert.Equal(t, ts.day, got)
 			}
 		})
 	}
@@ -1895,13 +1891,9 @@ func TestWeekday_MarshalJSON(t *testing.T) {
 		t.Run(ts.name, func(t *testing.T) {
 			out, err := json.Marshal(ts.day)
 			valid := err == nil
-			if valid != ts.valid {
-				t.Errorf("valid marshal case\n\tgot: %+v\n\twant : %+v", valid, ts.valid)
-			}
-
-			if valid && ts.json != string(out) {
-				t.Errorf("\ninput: %s\ngot : %+v\nwant  : %+v\n",
-					ts.day, string(out), ts.json)
+			assert.Equal(t, ts.valid, valid)
+			if valid {
+				assert.Equal(t, ts.json, string(out))
 			}
 		})
 	}

--- a/load_balancers_test.go
+++ b/load_balancers_test.go
@@ -3,6 +3,7 @@ package godo
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"net/http"
 	"testing"
 
@@ -291,9 +292,7 @@ func TestLoadBalancers_Get(t *testing.T) {
 	})
 
 	loadBalancer, _, err := client.LoadBalancers.Get(ctx, loadBalancerID)
-	if err != nil {
-		t.Errorf("LoadBalancers.Get returned error: %v", err)
-	}
+	require.NoError(t, err)
 
 	expected := &LoadBalancer{
 		ID:        "37e6be88-01ec-4ec7-9bc6-a514d4719057",
@@ -395,9 +394,7 @@ func TestLoadBalancers_Create(t *testing.T) {
 	})
 
 	loadBalancer, _, err := client.LoadBalancers.Create(ctx, createRequest)
-	if err != nil {
-		t.Errorf("LoadBalancers.Create returned error: %v", err)
-	}
+	require.NoError(t, err)
 
 	expected := &LoadBalancer{
 		ID:        "8268a81c-fcf5-423e-a337-bbfe95817f23",
@@ -513,9 +510,7 @@ func TestLoadBalancers_Update(t *testing.T) {
 	})
 
 	loadBalancer, _, err := client.LoadBalancers.Update(ctx, loadBalancerID, updateRequest)
-	if err != nil {
-		t.Errorf("LoadBalancers.Update returned error: %v", err)
-	}
+	require.NoError(t, err)
 
 	expected := &LoadBalancer{
 		ID:        "8268a81c-fcf5-423e-a337-bbfe95817f23",
@@ -578,9 +573,7 @@ func TestLoadBalancers_List(t *testing.T) {
 
 	loadBalancers, resp, err := client.LoadBalancers.List(ctx, nil)
 
-	if err != nil {
-		t.Errorf("LoadBalancers.List returned error: %v", err)
-	}
+	require.NoError(t, err)
 
 	expectedLBs := []LoadBalancer{
 		{
@@ -646,9 +639,7 @@ func TestLoadBalancers_List_Pagination(t *testing.T) {
 	opts := &ListOptions{Page: 2}
 	_, resp, err := client.LoadBalancers.List(ctx, opts)
 
-	if err != nil {
-		t.Errorf("LoadBalancers.List returned error: %v", err)
-	}
+	require.NoError(t, err)
 
 	assert.Equal(t, "http://localhost:3001/v2/load_balancers?page=2&per_page=1", resp.Links.Pages.Next)
 	assert.Equal(t, "http://localhost:3001/v2/load_balancers?page=3&per_page=1", resp.Links.Pages.Last)
@@ -667,9 +658,7 @@ func TestLoadBalancers_Delete(t *testing.T) {
 
 	_, err := client.LoadBalancers.Delete(ctx, lbID)
 
-	if err != nil {
-		t.Errorf("LoadBalancers.Delete returned error: %v", err)
-	}
+	assert.NoError(t, err)
 }
 
 func TestLoadBalancers_AddDroplets(t *testing.T) {
@@ -697,9 +686,7 @@ func TestLoadBalancers_AddDroplets(t *testing.T) {
 
 	_, err := client.LoadBalancers.AddDroplets(ctx, lbID, dropletIdsRequest.IDs...)
 
-	if err != nil {
-		t.Errorf("LoadBalancers.AddDroplets returned error: %v", err)
-	}
+	assert.NoError(t, err)
 }
 
 func TestLoadBalancers_RemoveDroplets(t *testing.T) {
@@ -727,9 +714,7 @@ func TestLoadBalancers_RemoveDroplets(t *testing.T) {
 
 	_, err := client.LoadBalancers.RemoveDroplets(ctx, lbID, dropletIdsRequest.IDs...)
 
-	if err != nil {
-		t.Errorf("LoadBalancers.RemoveDroplets returned error: %v", err)
-	}
+	assert.NoError(t, err)
 }
 
 func TestLoadBalancers_AddForwardingRules(t *testing.T) {
@@ -771,9 +756,7 @@ func TestLoadBalancers_AddForwardingRules(t *testing.T) {
 
 	_, err := client.LoadBalancers.AddForwardingRules(ctx, lbID, frr.Rules...)
 
-	if err != nil {
-		t.Errorf("LoadBalancers.AddForwardingRules returned error: %v", err)
-	}
+	assert.NoError(t, err)
 }
 
 func TestLoadBalancers_RemoveForwardingRules(t *testing.T) {
@@ -814,9 +797,7 @@ func TestLoadBalancers_RemoveForwardingRules(t *testing.T) {
 
 	_, err := client.LoadBalancers.RemoveForwardingRules(ctx, lbID, frr.Rules...)
 
-	if err != nil {
-		t.Errorf("LoadBalancers.RemoveForwardingRules returned error: %v", err)
-	}
+	assert.NoError(t, err)
 }
 
 func TestLoadBalancers_AsRequest(t *testing.T) {


### PR DESCRIPTION
This PR simplifies tests. It replaces `t.Error/t.Errorf` with functions from `github.com/stretchr/testify/assert`/`github.com/stretchr/testify/require` packages.

`require` is used when we should abort test and do not proceed with next asserts.