### PR TITLE
Add support for Reserved IP addresses

### DIFF
--- a/account.go
+++ b/account.go
@@ -24,6 +24,7 @@ var _ AccountService = &AccountServiceOp{}
 type Account struct {
 	DropletLimit    int    `json:"droplet_limit,omitempty"`
 	FloatingIPLimit int    `json:"floating_ip_limit,omitempty"`
+	ReservedIPLimit int    `json:"reserved_ip_limit,omitempty"`
 	VolumeLimit     int    `json:"volume_limit,omitempty"`
 	Email           string `json:"email,omitempty"`
 	UUID            string `json:"uuid,omitempty"`

--- a/account_test.go
+++ b/account_test.go
@@ -18,6 +18,7 @@ func TestAccountGet(t *testing.T) {
 		{ "account": {
 			"droplet_limit": 25,
 			"floating_ip_limit": 25,
+			"reserved_ip_limit": 25,
 			"volume_limit": 22,
 			"email": "sammy@digitalocean.com",
 			"uuid": "b6fr89dbf6d9156cace5f3c78dc9851d957381ef",
@@ -33,7 +34,7 @@ func TestAccountGet(t *testing.T) {
 		t.Errorf("Account.Get returned error: %v", err)
 	}
 
-	expected := &Account{DropletLimit: 25, FloatingIPLimit: 25, Email: "sammy@digitalocean.com",
+	expected := &Account{DropletLimit: 25, FloatingIPLimit: 25, ReservedIPLimit: 25, Email: "sammy@digitalocean.com",
 		UUID: "b6fr89dbf6d9156cace5f3c78dc9851d957381ef", EmailVerified: true, VolumeLimit: 22}
 	if !reflect.DeepEqual(acct, expected) {
 		t.Errorf("Account.Get returned %+v, expected %+v", acct, expected)
@@ -44,6 +45,7 @@ func TestAccountString(t *testing.T) {
 	acct := &Account{
 		DropletLimit:    25,
 		FloatingIPLimit: 25,
+		ReservedIPLimit: 25,
 		Email:           "sammy@digitalocean.com",
 		UUID:            "b6fr89dbf6d9156cace5f3c78dc9851d957381ef",
 		EmailVerified:   true,
@@ -53,7 +55,7 @@ func TestAccountString(t *testing.T) {
 	}
 
 	stringified := acct.String()
-	expected := `godo.Account{DropletLimit:25, FloatingIPLimit:25, VolumeLimit:22, Email:"sammy@digitalocean.com", UUID:"b6fr89dbf6d9156cace5f3c78dc9851d957381ef", EmailVerified:true, Status:"active", StatusMessage:"message"}`
+	expected := `godo.Account{DropletLimit:25, FloatingIPLimit:25, ReservedIPLimit:25, VolumeLimit:22, Email:"sammy@digitalocean.com", UUID:"b6fr89dbf6d9156cace5f3c78dc9851d957381ef", EmailVerified:true, Status:"active", StatusMessage:"message"}`
 	if expected != stringified {
 		t.Errorf("Account.String returned %+v, expected %+v", stringified, expected)
 	}

--- a/floating_ips_actions_test.go
+++ b/floating_ips_actions_test.go
@@ -144,10 +144,10 @@ func TestFloatingIPsActions_ListPageByNumber(t *testing.T) {
 		"actions":[{"status":"in-progress"}],
 		"links":{
 			"pages":{
-				"next":"http://example.com/v2/regions/?page=3",
-				"prev":"http://example.com/v2/regions/?page=1",
-				"last":"http://example.com/v2/regions/?page=3",
-				"first":"http://example.com/v2/regions/?page=1"
+				"next":"http://example.com/v2/floating_ips/?page=3",
+				"prev":"http://example.com/v2/floating_ips/?page=1",
+				"last":"http://example.com/v2/floating_ips/?page=3",
+				"first":"http://example.com/v2/floating_ips/?page=1"
 			}
 		}
 	}`

--- a/godo.go
+++ b/godo.go
@@ -64,6 +64,8 @@ type Client struct {
 	Sizes             SizesService
 	FloatingIPs       FloatingIPsService
 	FloatingIPActions FloatingIPActionsService
+	ReservedIPs       ReservedIPsService
+	ReservedIPActions ReservedIPActionsService
 	Snapshots         SnapshotsService
 	Storage           StorageService
 	StorageActions    StorageActionsService
@@ -219,6 +221,8 @@ func NewClient(httpClient *http.Client) *Client {
 	c.Firewalls = &FirewallsServiceOp{client: c}
 	c.FloatingIPs = &FloatingIPsServiceOp{client: c}
 	c.FloatingIPActions = &FloatingIPActionsServiceOp{client: c}
+	c.ReservedIPs = &ReservedIPsServiceOp{client: c}
+	c.ReservedIPActions = &ReservedIPActionsServiceOp{client: c}
 	c.Images = &ImagesServiceOp{client: c}
 	c.ImageActions = &ImageActionsServiceOp{client: c}
 	c.Invoices = &InvoicesServiceOp{client: c}

--- a/godo_test.go
+++ b/godo_test.go
@@ -90,6 +90,8 @@ func testClientServices(t *testing.T, c *Client) {
 		"Sizes",
 		"FloatingIPs",
 		"FloatingIPActions",
+		"ReservedIPs",
+		"ReservedIPActions",
 		"Tags",
 	}
 

--- a/projects_test.go
+++ b/projects_test.go
@@ -335,6 +335,13 @@ func TestProjects_ListResources(t *testing.T) {
 				Self: "http://example.com/v2/floating_ips/1.2.3.4",
 			},
 		},
+		{
+			URN:        "do:reservedip:1.2.3.4",
+			AssignedAt: "2018-09-27 00:00:00",
+			Links: &ProjectResourceLinks{
+				Self: "http://example.com/v2/reserved_ips/1.2.3.4",
+			},
+		},
 	}
 
 	mux.HandleFunc("/v2/projects/project-1/resources", func(w http.ResponseWriter, r *http.Request) {
@@ -378,6 +385,13 @@ func TestProjects_ListResourcesWithMultiplePages(t *testing.T) {
 				"links": {
 					"self": "http://example.com/v2/floating_ips/1.2.3.4"
 				}
+			},
+			{
+				"urn": "do:reservedip:1.2.3.4",
+				"assigned_at": "2018-09-27 00:00:00",
+				"links": {
+					"self": "http://example.com/v2/reserved_ips/1.2.3.4"
+				}
 			}
 		],
 		"links": {
@@ -420,6 +434,13 @@ func TestProjects_ListResourcesWithPageNumber(t *testing.T) {
 				"links": {
 					"self": "http://example.com/v2/floating_ips/1.2.3.4"
 				}
+			},
+			{
+				"urn": "do:reservedip:1.2.3.4",
+				"assigned_at": "2018-09-27 00:00:00",
+				"links": {
+					"self": "http://example.com/v2/reserved_ips/1.2.3.4"
+				}
 			}
 		],
 		"links": {
@@ -452,6 +473,7 @@ func TestProjects_AssignFleetResourcesWithTypes(t *testing.T) {
 	assignableResources := []interface{}{
 		&Droplet{ID: 1234},
 		&FloatingIP{IP: "1.2.3.4"},
+		&ReservedIP{IP: "1.2.3.4"},
 	}
 
 	mockResp := `
@@ -470,6 +492,13 @@ func TestProjects_AssignFleetResourcesWithTypes(t *testing.T) {
 				"links": {
 					"self": "http://example.com/v2/floating_ips/1.2.3.4"
 				}
+			},
+			{
+				"urn": "do:reservedip:1.2.3.4",
+				"assigned_at": "2018-09-27 00:00:00",
+				"links": {
+					"self": "http://example.com/v2/reserved_ips/1.2.3.4"
+				}
 			}
 		]
 	}`
@@ -482,7 +511,7 @@ func TestProjects_AssignFleetResourcesWithTypes(t *testing.T) {
 		}
 
 		req := strings.TrimSuffix(string(reqBytes), "\n")
-		expectedReq := `{"resources":["do:droplet:1234","do:floatingip:1.2.3.4"]}`
+		expectedReq := `{"resources":["do:droplet:1234","do:floatingip:1.2.3.4","do:reservedip:1.2.3.4"]}`
 		if req != expectedReq {
 			t.Errorf("projects assign req didn't match up:\n expected %+v\n got %+v\n", expectedReq, req)
 		}
@@ -503,6 +532,7 @@ func TestProjects_AssignFleetResourcesWithStrings(t *testing.T) {
 	assignableResources := []interface{}{
 		"do:droplet:1234",
 		"do:floatingip:1.2.3.4",
+		"do:reservedip:1.2.3.4",
 	}
 
 	mockResp := `
@@ -521,6 +551,13 @@ func TestProjects_AssignFleetResourcesWithStrings(t *testing.T) {
 				"links": {
 					"self": "http://example.com/v2/floating_ips/1.2.3.4"
 				}
+			},
+			{
+				"urn": "do:reservedip:1.2.3.4",
+				"assigned_at": "2018-09-27 00:00:00",
+				"links": {
+					"self": "http://example.com/v2/reserved_ips/1.2.3.4"
+				}
 			}
 		]
 	}`
@@ -533,7 +570,7 @@ func TestProjects_AssignFleetResourcesWithStrings(t *testing.T) {
 		}
 
 		req := strings.TrimSuffix(string(reqBytes), "\n")
-		expectedReq := `{"resources":["do:droplet:1234","do:floatingip:1.2.3.4"]}`
+		expectedReq := `{"resources":["do:droplet:1234","do:floatingip:1.2.3.4","do:reservedip:1.2.3.4"]}`
 		if req != expectedReq {
 			t.Errorf("projects assign req didn't match up:\n expected %+v\n got %+v\n", expectedReq, req)
 		}
@@ -554,6 +591,7 @@ func TestProjects_AssignFleetResourcesWithStringsAndTypes(t *testing.T) {
 	assignableResources := []interface{}{
 		"do:droplet:1234",
 		&FloatingIP{IP: "1.2.3.4"},
+		&ReservedIP{IP: "1.2.3.4"},
 	}
 
 	mockResp := `
@@ -572,6 +610,13 @@ func TestProjects_AssignFleetResourcesWithStringsAndTypes(t *testing.T) {
 				"links": {
 					"self": "http://example.com/v2/floating_ips/1.2.3.4"
 				}
+			},
+			{
+				"urn": "do:reservedip:1.2.3.4",
+				"assigned_at": "2018-09-27 00:00:00",
+				"links": {
+					"self": "http://example.com/v2/reserved_ips/1.2.3.4"
+				}
 			}
 		]
 	}`
@@ -584,7 +629,7 @@ func TestProjects_AssignFleetResourcesWithStringsAndTypes(t *testing.T) {
 		}
 
 		req := strings.TrimSuffix(string(reqBytes), "\n")
-		expectedReq := `{"resources":["do:droplet:1234","do:floatingip:1.2.3.4"]}`
+		expectedReq := `{"resources":["do:droplet:1234","do:floatingip:1.2.3.4","do:reservedip:1.2.3.4"]}`
 		if req != expectedReq {
 			t.Errorf("projects assign req didn't match up:\n expected %+v\n got %+v\n", expectedReq, req)
 		}

--- a/reserved_ips.go
+++ b/reserved_ips.go
@@ -1,0 +1,145 @@
+package godo
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+const resourceType = "ReservedIP"
+const reservedIPsBasePath = "v2/reserved_ips"
+
+// ReservedIPsService is an interface for interfacing with the reserved IPs
+// endpoints of the Digital Ocean API.
+// See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Reserved-IPs
+type ReservedIPsService interface {
+	List(context.Context, *ListOptions) ([]ReservedIP, *Response, error)
+	Get(context.Context, string) (*ReservedIP, *Response, error)
+	Create(context.Context, *ReservedIPCreateRequest) (*ReservedIP, *Response, error)
+	Delete(context.Context, string) (*Response, error)
+}
+
+// ReservedIPsServiceOp handles communication with the reserved IPs related methods of the
+// DigitalOcean API.
+type ReservedIPsServiceOp struct {
+	client *Client
+}
+
+var _ ReservedIPsService = &ReservedIPsServiceOp{}
+
+// ReservedIP represents a Digital Ocean reserved IP.
+type ReservedIP struct {
+	Region  *Region  `json:"region"`
+	Droplet *Droplet `json:"droplet"`
+	IP      string   `json:"ip"`
+}
+
+func (f ReservedIP) String() string {
+	return Stringify(f)
+}
+
+// URN returns the reserved IP in a valid DO API URN form.
+func (f ReservedIP) URN() string {
+	return ToURN(resourceType, f.IP)
+}
+
+type reservedIPsRoot struct {
+	ReservedIPs []ReservedIP `json:"reserved_ips"`
+	Links       *Links       `json:"links"`
+	Meta        *Meta        `json:"meta"`
+}
+
+type reservedIPRoot struct {
+	ReservedIP *ReservedIP `json:"reserved_ip"`
+	Links      *Links      `json:"links,omitempty"`
+}
+
+// ReservedIPCreateRequest represents a request to create a reserved IP.
+// Specify DropletID to assign the reserved IP to a Droplet or Region
+// to reserve it to the region.
+type ReservedIPCreateRequest struct {
+	Region    string `json:"region,omitempty"`
+	DropletID int    `json:"droplet_id,omitempty"`
+}
+
+// List all reserved IPs.
+func (r *ReservedIPsServiceOp) List(ctx context.Context, opt *ListOptions) ([]ReservedIP, *Response, error) {
+	path := reservedIPsBasePath
+	path, err := addOptions(path, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := r.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(reservedIPsRoot)
+	resp, err := r.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
+	}
+
+	return root.ReservedIPs, resp, err
+}
+
+// Get an individual reserved IP.
+func (r *ReservedIPsServiceOp) Get(ctx context.Context, ip string) (*ReservedIP, *Response, error) {
+	path := fmt.Sprintf("%s/%s", reservedIPsBasePath, ip)
+
+	req, err := r.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(reservedIPRoot)
+	resp, err := r.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.ReservedIP, resp, err
+}
+
+// Create a reserved IP. If the DropletID field of the request is not empty,
+// the reserved IP will also be assigned to the droplet.
+func (r *ReservedIPsServiceOp) Create(ctx context.Context, createRequest *ReservedIPCreateRequest) (*ReservedIP, *Response, error) {
+	path := reservedIPsBasePath
+
+	req, err := r.client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(reservedIPRoot)
+	resp, err := r.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.ReservedIP, resp, err
+}
+
+// Delete a reserved IP.
+func (r *ReservedIPsServiceOp) Delete(ctx context.Context, ip string) (*Response, error) {
+	path := fmt.Sprintf("%s/%s", reservedIPsBasePath, ip)
+
+	req, err := r.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := r.client.Do(ctx, req, nil)
+
+	return resp, err
+}

--- a/reserved_ips_actions.go
+++ b/reserved_ips_actions.go
@@ -1,0 +1,109 @@
+package godo
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// ReservedIPActionsService is an interface for interfacing with the
+// reserved IPs actions endpoints of the Digital Ocean API.
+// See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Reserved-IP-Actions
+type ReservedIPActionsService interface {
+	Assign(ctx context.Context, ip string, dropletID int) (*Action, *Response, error)
+	Unassign(ctx context.Context, ip string) (*Action, *Response, error)
+	Get(ctx context.Context, ip string, actionID int) (*Action, *Response, error)
+	List(ctx context.Context, ip string, opt *ListOptions) ([]Action, *Response, error)
+}
+
+// ReservedIPActionsServiceOp handles communication with the reserved IPs
+// action related methods of the DigitalOcean API.
+type ReservedIPActionsServiceOp struct {
+	client *Client
+}
+
+// Assign a reserved IP to a droplet.
+func (s *ReservedIPActionsServiceOp) Assign(ctx context.Context, ip string, dropletID int) (*Action, *Response, error) {
+	request := &ActionRequest{
+		"type":       "assign",
+		"droplet_id": dropletID,
+	}
+	return s.doAction(ctx, ip, request)
+}
+
+// Unassign a rerserved IP from the droplet it is currently assigned to.
+func (s *ReservedIPActionsServiceOp) Unassign(ctx context.Context, ip string) (*Action, *Response, error) {
+	request := &ActionRequest{"type": "unassign"}
+	return s.doAction(ctx, ip, request)
+}
+
+// Get an action for a particular reserved IP by id.
+func (s *ReservedIPActionsServiceOp) Get(ctx context.Context, ip string, actionID int) (*Action, *Response, error) {
+	path := fmt.Sprintf("%s/%d", reservedIPActionPath(ip), actionID)
+	return s.get(ctx, path)
+}
+
+// List the actions for a particular reserved IP.
+func (s *ReservedIPActionsServiceOp) List(ctx context.Context, ip string, opt *ListOptions) ([]Action, *Response, error) {
+	path := reservedIPActionPath(ip)
+	path, err := addOptions(path, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return s.list(ctx, path)
+}
+
+func (s *ReservedIPActionsServiceOp) doAction(ctx context.Context, ip string, request *ActionRequest) (*Action, *Response, error) {
+	path := reservedIPActionPath(ip)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, request)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(actionRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Event, resp, err
+}
+
+func (s *ReservedIPActionsServiceOp) get(ctx context.Context, path string) (*Action, *Response, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(actionRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Event, resp, err
+}
+
+func (s *ReservedIPActionsServiceOp) list(ctx context.Context, path string) ([]Action, *Response, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(actionsRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.Actions, resp, err
+}
+
+func reservedIPActionPath(ip string) string {
+	return fmt.Sprintf("%s/%s/actions", reservedIPsBasePath, ip)
+}

--- a/reserved_ips_actions_test.go
+++ b/reserved_ips_actions_test.go
@@ -1,0 +1,167 @@
+package godo
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestReservedIPsActions_Assign(t *testing.T) {
+	setup()
+	defer teardown()
+	dropletID := 12345
+	assignRequest := &ActionRequest{
+		"droplet_id": float64(dropletID), // encoding/json decodes numbers as floats
+		"type":       "assign",
+	}
+
+	mux.HandleFunc("/v2/reserved_ips/192.168.0.1/actions", func(w http.ResponseWriter, r *http.Request) {
+		v := new(ActionRequest)
+		err := json.NewDecoder(r.Body).Decode(v)
+		if err != nil {
+			t.Fatalf("decode json: %v", err)
+		}
+
+		testMethod(t, r, http.MethodPost)
+		if !reflect.DeepEqual(v, assignRequest) {
+			t.Errorf("Request body = %#v, expected %#v", v, assignRequest)
+		}
+
+		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
+
+	})
+
+	assign, _, err := client.ReservedIPActions.Assign(ctx, "192.168.0.1", 12345)
+	if err != nil {
+		t.Errorf("ReservedIPsActions.Assign returned error: %v", err)
+	}
+
+	expected := &Action{Status: "in-progress"}
+	if !reflect.DeepEqual(assign, expected) {
+		t.Errorf("ReservedIPsActions.Assign returned %+v, expected %+v", assign, expected)
+	}
+}
+
+func TestReservedIPsActions_Unassign(t *testing.T) {
+	setup()
+	defer teardown()
+
+	unassignRequest := &ActionRequest{
+		"type": "unassign",
+	}
+
+	mux.HandleFunc("/v2/reserved_ips/192.168.0.1/actions", func(w http.ResponseWriter, r *http.Request) {
+		v := new(ActionRequest)
+		err := json.NewDecoder(r.Body).Decode(v)
+		if err != nil {
+			t.Fatalf("decode json: %v", err)
+		}
+
+		testMethod(t, r, http.MethodPost)
+		if !reflect.DeepEqual(v, unassignRequest) {
+			t.Errorf("Request body = %+v, expected %+v", v, unassignRequest)
+		}
+
+		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
+	})
+
+	action, _, err := client.ReservedIPActions.Unassign(ctx, "192.168.0.1")
+	if err != nil {
+		t.Errorf("ReservedIPsActions.Get returned error: %v", err)
+	}
+
+	expected := &Action{Status: "in-progress"}
+	if !reflect.DeepEqual(action, expected) {
+		t.Errorf("ReservedIPsActions.Get returned %+v, expected %+v", action, expected)
+	}
+}
+
+func TestReservedIPsActions_Get(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/reserved_ips/192.168.0.1/actions/456", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprintf(w, `{"action":{"status":"in-progress"}}`)
+	})
+
+	action, _, err := client.ReservedIPActions.Get(ctx, "192.168.0.1", 456)
+	if err != nil {
+		t.Errorf("ReservedIPsActions.Get returned error: %v", err)
+	}
+
+	expected := &Action{Status: "in-progress"}
+	if !reflect.DeepEqual(action, expected) {
+		t.Errorf("ReservedIPsActions.Get returned %+v, expected %+v", action, expected)
+	}
+}
+
+func TestReservedIPsActions_List(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/reserved_ips/192.168.0.1/actions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprintf(w, `{"actions":[{"status":"in-progress"}]}`)
+	})
+
+	actions, _, err := client.ReservedIPActions.List(ctx, "192.168.0.1", nil)
+	if err != nil {
+		t.Errorf("ReservedIPsActions.List returned error: %v", err)
+	}
+
+	expected := []Action{{Status: "in-progress"}}
+	if !reflect.DeepEqual(actions, expected) {
+		t.Errorf("ReservedIPsActions.List returned %+v, expected %+v", actions, expected)
+	}
+}
+
+func TestReservedIPsActions_ListMultiplePages(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/reserved_ips/192.168.0.1/actions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{"actions":[{"status":"in-progress"}], "links":{"pages":{"next":"http://example.com/v2/reserved_ips/192.168.0.1/actions?page=2"}}}`)
+	})
+
+	_, resp, err := client.ReservedIPActions.List(ctx, "192.168.0.1", nil)
+	if err != nil {
+		t.Errorf("ReservedIPsActions.List returned error: %v", err)
+	}
+
+	checkCurrentPage(t, resp, 1)
+}
+
+func TestReservedIPsActions_ListPageByNumber(t *testing.T) {
+	setup()
+	defer teardown()
+
+	jBlob := `
+	{
+		"actions":[{"status":"in-progress"}],
+		"links":{
+			"pages":{
+				"next":"http://example.com/v2/reserved_ips/?page=3",
+				"prev":"http://example.com/v2/reserved_ips/?page=1",
+				"last":"http://example.com/v2/reserved_ips/?page=3",
+				"first":"http://example.com/v2/reserved_ips/?page=1"
+			}
+		}
+	}`
+
+	mux.HandleFunc("/v2/reserved_ips/192.168.0.1/actions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, jBlob)
+	})
+
+	opt := &ListOptions{Page: 2}
+	_, resp, err := client.ReservedIPActions.List(ctx, "192.168.0.1", opt)
+	if err != nil {
+		t.Errorf("ReservedIPsActions.List returned error: %v", err)
+	}
+
+	checkCurrentPage(t, resp, 2)
+}

--- a/reserved_ips_test.go
+++ b/reserved_ips_test.go
@@ -1,0 +1,156 @@
+package godo
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestReservedIPs_ListReservedIPs(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/reserved_ips", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{"reserved_ips": [{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1"},{"region":{"slug":"nyc3"},"droplet":{"id":2},"ip":"192.168.0.2"}],"meta":{"total":2}}`)
+	})
+
+	reservedIPs, resp, err := client.ReservedIPs.List(ctx, nil)
+	if err != nil {
+		t.Errorf("ReservedIPs.List returned error: %v", err)
+	}
+
+	expectedReservedIPs := []ReservedIP{
+		{Region: &Region{Slug: "nyc3"}, Droplet: &Droplet{ID: 1}, IP: "192.168.0.1"},
+		{Region: &Region{Slug: "nyc3"}, Droplet: &Droplet{ID: 2}, IP: "192.168.0.2"},
+	}
+	if !reflect.DeepEqual(reservedIPs, expectedReservedIPs) {
+		t.Errorf("ReservedIPs.List returned reserved IPs %+v, expected %+v", reservedIPs, expectedReservedIPs)
+	}
+
+	expectedMeta := &Meta{
+		Total: 2,
+	}
+	if !reflect.DeepEqual(resp.Meta, expectedMeta) {
+		t.Errorf("ReservedIPs.List returned meta %+v, expected %+v", resp.Meta, expectedMeta)
+	}
+}
+
+func TestReservedIPs_ListReservedIPsMultiplePages(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/reserved_ips", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{"reserved_ips": [{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1"},{"region":{"slug":"nyc3"},"droplet":{"id":2},"ip":"192.168.0.2"}], "links":{"pages":{"next":"http://example.com/v2/reserved_ips/?page=2"}}}`)
+	})
+
+	_, resp, err := client.ReservedIPs.List(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checkCurrentPage(t, resp, 1)
+}
+
+func TestReservedIPs_RetrievePageByNumber(t *testing.T) {
+	setup()
+	defer teardown()
+
+	jBlob := `
+	{
+		"reserved_ips": [{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1"},{"region":{"slug":"nyc3"},"droplet":{"id":2},"ip":"192.168.0.2"}],
+		"links":{
+			"pages":{
+				"next":"http://example.com/v2/reserved_ips/?page=3",
+				"prev":"http://example.com/v2/reserved_ips/?page=1",
+				"last":"http://example.com/v2/reserved_ips/?page=3",
+				"first":"http://example.com/v2/reserved_ips/?page=1"
+			}
+		}
+	}`
+
+	mux.HandleFunc("/v2/reserved_ips", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, jBlob)
+	})
+
+	opt := &ListOptions{Page: 2}
+	_, resp, err := client.ReservedIPs.List(ctx, opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checkCurrentPage(t, resp, 2)
+}
+
+func TestReservedIPs_Get(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/reserved_ips/192.168.0.1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{"reserved_ip":{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1"}}`)
+	})
+
+	reservedIP, _, err := client.ReservedIPs.Get(ctx, "192.168.0.1")
+	if err != nil {
+		t.Errorf("domain.Get returned error: %v", err)
+	}
+
+	expected := &ReservedIP{Region: &Region{Slug: "nyc3"}, Droplet: &Droplet{ID: 1}, IP: "192.168.0.1"}
+	if !reflect.DeepEqual(reservedIP, expected) {
+		t.Errorf("ReservedIPs.Get returned %+v, expected %+v", reservedIP, expected)
+	}
+}
+
+func TestReservedIPs_Create(t *testing.T) {
+	setup()
+	defer teardown()
+
+	createRequest := &ReservedIPCreateRequest{
+		Region:    "nyc3",
+		DropletID: 1,
+	}
+
+	mux.HandleFunc("/v2/reserved_ips", func(w http.ResponseWriter, r *http.Request) {
+		v := new(ReservedIPCreateRequest)
+		err := json.NewDecoder(r.Body).Decode(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		testMethod(t, r, http.MethodPost)
+		if !reflect.DeepEqual(v, createRequest) {
+			t.Errorf("Request body = %+v, expected %+v", v, createRequest)
+		}
+
+		fmt.Fprint(w, `{"reserved_ip":{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1"}}`)
+	})
+
+	reservedIP, _, err := client.ReservedIPs.Create(ctx, createRequest)
+	if err != nil {
+		t.Errorf("ReservedIPs.Create returned error: %v", err)
+	}
+
+	expected := &ReservedIP{Region: &Region{Slug: "nyc3"}, Droplet: &Droplet{ID: 1}, IP: "192.168.0.1"}
+	if !reflect.DeepEqual(reservedIP, expected) {
+		t.Errorf("ReservedIPs.Create returned %+v, expected %+v", reservedIP, expected)
+	}
+}
+
+func TestReservedIPs_Destroy(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/reserved_ips/192.168.0.1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+	})
+
+	_, err := client.ReservedIPs.Delete(ctx, "192.168.0.1")
+	if err != nil {
+		t.Errorf("ReservedIPs.Delete returned error: %v", err)
+	}
+}


### PR DESCRIPTION
Floating IPs are being renamed to Reserved IPs. We'll need to
support both for awhile, treating them as distinct resource
types until Floating IPs are deprecated or removed.

This change allows the caller to use either or both at the same
time.

Signed-off-by: Chris Cummer <chriscummer@me.com>