### PR TITLE
registry: Add registry region support

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -50,6 +50,7 @@ type RegistryServiceOp struct {
 type RegistryCreateRequest struct {
 	Name                 string `json:"name,omitempty"`
 	SubscriptionTierSlug string `json:"subscription_tier_slug,omitempty"`
+	Region               string `json:"region,omitempty"`
 }
 
 // RegistryDockerCredentialsRequest represents a request to retrieve docker
@@ -65,6 +66,7 @@ type Registry struct {
 	StorageUsageBytes          uint64    `json:"storage_usage_bytes,omitempty"`
 	StorageUsageBytesUpdatedAt time.Time `json:"storage_usage_bytes_updated_at,omitempty"`
 	CreatedAt                  time.Time `json:"created_at,omitempty"`
+	Region                     string    `json:"region,omitempty"`
 }
 
 // Repository represents a repository
@@ -192,6 +194,7 @@ type UpdateGarbageCollectionRequest struct {
 // RegistryOptions are options for users when creating or updating a registry.
 type RegistryOptions struct {
 	SubscriptionTiers []*RegistrySubscriptionTier `json:"subscription_tiers,omitempty"`
+	AvailableRegions  []string                    `json:"available_regions"`
 }
 
 type registryOptionsRoot struct {

--- a/registry_test.go
+++ b/registry_test.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	testRegistry          = "test-registry"
+	testRegion            = "r1"
 	testRepository        = "test/repository"
 	testEncodedRepository = "test%2Frepository"
 	testTag               = "test-tag"
@@ -52,11 +53,13 @@ func TestRegistry_Create(t *testing.T) {
 		StorageUsageBytes:          0,
 		StorageUsageBytesUpdatedAt: testTime,
 		CreatedAt:                  testTime,
+		Region:                     testRegion,
 	}
 
 	createRequest := &RegistryCreateRequest{
 		Name:                 want.Name,
 		SubscriptionTierSlug: "basic",
+		Region:               testRegion,
 	}
 
 	createResponseJSON := `
@@ -65,7 +68,8 @@ func TestRegistry_Create(t *testing.T) {
 		"name": "` + testRegistry + `",
 		"storage_usage_bytes": 0,
         "storage_usage_bytes_updated_at": "` + testTimeString + `",
-        "created_at": "` + testTimeString + `"
+        "created_at": "` + testTimeString + `",
+		"region": "` + testRegion + `"
 	},
     "subscription": {
       "tier": {
@@ -108,6 +112,7 @@ func TestRegistry_Get(t *testing.T) {
 		StorageUsageBytes:          0,
 		StorageUsageBytesUpdatedAt: testTime,
 		CreatedAt:                  testTime,
+		Region:                     testRegion,
 	}
 
 	getResponseJSON := `
@@ -116,7 +121,8 @@ func TestRegistry_Get(t *testing.T) {
 		"name": "` + testRegistry + `",
 		"storage_usage_bytes": 0,
         "storage_usage_bytes_updated_at": "` + testTimeString + `",
-        "created_at": "` + testTimeString + `"
+        "created_at": "` + testTimeString + `",
+		"region": "` + testRegion + `"
 	}
 }`
 
@@ -730,6 +736,10 @@ func TestRegistry_GetOptions(t *testing.T) {
 	responseJSON := `
 {
   "options": {
+	"available_regions": [
+		"r1",
+		"r2"
+	],
     "subscription_tiers": [
       {
         "name": "Starter",
@@ -772,6 +782,10 @@ func TestRegistry_GetOptions(t *testing.T) {
   }
 }`
 	want := &RegistryOptions{
+		AvailableRegions: []string{
+			"r1",
+			"r2",
+		},
 		SubscriptionTiers: []*RegistrySubscriptionTier{
 			{
 				Name:                   "Starter",


### PR DESCRIPTION
Added DOCR Registry and Options region support to reflect API changes added with CON-5476/CON-5477 (not yet deployed). 

Pairs with https://github.com/digitalocean/openapi/pull/589