### PR TITLE
Add FloatingIPAddress option to the create process

### DIFF
--- a/droplets.go
+++ b/droplets.go
@@ -232,6 +232,7 @@ type DropletCreateRequest struct {
 	WithDropletAgent        *bool                 `json:"with_droplet_agent,omitempty"`
 	DisablePublicNetworking bool                  `json:"disable_public_networking,omitempty"`
 	WithFloatingIPAddress   bool                  `json:"with_floating_ip_address,omitempty"`
+	FloatingIPAddress       string                `json:"floating_ip_address,omitempty"`
 }
 
 // DropletMultiCreateRequest is a request to create multiple Droplets.

--- a/droplets_test.go
+++ b/droplets_test.go
@@ -537,6 +537,86 @@ func TestDroplets_CreateWithFloatingIPAddress(t *testing.T) {
 	}
 }
 
+func TestDroplets_CreateFloatingIPAddress(t *testing.T) {
+	setup()
+	defer teardown()
+
+	createRequest := &DropletCreateRequest{
+		Name:   "name",
+		Region: "region",
+		Size:   "size",
+		Image: DropletCreateImage{
+			ID: 1,
+		},
+		Volumes: []DropletCreateVolume{
+			{ID: "hello-im-another-volume"},
+			{Name: "should be ignored due to Name", ID: "aaa-111-bbb-222-ccc"},
+		},
+		Tags:              []string{"one", "two"},
+		VPCUUID:           "880b7f98-f062-404d-b33c-458d545696f6",
+		FloatingIPAddress: "123.234.345.456",
+	}
+
+	mux.HandleFunc("/v2/droplets", func(w http.ResponseWriter, r *http.Request) {
+		expected := map[string]interface{}{
+			"name":               "name",
+			"region":             "region",
+			"size":               "size",
+			"image":              float64(1),
+			"ssh_keys":           nil,
+			"backups":            false,
+			"ipv6":               false,
+			"private_networking": false,
+			"monitoring":         false,
+			"volumes": []interface{}{
+				map[string]interface{}{"id": "hello-im-another-volume"},
+				map[string]interface{}{"id": "aaa-111-bbb-222-ccc"},
+			},
+			"tags":                []interface{}{"one", "two"},
+			"vpc_uuid":            "880b7f98-f062-404d-b33c-458d545696f6",
+			"floating_ip_address": "123.234.345.456",
+		}
+		jsonBlob := `
+{
+  "droplet": {
+    "id": 1,
+    "vpc_uuid": "880b7f98-f062-404d-b33c-458d545696f6"
+  },
+  "links": {
+    "actions": [
+      {
+        "id": 1,
+        "href": "http://example.com",
+        "rel": "create"
+      }
+    ]
+  }
+}
+`
+
+		var v map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&v)
+		if err != nil {
+			t.Fatalf("decode json: %v", err)
+		}
+
+		if !reflect.DeepEqual(v, expected) {
+			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
+		}
+
+		fmt.Fprintf(w, jsonBlob)
+	})
+
+	droplet, _, err := client.Droplets.Create(ctx, createRequest)
+	if err != nil {
+		t.Errorf("Droplets.Create returned error: %v", err)
+	}
+
+	if id := droplet.ID; id != 1 {
+		t.Errorf("expected id '%d', received '%d'", 1, id)
+	}
+}
+
 func TestDroplet_PrivateNetworkingJsonMarshal(t *testing.T) {
 	tests := []struct {
 		in   *DropletCreateRequest


### PR DESCRIPTION
Adds the ability to pass an explicit Floating IP address along with a droplet create request. Only applies to the singular droplet create flow, does not apply to the multiple droplet create flow (cannot assign the same FLIP to multiple droplets).

Signed-off-by: Chris Cummer <chriscummer@me.com>