### PR TITLE
Remove DisablePublicNetworking option from the Create path

### DIFF
--- a/droplets.go
+++ b/droplets.go
@@ -216,39 +216,37 @@ func (d DropletCreateSSHKey) MarshalJSON() ([]byte, error) {
 
 // DropletCreateRequest represents a request to create a Droplet.
 type DropletCreateRequest struct {
-	Name                    string                `json:"name"`
-	Region                  string                `json:"region"`
-	Size                    string                `json:"size"`
-	Image                   DropletCreateImage    `json:"image"`
-	SSHKeys                 []DropletCreateSSHKey `json:"ssh_keys"`
-	Backups                 bool                  `json:"backups"`
-	IPv6                    bool                  `json:"ipv6"`
-	PrivateNetworking       bool                  `json:"private_networking"`
-	Monitoring              bool                  `json:"monitoring"`
-	UserData                string                `json:"user_data,omitempty"`
-	Volumes                 []DropletCreateVolume `json:"volumes,omitempty"`
-	Tags                    []string              `json:"tags"`
-	VPCUUID                 string                `json:"vpc_uuid,omitempty"`
-	WithDropletAgent        *bool                 `json:"with_droplet_agent,omitempty"`
-	DisablePublicNetworking bool                  `json:"disable_public_networking,omitempty"`
+	Name              string                `json:"name"`
+	Region            string                `json:"region"`
+	Size              string                `json:"size"`
+	Image             DropletCreateImage    `json:"image"`
+	SSHKeys           []DropletCreateSSHKey `json:"ssh_keys"`
+	Backups           bool                  `json:"backups"`
+	IPv6              bool                  `json:"ipv6"`
+	PrivateNetworking bool                  `json:"private_networking"`
+	Monitoring        bool                  `json:"monitoring"`
+	UserData          string                `json:"user_data,omitempty"`
+	Volumes           []DropletCreateVolume `json:"volumes,omitempty"`
+	Tags              []string              `json:"tags"`
+	VPCUUID           string                `json:"vpc_uuid,omitempty"`
+	WithDropletAgent  *bool                 `json:"with_droplet_agent,omitempty"`
 }
 
 // DropletMultiCreateRequest is a request to create multiple Droplets.
 type DropletMultiCreateRequest struct {
-	Names                   []string              `json:"names"`
-	Region                  string                `json:"region"`
-	Size                    string                `json:"size"`
-	Image                   DropletCreateImage    `json:"image"`
-	SSHKeys                 []DropletCreateSSHKey `json:"ssh_keys"`
-	Backups                 bool                  `json:"backups"`
-	IPv6                    bool                  `json:"ipv6"`
-	PrivateNetworking       bool                  `json:"private_networking"`
-	Monitoring              bool                  `json:"monitoring"`
-	UserData                string                `json:"user_data,omitempty"`
-	Tags                    []string              `json:"tags"`
-	VPCUUID                 string                `json:"vpc_uuid,omitempty"`
-	WithDropletAgent        *bool                 `json:"with_droplet_agent,omitempty"`
-	DisablePublicNetworking bool                  `json:"disable_public_networking,omitempty"`
+	Names             []string              `json:"names"`
+	Region            string                `json:"region"`
+	Size              string                `json:"size"`
+	Image             DropletCreateImage    `json:"image"`
+	SSHKeys           []DropletCreateSSHKey `json:"ssh_keys"`
+	Backups           bool                  `json:"backups"`
+	IPv6              bool                  `json:"ipv6"`
+	PrivateNetworking bool                  `json:"private_networking"`
+	Monitoring        bool                  `json:"monitoring"`
+	UserData          string                `json:"user_data,omitempty"`
+	Tags              []string              `json:"tags"`
+	VPCUUID           string                `json:"vpc_uuid,omitempty"`
+	WithDropletAgent  *bool                 `json:"with_droplet_agent,omitempty"`
 }
 
 func (d DropletCreateRequest) String() string {

--- a/droplets_test.go
+++ b/droplets_test.go
@@ -392,9 +392,8 @@ func TestDroplets_CreateWithDisabledPublicNetworking(t *testing.T) {
 			{ID: "hello-im-another-volume"},
 			{Name: "should be ignored due to Name", ID: "aaa-111-bbb-222-ccc"},
 		},
-		Tags:                    []string{"one", "two"},
-		VPCUUID:                 "880b7f98-f062-404d-b33c-458d545696f6",
-		DisablePublicNetworking: true,
+		Tags:    []string{"one", "two"},
+		VPCUUID: "880b7f98-f062-404d-b33c-458d545696f6",
 	}
 
 	mux.HandleFunc("/v2/droplets", func(w http.ResponseWriter, r *http.Request) {
@@ -412,9 +411,8 @@ func TestDroplets_CreateWithDisabledPublicNetworking(t *testing.T) {
 				map[string]interface{}{"id": "hello-im-another-volume"},
 				map[string]interface{}{"id": "aaa-111-bbb-222-ccc"},
 			},
-			"tags":                      []interface{}{"one", "two"},
-			"vpc_uuid":                  "880b7f98-f062-404d-b33c-458d545696f6",
-			"disable_public_networking": true,
+			"tags":     []interface{}{"one", "two"},
+			"vpc_uuid": "880b7f98-f062-404d-b33c-458d545696f6",
 		}
 		jsonBlob := `
 {
@@ -454,38 +452,6 @@ func TestDroplets_CreateWithDisabledPublicNetworking(t *testing.T) {
 
 	if id := droplet.ID; id != 1 {
 		t.Errorf("expected id '%d', received '%d'", 1, id)
-	}
-}
-
-func TestDroplet_PrivateNetworkingJsonMarshal(t *testing.T) {
-	tests := []struct {
-		in   *DropletCreateRequest
-		want string
-	}{
-		{
-			in:   &DropletCreateRequest{Name: "foo"},
-			want: `{"name":"foo","region":"","size":"","image":0,"ssh_keys":null,"backups":false,"ipv6":false,"private_networking":false,"monitoring":false,"tags":null}`,
-		},
-		{
-			in:   &DropletCreateRequest{Name: "foo", DisablePublicNetworking: false},
-			want: `{"name":"foo","region":"","size":"","image":0,"ssh_keys":null,"backups":false,"ipv6":false,"private_networking":false,"monitoring":false,"tags":null}`,
-		},
-		{
-			in:   &DropletCreateRequest{Name: "foo", DisablePublicNetworking: true},
-			want: `{"name":"foo","region":"","size":"","image":0,"ssh_keys":null,"backups":false,"ipv6":false,"private_networking":false,"monitoring":false,"tags":null,"disable_public_networking":true}`,
-		},
-	}
-
-	for _, tt := range tests {
-		got, err := json.Marshal(tt.in)
-
-		if err != nil {
-			t.Fatalf("error: %v", err)
-		}
-
-		if !reflect.DeepEqual(tt.want, string(got)) {
-			t.Errorf("\nexpected: %v\n,    got: %v", tt.want, string(got))
-		}
 	}
 }
 

--- a/godo_test.go
+++ b/godo_test.go
@@ -276,34 +276,6 @@ func TestNewRequest_withDropletAgent(t *testing.T) {
 	}
 }
 
-func TestNewRequest_DisablePublicNetworking(t *testing.T) {
-	c := NewClient(nil)
-
-	inURL, outURL := "/foo", defaultBaseURL+"foo"
-	inBody, outBody := &DropletCreateRequest{Name: "l", DisablePublicNetworking: true},
-		`{"name":"l","region":"","size":"","image":0,`+
-			`"ssh_keys":null,"backups":false,"ipv6":false,`+
-			`"private_networking":false,"monitoring":false,"tags":null,"disable_public_networking":true}`+"\n"
-	req, _ := c.NewRequest(ctx, http.MethodPost, inURL, inBody)
-
-	// test relative URL was expanded
-	if req.URL.String() != outURL {
-		t.Errorf("NewRequest(%v) URL = %v, expected %v", inURL, req.URL, outURL)
-	}
-
-	// test body was JSON encoded
-	body, _ := ioutil.ReadAll(req.Body)
-	if string(body) != outBody {
-		t.Errorf("NewRequest(%v)Body = %v, expected %v", inBody, string(body), outBody)
-	}
-
-	// test default user-agent is attached to the request
-	userAgent := req.Header.Get("User-Agent")
-	if c.UserAgent != userAgent {
-		t.Errorf("NewRequest() User-Agent = %v, expected %v", userAgent, c.UserAgent)
-	}
-}
-
 func TestNewRequest_badURL(t *testing.T) {
 	c := NewClient(nil)
 	_, err := c.NewRequest(ctx, http.MethodGet, ":", nil)


### PR DESCRIPTION
This option is now set from within the backend based on internal considerations and is no longer user-definable.

Signed-off-by: Chris Cummer <chriscummer@me.com>