### PR TITLE
apps: Add URN() method.

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -127,6 +127,11 @@ type AppsServiceOp struct {
 	client *Client
 }
 
+// URN returns a URN identifier for the app
+func (a App) URN() string {
+	return ToURN("app", a.ID)
+}
+
 // Create an app.
 func (s *AppsServiceOp) Create(ctx context.Context, create *AppCreateRequest) (*App, *Response, error) {
 	path := appsBasePath

--- a/apps_test.go
+++ b/apps_test.go
@@ -630,3 +630,13 @@ func TestApps_Detect(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, component, res.Components[0])
 }
+
+func TestApps_ToURN(t *testing.T) {
+	app := &App{
+		ID: "deadbeef-dead-4aa5-beef-deadbeef347d",
+	}
+	want := "do:app:deadbeef-dead-4aa5-beef-deadbeef347d"
+	got := app.URN()
+
+	require.Equal(t, want, got)
+}


### PR DESCRIPTION
Projects have supported apps for sometime now. To simplify adding an app to a project, this exposes an `URN()` method like other resources with projects support.

Related: https://github.com/digitalocean/terraform-provider-digitalocean/issues/853