### PR TITLE
databases: Support advanced config endpoints.

### DIFF
--- a/databases.go
+++ b/databases.go
@@ -12,6 +12,7 @@ const (
 	databaseBasePath           = "/v2/databases"
 	databaseSinglePath         = databaseBasePath + "/%s"
 	databaseCAPath             = databaseBasePath + "/%s/ca"
+	databaseConfigPath         = databaseBasePath + "/%s/config"
 	databaseResizePath         = databaseBasePath + "/%s/resize"
 	databaseMigratePath        = databaseBasePath + "/%s/migrate"
 	databaseMaintenancePath    = databaseBasePath + "/%s/maintenance"
@@ -122,6 +123,12 @@ type DatabasesService interface {
 	SetSQLMode(context.Context, string, ...string) (*Response, error)
 	GetFirewallRules(context.Context, string) ([]DatabaseFirewallRule, *Response, error)
 	UpdateFirewallRules(context.Context, string, *DatabaseUpdateFirewallRulesRequest) (*Response, error)
+	GetPostgreSQLConfig(context.Context, string) (*PostgreSQLConfig, *Response, error)
+	GetRedisConfig(context.Context, string) (*RedisConfig, *Response, error)
+	GetMySQLConfig(context.Context, string) (*MySQLConfig, *Response, error)
+	UpdatePostgreSQLConfig(context.Context, string, *PostgreSQLConfig) (*Response, error)
+	UpdateRedisConfig(context.Context, string, *RedisConfig) (*Response, error)
+	UpdateMySQLConfig(context.Context, string, *MySQLConfig) (*Response, error)
 }
 
 // DatabasesServiceOp handles communication with the Databases related methods
@@ -318,6 +325,125 @@ type DatabaseFirewallRule struct {
 	CreatedAt   time.Time `json:"created_at"`
 }
 
+// PostgreSQLConfig holds advanced configurations for PostgreSQL database clusters.
+type PostgreSQLConfig struct {
+	AutovacuumFreezeMaxAge          *int                         `json:"autovacuum_freeze_max_age,omitempty"`
+	AutovacuumMaxWorkers            *int                         `json:"autovacuum_max_workers,omitempty"`
+	AutovacuumNaptime               *int                         `json:"autovacuum_naptime,omitempty"`
+	AutovacuumVacuumThreshold       *int                         `json:"autovacuum_vacuum_threshold,omitempty"`
+	AutovacuumAnalyzeThreshold      *int                         `json:"autovacuum_analyze_threshold,omitempty"`
+	AutovacuumVacuumScaleFactor     *float32                     `json:"autovacuum_vacuum_scale_factor,omitempty"`
+	AutovacuumAnalyzeScaleFactor    *float32                     `json:"autovacuum_analyze_scale_factor,omitempty"`
+	AutovacuumVacuumCostDelay       *int                         `json:"autovacuum_vacuum_cost_delay,omitempty"`
+	AutovacuumVacuumCostLimit       *int                         `json:"autovacuum_vacuum_cost_limit,omitempty"`
+	BGWriterDelay                   *int                         `json:"bgwriter_delay,omitempty"`
+	BGWriterFlushAfter              *int                         `json:"bgwriter_flush_after,omitempty"`
+	BGWriterLRUMaxpages             *int                         `json:"bgwriter_lru_maxpages,omitempty"`
+	BGWriterLRUMultiplier           *float32                     `json:"bgwriter_lru_multiplier,omitempty"`
+	DeadlockTimeoutMillis           *int                         `json:"deadlock_timeout,omitempty"`
+	DefaultToastCompression         *string                      `json:"default_toast_compression,omitempty"`
+	IdleInTransactionSessionTimeout *int                         `json:"idle_in_transaction_session_timeout,omitempty"`
+	JIT                             *bool                        `json:"jit,omitempty"`
+	LogAutovacuumMinDuration        *int                         `json:"log_autovacuum_min_duration,omitempty"`
+	LogErrorVerbosity               *string                      `json:"log_error_verbosity,omitempty"`
+	LogLinePrefix                   *string                      `json:"log_line_prefix,omitempty"`
+	LogMinDurationStatement         *int                         `json:"log_min_duration_statement,omitempty"`
+	MaxFilesPerProcess              *int                         `json:"max_files_per_process,omitempty"`
+	MaxPreparedTransactions         *int                         `json:"max_prepared_transactions,omitempty"`
+	MaxPredLocksPerTransaction      *int                         `json:"max_pred_locks_per_transaction,omitempty"`
+	MaxLocksPerTransaction          *int                         `json:"max_locks_per_transaction,omitempty"`
+	MaxStackDepth                   *int                         `json:"max_stack_depth,omitempty"`
+	MaxStandbyArchiveDelay          *int                         `json:"max_standby_archive_delay,omitempty"`
+	MaxStandbyStreamingDelay        *int                         `json:"max_standby_streaming_delay,omitempty"`
+	MaxReplicationSlots             *int                         `json:"max_replication_slots,omitempty"`
+	MaxLogicalReplicationWorkers    *int                         `json:"max_logical_replication_workers,omitempty"`
+	MaxParallelWorkers              *int                         `json:"max_parallel_workers,omitempty"`
+	MaxParallelWorkersPerGather     *int                         `json:"max_parallel_workers_per_gather,omitempty"`
+	MaxWorkerProcesses              *int                         `json:"max_worker_processes,omitempty"`
+	PGPartmanBGWRole                *string                      `json:"pg_partman_bgw.role,omitempty"`
+	PGPartmanBGWInterval            *int                         `json:"pg_partman_bgw.interval,omitempty"`
+	PGStatStatementsTrack           *string                      `json:"pg_stat_statements.track,omitempty"`
+	TempFileLimit                   *int                         `json:"temp_file_limit,omitempty"`
+	Timezone                        *string                      `json:"timezone,omitempty"`
+	TrackActivityQuerySize          *int                         `json:"track_activity_query_size,omitempty"`
+	TrackCommitTimestamp            *string                      `json:"track_commit_timestamp,omitempty"`
+	TrackFunctions                  *string                      `json:"track_functions,omitempty"`
+	TrackIOTiming                   *string                      `json:"track_io_timing,omitempty"`
+	MaxWalSenders                   *int                         `json:"max_wal_senders,omitempty"`
+	WalSenderTimeout                *int                         `json:"wal_sender_timeout,omitempty"`
+	WalWriterDelay                  *int                         `json:"wal_writer_delay,omitempty"`
+	SharedBuffersPercentage         *float32                     `json:"shared_buffers_percentage,omitempty"`
+	PgBouncer                       *PostgreSQLBouncerConfig     `json:"pgbouncer,omitempty"`
+	BackupHour                      *int                         `json:"backup_hour,omitempty"`
+	BackupMinute                    *int                         `json:"backup_minute,omitempty"`
+	WorkMem                         *int                         `json:"work_mem,omitempty"`
+	TimeScaleDB                     *PostgreSQLTimeScaleDBConfig `json:"timescaledb,omitempty"`
+}
+
+// PostgreSQLBouncerConfig configuration
+type PostgreSQLBouncerConfig struct {
+	ServerResetQueryAlways  *bool     `json:"server_reset_query_always,omitempty"`
+	IgnoreStartupParameters *[]string `json:"ignore_startup_parameters,omitempty"`
+	MinPoolSize             *int      `json:"min_pool_size,omitempty"`
+	ServerLifetime          *int      `json:"server_lifetime,omitempty"`
+	ServerIdleTimeout       *int      `json:"server_idle_timeout,omitempty"`
+	AutodbPoolSize          *int      `json:"autodb_pool_size,omitempty"`
+	AutodbPoolMode          *string   `json:"autodb_pool_mode,omitempty"`
+	AutodbMaxDbConnections  *int      `json:"autodb_max_db_connections,omitempty"`
+	AutodbIdleTimeout       *int      `json:"autodb_idle_timeout,omitempty"`
+}
+
+// PostgreSQLTimeScaleDBConfig configuration
+type PostgreSQLTimeScaleDBConfig struct {
+	MaxBackgroundWorkers *int `json:"max_background_workers,omitempty"`
+}
+
+// RedisConfig holds advanced configurations for Redis database clusters.
+type RedisConfig struct {
+	RedisMaxmemoryPolicy               *string `json:"redis_maxmemory_policy,omitempty"`
+	RedisPubsubClientOutputBufferLimit *int    `json:"redis_pubsub_client_output_buffer_limit,omitempty"`
+	RedisNumberOfDatabases             *int    `json:"redis_number_of_databases,omitempty"`
+	RedisIOThreads                     *int    `json:"redis_io_threads,omitempty"`
+	RedisLFULogFactor                  *int    `json:"redis_lfu_log_factor,omitempty"`
+	RedisLFUDecayTime                  *int    `json:"redis_lfu_decay_time,omitempty"`
+	RedisSSL                           *bool   `json:"redis_ssl,omitempty"`
+	RedisTimeout                       *int    `json:"redis_timeout,omitempty"`
+	RedisNotifyKeyspaceEvents          *string `json:"redis_notify_keyspace_events,omitempty"`
+	RedisPersistence                   *string `json:"redis_persistence,omitempty"`
+	RedisACLChannelsDefault            *string `json:"redis_acl_channels_default,omitempty"`
+}
+
+// MySQLConfig holds advanced configurations for MySQL database clusters.
+type MySQLConfig struct {
+	ConnectTimeout               *int     `json:"connect_timeout,omitempty"`
+	DefaultTimeZone              *string  `json:"default_time_zone,omitempty"`
+	InnodbLogBufferSize          *int     `json:"innodb_log_buffer_size,omitempty"`
+	InnodbOnlineAlterLogMaxSize  *int     `json:"innodb_online_alter_log_max_size,omitempty"`
+	InnodbLockWaitTimeout        *int     `json:"innodb_lock_wait_timeout,omitempty"`
+	InteractiveTimeout           *int     `json:"interactive_timeout,omitempty"`
+	MaxAllowedPacket             *int     `json:"max_allowed_packet,omitempty"`
+	NetReadTimeout               *int     `json:"net_read_timeout,omitempty"`
+	SortBufferSize               *int     `json:"sort_buffer_size,omitempty"`
+	SQLMode                      *string  `json:"sql_mode,omitempty"`
+	SQLRequirePrimaryKey         *bool    `json:"sql_require_primary_key,omitempty"`
+	WaitTimeout                  *int     `json:"wait_timeout,omitempty"`
+	NetWriteTimeout              *int     `json:"net_write_timeout,omitempty"`
+	GroupConcatMaxLen            *int     `json:"group_concat_max_len,omitempty"`
+	InformationSchemaStatsExpiry *int     `json:"information_schema_stats_expiry,omitempty"`
+	InnodbFtMinTokenSize         *int     `json:"innodb_ft_min_token_size,omitempty"`
+	InnodbFtServerStopwordTable  *string  `json:"innodb_ft_server_stopword_table,omitempty"`
+	InnodbPrintAllDeadlocks      *bool    `json:"innodb_print_all_deadlocks,omitempty"`
+	InnodbRollbackOnTimeout      *bool    `json:"innodb_rollback_on_timeout,omitempty"`
+	InternalTmpMemStorageEngine  *string  `json:"internal_tmp_mem_storage_engine,omitempty"`
+	MaxHeapTableSize             *int     `json:"max_heap_table_size,omitempty"`
+	TmpTableSize                 *int     `json:"tmp_table_size,omitempty"`
+	SlowQueryLog                 *bool    `json:"slow_query_log,omitempty"`
+	LongQueryTime                *float32 `json:"long_query_time,omitempty"`
+	BackupHour                   *int     `json:"backup_hour,omitempty"`
+	BackupMinute                 *int     `json:"backup_minute,omitempty"`
+	BinlogRetentionPeriod        *int     `json:"binlog_retention_period,omitempty"`
+}
+
 type databaseUserRoot struct {
 	User *DatabaseUser `json:"user"`
 }
@@ -344,6 +470,18 @@ type databaseRoot struct {
 
 type databaseCARoot struct {
 	CA *DatabaseCA `json:"ca"`
+}
+
+type databasePostgreSQLConfigRoot struct {
+	Config *PostgreSQLConfig `json:"config"`
+}
+
+type databaseRedisConfigRoot struct {
+	Config *RedisConfig `json:"config"`
+}
+
+type databaseMySQLConfigRoot struct {
+	Config *MySQLConfig `json:"config"`
 }
 
 type databaseBackupsRoot struct {
@@ -878,4 +1016,100 @@ func (svc *DatabasesServiceOp) UpdateFirewallRules(ctx context.Context, database
 		return nil, err
 	}
 	return svc.client.Do(ctx, req, nil)
+}
+
+// GetPostgreSQLConfig retrieves the config for a PostgreSQL database cluster.
+func (svc *DatabasesServiceOp) GetPostgreSQLConfig(ctx context.Context, databaseID string) (*PostgreSQLConfig, *Response, error) {
+	path := fmt.Sprintf(databaseConfigPath, databaseID)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(databasePostgreSQLConfigRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Config, resp, nil
+}
+
+// UpdatePostgreSQLConfig updates the config for a PostgreSQL database cluster.
+func (svc *DatabasesServiceOp) UpdatePostgreSQLConfig(ctx context.Context, databaseID string, config *PostgreSQLConfig) (*Response, error) {
+	path := fmt.Sprintf(databaseConfigPath, databaseID)
+	root := &databasePostgreSQLConfigRoot{
+		Config: config,
+	}
+	req, err := svc.client.NewRequest(ctx, http.MethodPatch, path, root)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := svc.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}
+
+// GetRedisConfig retrieves the config for a Redis database cluster.
+func (svc *DatabasesServiceOp) GetRedisConfig(ctx context.Context, databaseID string) (*RedisConfig, *Response, error) {
+	path := fmt.Sprintf(databaseConfigPath, databaseID)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(databaseRedisConfigRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Config, resp, nil
+}
+
+// UpdateRedisConfig updates the config for a Redis database cluster.
+func (svc *DatabasesServiceOp) UpdateRedisConfig(ctx context.Context, databaseID string, config *RedisConfig) (*Response, error) {
+	path := fmt.Sprintf(databaseConfigPath, databaseID)
+	root := &databaseRedisConfigRoot{
+		Config: config,
+	}
+	req, err := svc.client.NewRequest(ctx, http.MethodPatch, path, root)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := svc.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}
+
+// GetMySQLConfig retrieves the config for a MySQL database cluster.
+func (svc *DatabasesServiceOp) GetMySQLConfig(ctx context.Context, databaseID string) (*MySQLConfig, *Response, error) {
+	path := fmt.Sprintf(databaseConfigPath, databaseID)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(databaseMySQLConfigRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Config, resp, nil
+}
+
+// UpdateMySQLConfig updates the config for a MySQL database cluster.
+func (svc *DatabasesServiceOp) UpdateMySQLConfig(ctx context.Context, databaseID string, config *MySQLConfig) (*Response, error) {
+	path := fmt.Sprintf(databaseConfigPath, databaseID)
+	root := &databaseMySQLConfigRoot{
+		Config: config,
+	}
+	req, err := svc.client.NewRequest(ctx, http.MethodPatch, path, root)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := svc.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
 }

--- a/godo_test.go
+++ b/godo_test.go
@@ -781,3 +781,11 @@ func intPtr(val int) *int {
 func boolPtr(val bool) *bool {
 	return &val
 }
+
+func float32Ptr(val float32) *float32 {
+	return &val
+}
+
+func strPtr(val string) *string {
+	return &val
+}


### PR DESCRIPTION
This adds support for the advanced DBaaS config endpoints. A few things to note:

- We provide consts for use with `SetEvictionPolicy` method. Unfortunately, those are  in a slightly different format than what can be used for `RedisConfig.RedisMaxmemoryPolicy`. So I attempt to normalize input to `UpdateRedisConfig` if the old consts are used.
- I've used pointer values for the config structs as zero values may be important for some options and it is a PATCH method. It might not be necessary for all of them, but keeping them consistent seemed the best option.