### PR TITLE
Add private networking configuration options to the Create request

### DIFF
--- a/droplets.go
+++ b/droplets.go
@@ -216,37 +216,41 @@ func (d DropletCreateSSHKey) MarshalJSON() ([]byte, error) {
 
 // DropletCreateRequest represents a request to create a Droplet.
 type DropletCreateRequest struct {
-	Name              string                `json:"name"`
-	Region            string                `json:"region"`
-	Size              string                `json:"size"`
-	Image             DropletCreateImage    `json:"image"`
-	SSHKeys           []DropletCreateSSHKey `json:"ssh_keys"`
-	Backups           bool                  `json:"backups"`
-	IPv6              bool                  `json:"ipv6"`
-	PrivateNetworking bool                  `json:"private_networking"`
-	Monitoring        bool                  `json:"monitoring"`
-	UserData          string                `json:"user_data,omitempty"`
-	Volumes           []DropletCreateVolume `json:"volumes,omitempty"`
-	Tags              []string              `json:"tags"`
-	VPCUUID           string                `json:"vpc_uuid,omitempty"`
-	WithDropletAgent  *bool                 `json:"with_droplet_agent,omitempty"`
+	Name                    string                `json:"name"`
+	Region                  string                `json:"region"`
+	Size                    string                `json:"size"`
+	Image                   DropletCreateImage    `json:"image"`
+	SSHKeys                 []DropletCreateSSHKey `json:"ssh_keys"`
+	Backups                 bool                  `json:"backups"`
+	IPv6                    bool                  `json:"ipv6"`
+	PrivateNetworking       bool                  `json:"private_networking"`
+	Monitoring              bool                  `json:"monitoring"`
+	UserData                string                `json:"user_data,omitempty"`
+	Volumes                 []DropletCreateVolume `json:"volumes,omitempty"`
+	Tags                    []string              `json:"tags"`
+	VPCUUID                 string                `json:"vpc_uuid,omitempty"`
+	WithDropletAgent        *bool                 `json:"with_droplet_agent,omitempty"`
+	DisablePublicNetworking bool                  `json:"disable_public_networking,omitempty"`
+	WithFloatingIPAddress   bool                  `json:"with_floating_ip_address,omitempty"`
 }
 
 // DropletMultiCreateRequest is a request to create multiple Droplets.
 type DropletMultiCreateRequest struct {
-	Names             []string              `json:"names"`
-	Region            string                `json:"region"`
-	Size              string                `json:"size"`
-	Image             DropletCreateImage    `json:"image"`
-	SSHKeys           []DropletCreateSSHKey `json:"ssh_keys"`
-	Backups           bool                  `json:"backups"`
-	IPv6              bool                  `json:"ipv6"`
-	PrivateNetworking bool                  `json:"private_networking"`
-	Monitoring        bool                  `json:"monitoring"`
-	UserData          string                `json:"user_data,omitempty"`
-	Tags              []string              `json:"tags"`
-	VPCUUID           string                `json:"vpc_uuid,omitempty"`
-	WithDropletAgent  *bool                 `json:"with_droplet_agent,omitempty"`
+	Names                   []string              `json:"names"`
+	Region                  string                `json:"region"`
+	Size                    string                `json:"size"`
+	Image                   DropletCreateImage    `json:"image"`
+	SSHKeys                 []DropletCreateSSHKey `json:"ssh_keys"`
+	Backups                 bool                  `json:"backups"`
+	IPv6                    bool                  `json:"ipv6"`
+	PrivateNetworking       bool                  `json:"private_networking"`
+	Monitoring              bool                  `json:"monitoring"`
+	UserData                string                `json:"user_data,omitempty"`
+	Tags                    []string              `json:"tags"`
+	VPCUUID                 string                `json:"vpc_uuid,omitempty"`
+	WithDropletAgent        *bool                 `json:"with_droplet_agent,omitempty"`
+	DisablePublicNetworking bool                  `json:"disable_public_networking,omitempty"`
+	WithFloatingIPAddress   bool                  `json:"with_floating_ip_address,omitempty"`
 }
 
 func (d DropletCreateRequest) String() string {

--- a/godo_test.go
+++ b/godo_test.go
@@ -276,6 +276,62 @@ func TestNewRequest_withDropletAgent(t *testing.T) {
 	}
 }
 
+func TestNewRequest_DisablePublicNetworking(t *testing.T) {
+	c := NewClient(nil)
+
+	inURL, outURL := "/foo", defaultBaseURL+"foo"
+	inBody, outBody := &DropletCreateRequest{Name: "l", DisablePublicNetworking: true},
+		`{"name":"l","region":"","size":"","image":0,`+
+			`"ssh_keys":null,"backups":false,"ipv6":false,`+
+			`"private_networking":false,"monitoring":false,"tags":null,"disable_public_networking":true}`+"\n"
+	req, _ := c.NewRequest(ctx, http.MethodPost, inURL, inBody)
+
+	// test relative URL was expanded
+	if req.URL.String() != outURL {
+		t.Errorf("NewRequest(%v) URL = %v, expected %v", inURL, req.URL, outURL)
+	}
+
+	// test body was JSON encoded
+	body, _ := ioutil.ReadAll(req.Body)
+	if string(body) != outBody {
+		t.Errorf("NewRequest(%v)Body = %v, expected %v", inBody, string(body), outBody)
+	}
+
+	// test default user-agent is attached to the request
+	userAgent := req.Header.Get("User-Agent")
+	if c.UserAgent != userAgent {
+		t.Errorf("NewRequest() User-Agent = %v, expected %v", userAgent, c.UserAgent)
+	}
+}
+
+func TestNewRequest_WithFLoatingIPAddress(t *testing.T) {
+	c := NewClient(nil)
+
+	inURL, outURL := "/foo", defaultBaseURL+"foo"
+	inBody, outBody := &DropletCreateRequest{Name: "l", WithFloatingIPAddress: true},
+		`{"name":"l","region":"","size":"","image":0,`+
+			`"ssh_keys":null,"backups":false,"ipv6":false,`+
+			`"private_networking":false,"monitoring":false,"tags":null,"with_floating_ip_address":true}`+"\n"
+	req, _ := c.NewRequest(ctx, http.MethodPost, inURL, inBody)
+
+	// test relative URL was expanded
+	if req.URL.String() != outURL {
+		t.Errorf("NewRequest(%v) URL = %v, expected %v", inURL, req.URL, outURL)
+	}
+
+	// test body was JSON encoded
+	body, _ := ioutil.ReadAll(req.Body)
+	if string(body) != outBody {
+		t.Errorf("NewRequest(%v)Body = %v, expected %v", inBody, string(body), outBody)
+	}
+
+	// test default user-agent is attached to the request
+	userAgent := req.Header.Get("User-Agent")
+	if c.UserAgent != userAgent {
+		t.Errorf("NewRequest() User-Agent = %v, expected %v", userAgent, c.UserAgent)
+	}
+}
+
 func TestNewRequest_badURL(t *testing.T) {
 	c := NewClient(nil)
 	_, err := c.NewRequest(ctx, http.MethodGet, ":", nil)


### PR DESCRIPTION
During the create request, it will soon be possible to create droplets
that have no public interface attached to them (droplets that only have
a private interface).

It will also be possible to attach a floating IP address to a droplet
during the create proceess.

This PR sets up the DropletCreateRequest fields to allow for that.

Signed-off-by: Chris Cummer <ccummer@digitalocean.com>