### PR TITLE
APPS-4420: Add PreservePathPrefix to AppRouteSpec

### DIFF
--- a/apps.gen.go
+++ b/apps.gen.go
@@ -259,7 +259,7 @@ type AppLogDestinationSpecPapertrail struct {
 type AppRouteSpec struct {
 	// An HTTP path prefix. Paths must start with / and must be unique across all components within an app.
 	Path string `json:"path,omitempty"`
-	// An Optional flag to preserve the path that is forwarded to the backend service. By default, the HTTP request path will be trimmed from the left when forwarded to the component. By default a component with path=/api, will have requests to \"/api/list\" trimmed to \"/list\"; if this value is true the path will remain \"/api/list\".
+	//  Boolean. An optional flag to preserve the path that is forwarded to the backend service. By default, the HTTP request path will be trimmed from the left when forwarded to the component. For example, a component with `path=/api` will have requests to `/api/list` trimmed to `/list`. If this value is `true`, the path will remain `/api/list`.
 	PreservePathPrefix bool `json:"preserve_path_prefix,omitempty"`
 }
 

--- a/apps.gen.go
+++ b/apps.gen.go
@@ -259,6 +259,8 @@ type AppLogDestinationSpecPapertrail struct {
 type AppRouteSpec struct {
 	// An HTTP path prefix. Paths must start with / and must be unique across all components within an app.
 	Path string `json:"path,omitempty"`
+	// An Optional flag to preserve the path that is forwarded to the backend service. By default, the HTTP request path will be trimmed from the left when forwarded to the component. By default a component with path=/api, will have requests to \"/api/list\" trimmed to \"/list\"; if this value is true the path will remain \"/api/list\".
+	PreservePathPrefix bool `json:"preserve_path_prefix,omitempty"`
 }
 
 // AppServiceSpec struct for AppServiceSpec

--- a/apps.gen.go
+++ b/apps.gen.go
@@ -259,7 +259,7 @@ type AppLogDestinationSpecPapertrail struct {
 type AppRouteSpec struct {
 	// An HTTP path prefix. Paths must start with / and must be unique across all components within an app.
 	Path string `json:"path,omitempty"`
-	//  Boolean. An optional flag to preserve the path that is forwarded to the backend service. By default, the HTTP request path will be trimmed from the left when forwarded to the component. For example, a component with `path=/api` will have requests to `/api/list` trimmed to `/list`. If this value is `true`, the path will remain `/api/list`.
+	// An optional flag to preserve the path that is forwarded to the backend service. By default, the HTTP request path will be trimmed from the left when forwarded to the component. For example, a component with `path=/api` will have requests to `/api/list` trimmed to `/list`. If this value is `true`, the path will remain `/api/list`.
 	PreservePathPrefix bool `json:"preserve_path_prefix,omitempty"`
 }
 


### PR DESCRIPTION
APPS-4420: This changes gives the option to preserve the route prefix in the forwarded request.

Apps PR: https://github.internal.digitalocean.com/digitalocean/cthulhu/pull/68717