### PR TITLE
registry: Add ListManfiests and ListRepositoriesV2 api endpoint support + Token pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Some endpoints offer token based pagination. For example, to fetch all Registry 
 
 ```go
 func ListRepositoriesV2(ctx context.Context, client *godo.Client, registryName string) ([]*godo.RepositoryV2, error) {
-    // create a list to hold our droplets
+    // create a list to hold our registries
     list := []*godo.RepositoryV2{}
 
     // create options. initially, these will be blank
@@ -133,7 +133,7 @@ func ListRepositoriesV2(ctx context.Context, client *godo.Client, registryName s
             return nil, err
         }
 
-        // append the current page's droplets to our list
+        // append the current page's registries to our list
         list = append(list, repositories...)
 
         // if we are at the last page, break out the for loop

--- a/README.md
+++ b/README.md
@@ -118,6 +118,43 @@ func DropletList(ctx context.Context, client *godo.Client) ([]godo.Droplet, erro
 }
 ```
 
+Some endpoints offer token based pagination. For example, to fetch all Registry Repositories:
+
+```go
+func ListRepositoriesV2(ctx context.Context, client *godo.Client, registryName string) ([]*godo.RepositoryV2, error) {
+    // create a list to hold our droplets
+    list := []*godo.RepositoryV2{}
+
+    // create options. initially, these will be blank
+    opt := &godo.TokenListOptions{}
+    for {
+        repositories, resp, err := client.Registry.ListRepositoriesV2(ctx, registryName, opt)
+        if err != nil {
+            return nil, err
+        }
+
+        // append the current page's droplets to our list
+        list = append(list, repositories...)
+
+        // if we are at the last page, break out the for loop
+        if resp.Links == nil || resp.Links.IsLastPage() {
+            break
+        }
+
+        // grab the next page token
+        nextPageToken, err := resp.Links.NextPageToken()
+        if err != nil {
+            return nil, err
+        }
+
+        // provide the next page token for the next request
+        opt.Token = nextPageToken
+    }
+
+    return list, nil
+}
+```
+
 ## Versioning
 
 Each version of the client is tagged and the version is updated accordingly.

--- a/godo.go
+++ b/godo.go
@@ -99,6 +99,20 @@ type ListOptions struct {
 	PerPage int `url:"per_page,omitempty"`
 }
 
+// TokenListOptions specifies the optional parameters to various List methods that support token pagination.
+type TokenListOptions struct {
+	// For paginated result sets, page of results to retrieve.
+	Page int `url:"page,omitempty"`
+
+	// For paginated result sets, the number of results to include per page.
+	PerPage int `url:"per_page,omitempty"`
+
+	// For paginated result sets which support tokens, the token provided by the last set
+	// of results in order to retrieve the next set of results. This is expected to be faster
+	// than incrementing or decrementing the page number.
+	Token string `url:"page_token,omitempty"`
+}
+
 // Response is a DigitalOcean response. This wraps the standard http.Response returned from DigitalOcean.
 type Response struct {
 	*http.Response

--- a/godo_test.go
+++ b/godo_test.go
@@ -611,6 +611,32 @@ func checkCurrentPage(t *testing.T, resp *Response, expectedPage int) {
 	}
 }
 
+func checkNextPageToken(t *testing.T, resp *Response, expectedNextPageToken string) {
+	t.Helper()
+	links := resp.Links
+	pageToken, err := links.NextPageToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if pageToken != expectedNextPageToken {
+		t.Fatalf("expected next page token to be '%s', was '%s'", expectedNextPageToken, pageToken)
+	}
+}
+
+func checkPreviousPageToken(t *testing.T, resp *Response, expectedPreviousPageToken string) {
+	t.Helper()
+	links := resp.Links
+	pageToken, err := links.PrevPageToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if pageToken != expectedPreviousPageToken {
+		t.Fatalf("expected previous page token to be '%s', was '%s'", expectedPreviousPageToken, pageToken)
+	}
+}
+
 func TestDo_completion_callback(t *testing.T) {
 	setup()
 	defer teardown()

--- a/links.go
+++ b/links.go
@@ -64,7 +64,7 @@ func (p *Pages) nextPageToken() (string, error) {
 	if p == nil || p.Next == "" {
 		return "", nil
 	}
-	token, err := pageTokenForURL(p.Next)
+	token, err := pageTokenFromURL(p.Next)
 	if err != nil {
 		return "", err
 	}
@@ -75,7 +75,7 @@ func (p *Pages) prevPageToken() (string, error) {
 	if p == nil || p.Prev == "" {
 		return "", nil
 	}
-	token, err := pageTokenForURL(p.Prev)
+	token, err := pageTokenFromURL(p.Prev)
 	if err != nil {
 		return "", err
 	}
@@ -109,7 +109,7 @@ func pageForURL(urlText string) (int, error) {
 	return page, nil
 }
 
-func pageTokenForURL(urlText string) (string, error) {
+func pageTokenFromURL(urlText string) (string, error) {
 	u, err := url.ParseRequestURI(urlText)
 	if err != nil {
 		return "", err

--- a/links.go
+++ b/links.go
@@ -32,6 +32,16 @@ func (l *Links) CurrentPage() (int, error) {
 	return l.Pages.current()
 }
 
+// NextPageToken is the page token to request the next page of the list
+func (l *Links) NextPageToken() (string, error) {
+	return l.Pages.nextPageToken()
+}
+
+// PrevPageToken is the page token to request the previous page of the list
+func (l *Links) PrevPageToken() (string, error) {
+	return l.Pages.prevPageToken()
+}
+
 func (p *Pages) current() (int, error) {
 	switch {
 	case p == nil:
@@ -48,6 +58,28 @@ func (p *Pages) current() (int, error) {
 	}
 
 	return 0, nil
+}
+
+func (p *Pages) nextPageToken() (string, error) {
+	if p == nil || p.Next == "" {
+		return "", nil
+	}
+	token, err := pageTokenForURL(p.Next)
+	if err != nil {
+		return "", err
+	}
+	return token, nil
+}
+
+func (p *Pages) prevPageToken() (string, error) {
+	if p == nil || p.Prev == "" {
+		return "", nil
+	}
+	token, err := pageTokenForURL(p.Prev)
+	if err != nil {
+		return "", err
+	}
+	return token, nil
 }
 
 // IsLastPage returns true if the current page is the last
@@ -75,6 +107,14 @@ func pageForURL(urlText string) (int, error) {
 	}
 
 	return page, nil
+}
+
+func pageTokenForURL(urlText string) (string, error) {
+	u, err := url.ParseRequestURI(urlText)
+	if err != nil {
+		return "", err
+	}
+	return u.Query().Get("page_token"), nil
 }
 
 // Get a link action by id.

--- a/registry.go
+++ b/registry.go
@@ -352,6 +352,9 @@ func (svc *RegistryServiceOp) ListRepositoriesV2(ctx context.Context, registry s
 		return nil, resp, err
 	}
 
+	resp.Links = root.Links
+	resp.Meta = root.Meta
+
 	return root.Repositories, resp, nil
 }
 
@@ -415,6 +418,9 @@ func (svc *RegistryServiceOp) ListRepositoryManifests(ctx context.Context, regis
 	if err != nil {
 		return nil, resp, err
 	}
+
+	resp.Links = root.Links
+	resp.Meta = root.Meta
 
 	return root.Manifests, resp, nil
 }

--- a/registry.go
+++ b/registry.go
@@ -352,13 +352,6 @@ func (svc *RegistryServiceOp) ListRepositoriesV2(ctx context.Context, registry s
 		return nil, resp, err
 	}
 
-	if l := root.Links; l != nil {
-		resp.Links = l
-	}
-	if m := root.Meta; m != nil {
-		resp.Meta = m
-	}
-
 	return root.Repositories, resp, nil
 }
 
@@ -421,13 +414,6 @@ func (svc *RegistryServiceOp) ListRepositoryManifests(ctx context.Context, regis
 	resp, err := svc.client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
-	}
-
-	if l := root.Links; l != nil {
-		resp.Links = l
-	}
-	if m := root.Meta; m != nil {
-		resp.Meta = m
 	}
 
 	return root.Manifests, resp, nil

--- a/registry.go
+++ b/registry.go
@@ -25,8 +25,10 @@ type RegistryService interface {
 	Delete(context.Context) (*Response, error)
 	DockerCredentials(context.Context, *RegistryDockerCredentialsRequest) (*DockerCredentials, *Response, error)
 	ListRepositories(context.Context, string, *ListOptions) ([]*Repository, *Response, error)
+	ListRepositoriesV2(context.Context, string, *TokenListOptions) ([]*RepositoryV2, *Response, error)
 	ListRepositoryTags(context.Context, string, string, *ListOptions) ([]*RepositoryTag, *Response, error)
 	DeleteTag(context.Context, string, string, string) (*Response, error)
+	ListRepositoryManifests(context.Context, string, string, *ListOptions) ([]*RepositoryManifest, *Response, error)
 	DeleteManifest(context.Context, string, string, string) (*Response, error)
 	StartGarbageCollection(context.Context, string, ...*StartGarbageCollectionRequest) (*GarbageCollection, *Response, error)
 	GetGarbageCollection(context.Context, string) (*GarbageCollection, *Response, error)
@@ -73,6 +75,15 @@ type Repository struct {
 	TagCount     uint64         `json:"tag_count,omitempty"`
 }
 
+// RepositoryV2 represents a repository in the V2 format
+type RepositoryV2 struct {
+	RegistryName   string              `json:"registry_name,omitempty"`
+	Name           string              `json:"name,omitempty"`
+	TagCount       uint64              `json:"tag_count,omitempty"`
+	ManifestCount  uint64              `json:"manifest_count,omitempty"`
+	LatestManifest *RepositoryManifest `json:"latest_manifest,omitempty"`
+}
+
 // RepositoryTag represents a repository tag
 type RepositoryTag struct {
 	RegistryName        string    `json:"registry_name,omitempty"`
@@ -82,6 +93,24 @@ type RepositoryTag struct {
 	CompressedSizeBytes uint64    `json:"compressed_size_bytes,omitempty"`
 	SizeBytes           uint64    `json:"size_bytes,omitempty"`
 	UpdatedAt           time.Time `json:"updated_at,omitempty"`
+}
+
+// RepositoryManifest represents a repository manifest
+type RepositoryManifest struct {
+	RegistryName        string    `json:"registry_name,omitempty"`
+	Repository          string    `json:"repository,omitempty"`
+	Digest              string    `json:"digest,omitempty"`
+	CompressedSizeBytes uint64    `json:"compressed_size_bytes,omitempty"`
+	SizeBytes           uint64    `json:"size_bytes,omitempty"`
+	UpdatedAt           time.Time `json:"updated_at,omitempty"`
+	Tags                []string  `json:"tags,omitempty"`
+	Blobs               []*Blob   `json:"blobs,omitempty"`
+}
+
+// Blob represents a registry blob
+type Blob struct {
+	Digest              string `json:"digest,omitempty"`
+	CompressedSizeBytes uint64 `json:"compressed_size_bytes,omitempty"`
 }
 
 type registryRoot struct {
@@ -94,10 +123,22 @@ type repositoriesRoot struct {
 	Meta         *Meta         `json:"meta"`
 }
 
+type repositoriesV2Root struct {
+	Repositories []*RepositoryV2 `json:"repositories,omitempty"`
+	Links        *Links          `json:"links,omitempty"`
+	Meta         *Meta           `json:"meta"`
+}
+
 type repositoryTagsRoot struct {
 	Tags  []*RepositoryTag `json:"tags,omitempty"`
 	Links *Links           `json:"links,omitempty"`
 	Meta  *Meta            `json:"meta"`
+}
+
+type repositoryManifestsRoot struct {
+	Manifests []*RepositoryManifest `json:"manifests,omitempty"`
+	Links     *Links                `json:"links,omitempty"`
+	Meta      *Meta                 `json:"meta"`
 }
 
 // GarbageCollection represents a garbage collection.
@@ -293,6 +334,34 @@ func (svc *RegistryServiceOp) ListRepositories(ctx context.Context, registry str
 	return root.Repositories, resp, nil
 }
 
+// ListRepositoriesV2 returns a list of the Repositories in a registry.
+func (svc *RegistryServiceOp) ListRepositoriesV2(ctx context.Context, registry string, opts *TokenListOptions) ([]*RepositoryV2, *Response, error) {
+	path := fmt.Sprintf("%s/%s/repositoriesV2", registryPath, registry)
+	path, err := addOptions(path, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(repositoriesV2Root)
+
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
+	}
+
+	return root.Repositories, resp, nil
+}
+
 // ListRepositoryTags returns a list of the RepositoryTags available within the given repository.
 func (svc *RegistryServiceOp) ListRepositoryTags(ctx context.Context, registry, repository string, opts *ListOptions) ([]*RepositoryTag, *Response, error) {
 	path := fmt.Sprintf("%s/%s/repositories/%s/tags", registryPath, registry, url.PathEscape(repository))
@@ -334,6 +403,34 @@ func (svc *RegistryServiceOp) DeleteTag(ctx context.Context, registry, repositor
 	}
 
 	return resp, nil
+}
+
+// ListRepositoryManifests returns a list of the RepositoryManifests available within the given repository.
+func (svc *RegistryServiceOp) ListRepositoryManifests(ctx context.Context, registry, repository string, opts *ListOptions) ([]*RepositoryManifest, *Response, error) {
+	path := fmt.Sprintf("%s/%s/repositories/%s/digests", registryPath, registry, url.PathEscape(repository))
+	path, err := addOptions(path, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(repositoryManifestsRoot)
+
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
+	}
+
+	return root.Manifests, resp, nil
 }
 
 // DeleteManifest deletes a manifest by its digest within a given repository.


### PR DESCRIPTION
**Changes**
- Adds godo support for new endpoints. See docs PR https://github.com/digitalocean/openapi/pull/567 

I did go ahead and create a throwaway project to test these new methods and they work as expected. The token pagination also works well 👍🏻 

**Follow up**
- Changelog / version bump
- Add support to doctl

CON-3907