### PR TITLE
Update links to API documentation

### DIFF
--- a/balance.go
+++ b/balance.go
@@ -8,7 +8,7 @@ import (
 
 // BalanceService is an interface for interfacing with the Balance
 // endpoints of the DigitalOcean API
-// See: https://docs.digitalocean.com/reference/api/api-reference/#operation/get_customer_balance
+// See: https://docs.digitalocean.com/reference/api/api-reference/#operation/balance_get
 type BalanceService interface {
 	Get(context.Context) (*Balance, *Response, error)
 }

--- a/billing_history.go
+++ b/billing_history.go
@@ -10,7 +10,7 @@ const billingHistoryBasePath = "v2/customers/my/billing_history"
 
 // BillingHistoryService is an interface for interfacing with the BillingHistory
 // endpoints of the DigitalOcean API
-// See: https://docs.digitalocean.com/reference/api/api-reference/#operation/list_billing_history
+// See: https://docs.digitalocean.com/reference/api/api-reference/#operation/billingHistory_list
 type BillingHistoryService interface {
 	List(context.Context, *ListOptions) (*BillingHistory, *Response, error)
 }


### PR DESCRIPTION
Updates two links in the godo GoDoc comments that pointed to out-of-date anchor URLs.