### PR TITLE
Remove the WithFloatingIPAddress create option

### DIFF
--- a/droplets.go
+++ b/droplets.go
@@ -231,7 +231,6 @@ type DropletCreateRequest struct {
 	VPCUUID                 string                `json:"vpc_uuid,omitempty"`
 	WithDropletAgent        *bool                 `json:"with_droplet_agent,omitempty"`
 	DisablePublicNetworking bool                  `json:"disable_public_networking,omitempty"`
-	WithFloatingIPAddress   bool                  `json:"with_floating_ip_address,omitempty"`
 }
 
 // DropletMultiCreateRequest is a request to create multiple Droplets.
@@ -250,7 +249,6 @@ type DropletMultiCreateRequest struct {
 	VPCUUID                 string                `json:"vpc_uuid,omitempty"`
 	WithDropletAgent        *bool                 `json:"with_droplet_agent,omitempty"`
 	DisablePublicNetworking bool                  `json:"disable_public_networking,omitempty"`
-	WithFloatingIPAddress   bool                  `json:"with_floating_ip_address,omitempty"`
 }
 
 func (d DropletCreateRequest) String() string {

--- a/droplets_test.go
+++ b/droplets_test.go
@@ -457,86 +457,6 @@ func TestDroplets_CreateWithDisabledPublicNetworking(t *testing.T) {
 	}
 }
 
-func TestDroplets_CreateWithFloatingIPAddress(t *testing.T) {
-	setup()
-	defer teardown()
-
-	createRequest := &DropletCreateRequest{
-		Name:   "name",
-		Region: "region",
-		Size:   "size",
-		Image: DropletCreateImage{
-			ID: 1,
-		},
-		Volumes: []DropletCreateVolume{
-			{ID: "hello-im-another-volume"},
-			{Name: "should be ignored due to Name", ID: "aaa-111-bbb-222-ccc"},
-		},
-		Tags:                  []string{"one", "two"},
-		VPCUUID:               "880b7f98-f062-404d-b33c-458d545696f6",
-		WithFloatingIPAddress: true,
-	}
-
-	mux.HandleFunc("/v2/droplets", func(w http.ResponseWriter, r *http.Request) {
-		expected := map[string]interface{}{
-			"name":               "name",
-			"region":             "region",
-			"size":               "size",
-			"image":              float64(1),
-			"ssh_keys":           nil,
-			"backups":            false,
-			"ipv6":               false,
-			"private_networking": false,
-			"monitoring":         false,
-			"volumes": []interface{}{
-				map[string]interface{}{"id": "hello-im-another-volume"},
-				map[string]interface{}{"id": "aaa-111-bbb-222-ccc"},
-			},
-			"tags":                     []interface{}{"one", "two"},
-			"vpc_uuid":                 "880b7f98-f062-404d-b33c-458d545696f6",
-			"with_floating_ip_address": true,
-		}
-		jsonBlob := `
-{
-  "droplet": {
-    "id": 1,
-    "vpc_uuid": "880b7f98-f062-404d-b33c-458d545696f6"
-  },
-  "links": {
-    "actions": [
-      {
-        "id": 1,
-        "href": "http://example.com",
-        "rel": "create"
-      }
-    ]
-  }
-}
-`
-
-		var v map[string]interface{}
-		err := json.NewDecoder(r.Body).Decode(&v)
-		if err != nil {
-			t.Fatalf("decode json: %v", err)
-		}
-
-		if !reflect.DeepEqual(v, expected) {
-			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
-		}
-
-		fmt.Fprintf(w, jsonBlob)
-	})
-
-	droplet, _, err := client.Droplets.Create(ctx, createRequest)
-	if err != nil {
-		t.Errorf("Droplets.Create returned error: %v", err)
-	}
-
-	if id := droplet.ID; id != 1 {
-		t.Errorf("expected id '%d', received '%d'", 1, id)
-	}
-}
-
 func TestDroplet_PrivateNetworkingJsonMarshal(t *testing.T) {
 	tests := []struct {
 		in   *DropletCreateRequest
@@ -547,12 +467,12 @@ func TestDroplet_PrivateNetworkingJsonMarshal(t *testing.T) {
 			want: `{"name":"foo","region":"","size":"","image":0,"ssh_keys":null,"backups":false,"ipv6":false,"private_networking":false,"monitoring":false,"tags":null}`,
 		},
 		{
-			in:   &DropletCreateRequest{Name: "foo", DisablePublicNetworking: false, WithFloatingIPAddress: false},
+			in:   &DropletCreateRequest{Name: "foo", DisablePublicNetworking: false},
 			want: `{"name":"foo","region":"","size":"","image":0,"ssh_keys":null,"backups":false,"ipv6":false,"private_networking":false,"monitoring":false,"tags":null}`,
 		},
 		{
-			in:   &DropletCreateRequest{Name: "foo", DisablePublicNetworking: true, WithFloatingIPAddress: true},
-			want: `{"name":"foo","region":"","size":"","image":0,"ssh_keys":null,"backups":false,"ipv6":false,"private_networking":false,"monitoring":false,"tags":null,"disable_public_networking":true,"with_floating_ip_address":true}`,
+			in:   &DropletCreateRequest{Name: "foo", DisablePublicNetworking: true},
+			want: `{"name":"foo","region":"","size":"","image":0,"ssh_keys":null,"backups":false,"ipv6":false,"private_networking":false,"monitoring":false,"tags":null,"disable_public_networking":true}`,
 		},
 	}
 

--- a/godo_test.go
+++ b/godo_test.go
@@ -304,34 +304,6 @@ func TestNewRequest_DisablePublicNetworking(t *testing.T) {
 	}
 }
 
-func TestNewRequest_WithFLoatingIPAddress(t *testing.T) {
-	c := NewClient(nil)
-
-	inURL, outURL := "/foo", defaultBaseURL+"foo"
-	inBody, outBody := &DropletCreateRequest{Name: "l", WithFloatingIPAddress: true},
-		`{"name":"l","region":"","size":"","image":0,`+
-			`"ssh_keys":null,"backups":false,"ipv6":false,`+
-			`"private_networking":false,"monitoring":false,"tags":null,"with_floating_ip_address":true}`+"\n"
-	req, _ := c.NewRequest(ctx, http.MethodPost, inURL, inBody)
-
-	// test relative URL was expanded
-	if req.URL.String() != outURL {
-		t.Errorf("NewRequest(%v) URL = %v, expected %v", inURL, req.URL, outURL)
-	}
-
-	// test body was JSON encoded
-	body, _ := ioutil.ReadAll(req.Body)
-	if string(body) != outBody {
-		t.Errorf("NewRequest(%v)Body = %v, expected %v", inBody, string(body), outBody)
-	}
-
-	// test default user-agent is attached to the request
-	userAgent := req.Header.Get("User-Agent")
-	if c.UserAgent != userAgent {
-		t.Errorf("NewRequest() User-Agent = %v, expected %v", userAgent, c.UserAgent)
-	}
-}
-
 func TestNewRequest_badURL(t *testing.T) {
 	c := NewClient(nil)
 	_, err := c.NewRequest(ctx, http.MethodGet, ":", nil)


### PR DESCRIPTION
This option is not currently used by anyone at will some point be renamed to `WithReservedIPAddress`. Rather than keep dead code around, this PR removes it.

The new create options will be added when there's functional API endpoints for them to operate against.

Signed-off-by: Chris Cummer <chriscummer@me.com>