### PR TITLE
reserved IPs: Expose project_id and locked attributes.

### DIFF
--- a/floating_ips.go
+++ b/floating_ips.go
@@ -28,9 +28,11 @@ var _ FloatingIPsService = &FloatingIPsServiceOp{}
 
 // FloatingIP represents a Digital Ocean floating IP.
 type FloatingIP struct {
-	Region  *Region  `json:"region"`
-	Droplet *Droplet `json:"droplet"`
-	IP      string   `json:"ip"`
+	Region    *Region  `json:"region"`
+	Droplet   *Droplet `json:"droplet"`
+	IP        string   `json:"ip"`
+	ProjectID string   `json:"project_id"`
+	Locked    bool     `json:"locked"`
 }
 
 func (f FloatingIP) String() string {
@@ -59,6 +61,7 @@ type floatingIPRoot struct {
 type FloatingIPCreateRequest struct {
 	Region    string `json:"region,omitempty"`
 	DropletID int    `json:"droplet_id,omitempty"`
+	ProjectID string `json:"project_id"`
 }
 
 // List all floating IPs.

--- a/floating_ips_test.go
+++ b/floating_ips_test.go
@@ -14,7 +14,11 @@ func TestFloatingIPs_ListFloatingIPs(t *testing.T) {
 
 	mux.HandleFunc("/v2/floating_ips", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
-		fmt.Fprint(w, `{"floating_ips": [{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1"},{"region":{"slug":"nyc3"},"droplet":{"id":2},"ip":"192.168.0.2"}],"meta":{"total":2}}`)
+		fmt.Fprint(w, `{"floating_ips": [
+			{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1","project_id":"46d8977a-35cd-11ed-909f-43c99bbf6032", "locked":false},
+			{"region":{"slug":"nyc3"},"droplet":{"id":2},"ip":"192.168.0.2","project_id":"46d8977a-35cd-11ed-909f-43c99bbf6032", "locked":false}],
+			"meta":{"total":2}
+		}`)
 	})
 
 	floatingIPs, resp, err := client.FloatingIPs.List(ctx, nil)
@@ -23,8 +27,8 @@ func TestFloatingIPs_ListFloatingIPs(t *testing.T) {
 	}
 
 	expectedFloatingIPs := []FloatingIP{
-		{Region: &Region{Slug: "nyc3"}, Droplet: &Droplet{ID: 1}, IP: "192.168.0.1"},
-		{Region: &Region{Slug: "nyc3"}, Droplet: &Droplet{ID: 2}, IP: "192.168.0.2"},
+		{Region: &Region{Slug: "nyc3"}, Droplet: &Droplet{ID: 1}, IP: "192.168.0.1", Locked: false, ProjectID: "46d8977a-35cd-11ed-909f-43c99bbf6032"},
+		{Region: &Region{Slug: "nyc3"}, Droplet: &Droplet{ID: 2}, IP: "192.168.0.2", Locked: false, ProjectID: "46d8977a-35cd-11ed-909f-43c99bbf6032"},
 	}
 	if !reflect.DeepEqual(floatingIPs, expectedFloatingIPs) {
 		t.Errorf("FloatingIPs.List returned floating IPs %+v, expected %+v", floatingIPs, expectedFloatingIPs)
@@ -44,7 +48,11 @@ func TestFloatingIPs_ListFloatingIPsMultiplePages(t *testing.T) {
 
 	mux.HandleFunc("/v2/floating_ips", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
-		fmt.Fprint(w, `{"floating_ips": [{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1"},{"region":{"slug":"nyc3"},"droplet":{"id":2},"ip":"192.168.0.2"}], "links":{"pages":{"next":"http://example.com/v2/floating_ips/?page=2"}}}`)
+		fmt.Fprint(w, `{"floating_ips": [
+			{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1","project_id":"46d8977a-35cd-11ed-909f-43c99bbf6032", "locked":false},
+			{"region":{"slug":"nyc3"},"droplet":{"id":2},"ip":"192.168.0.2","project_id":"46d8977a-35cd-11ed-909f-43c99bbf6032", "locked":false}],
+			"links":{"pages":{"next":"http://example.com/v2/floating_ips/?page=2"}}}
+		`)
 	})
 
 	_, resp, err := client.FloatingIPs.List(ctx, nil)
@@ -61,7 +69,9 @@ func TestFloatingIPs_RetrievePageByNumber(t *testing.T) {
 
 	jBlob := `
 	{
-		"floating_ips": [{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1"},{"region":{"slug":"nyc3"},"droplet":{"id":2},"ip":"192.168.0.2"}],
+		"floating_ips": [
+			{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1","project_id":"46d8977a-35cd-11ed-909f-43c99bbf6032", "locked":false},
+			{"region":{"slug":"nyc3"},"droplet":{"id":2},"ip":"192.168.0.2","project_id":"46d8977a-35cd-11ed-909f-43c99bbf6032", "locked":false}],
 		"links":{
 			"pages":{
 				"next":"http://example.com/v2/floating_ips/?page=3",
@@ -92,7 +102,7 @@ func TestFloatingIPs_Get(t *testing.T) {
 
 	mux.HandleFunc("/v2/floating_ips/192.168.0.1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
-		fmt.Fprint(w, `{"floating_ip":{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1"}}`)
+		fmt.Fprint(w, `{"floating_ip":{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1","project_id":"46d8977a-35cd-11ed-909f-43c99bbf6032", "locked":false}}`)
 	})
 
 	floatingIP, _, err := client.FloatingIPs.Get(ctx, "192.168.0.1")
@@ -100,7 +110,7 @@ func TestFloatingIPs_Get(t *testing.T) {
 		t.Errorf("domain.Get returned error: %v", err)
 	}
 
-	expected := &FloatingIP{Region: &Region{Slug: "nyc3"}, Droplet: &Droplet{ID: 1}, IP: "192.168.0.1"}
+	expected := &FloatingIP{Region: &Region{Slug: "nyc3"}, Droplet: &Droplet{ID: 1}, IP: "192.168.0.1", Locked: false, ProjectID: "46d8977a-35cd-11ed-909f-43c99bbf6032"}
 	if !reflect.DeepEqual(floatingIP, expected) {
 		t.Errorf("FloatingIPs.Get returned %+v, expected %+v", floatingIP, expected)
 	}
@@ -113,6 +123,7 @@ func TestFloatingIPs_Create(t *testing.T) {
 	createRequest := &FloatingIPCreateRequest{
 		Region:    "nyc3",
 		DropletID: 1,
+		ProjectID: "46d8977a-35cd-11ed-909f-43c99bbf6032",
 	}
 
 	mux.HandleFunc("/v2/floating_ips", func(w http.ResponseWriter, r *http.Request) {
@@ -127,7 +138,7 @@ func TestFloatingIPs_Create(t *testing.T) {
 			t.Errorf("Request body = %+v, expected %+v", v, createRequest)
 		}
 
-		fmt.Fprint(w, `{"floating_ip":{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1"}}`)
+		fmt.Fprint(w, `{"floating_ip":{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1","project_id":"46d8977a-35cd-11ed-909f-43c99bbf6032", "locked":false}}`)
 	})
 
 	floatingIP, _, err := client.FloatingIPs.Create(ctx, createRequest)
@@ -135,7 +146,7 @@ func TestFloatingIPs_Create(t *testing.T) {
 		t.Errorf("FloatingIPs.Create returned error: %v", err)
 	}
 
-	expected := &FloatingIP{Region: &Region{Slug: "nyc3"}, Droplet: &Droplet{ID: 1}, IP: "192.168.0.1"}
+	expected := &FloatingIP{Region: &Region{Slug: "nyc3"}, Droplet: &Droplet{ID: 1}, IP: "192.168.0.1", Locked: false, ProjectID: "46d8977a-35cd-11ed-909f-43c99bbf6032"}
 	if !reflect.DeepEqual(floatingIP, expected) {
 		t.Errorf("FloatingIPs.Create returned %+v, expected %+v", floatingIP, expected)
 	}

--- a/reserved_ips.go
+++ b/reserved_ips.go
@@ -29,9 +29,11 @@ var _ ReservedIPsService = &ReservedIPsServiceOp{}
 
 // ReservedIP represents a Digital Ocean reserved IP.
 type ReservedIP struct {
-	Region  *Region  `json:"region"`
-	Droplet *Droplet `json:"droplet"`
-	IP      string   `json:"ip"`
+	Region    *Region  `json:"region"`
+	Droplet   *Droplet `json:"droplet"`
+	IP        string   `json:"ip"`
+	ProjectID string   `json:"project_id"`
+	Locked    bool     `json:"locked"`
 }
 
 func (f ReservedIP) String() string {
@@ -60,6 +62,7 @@ type reservedIPRoot struct {
 type ReservedIPCreateRequest struct {
 	Region    string `json:"region,omitempty"`
 	DropletID int    `json:"droplet_id,omitempty"`
+	ProjectID string `json:"project_id"`
 }
 
 // List all reserved IPs.

--- a/reserved_ips_test.go
+++ b/reserved_ips_test.go
@@ -14,7 +14,11 @@ func TestReservedIPs_ListReservedIPs(t *testing.T) {
 
 	mux.HandleFunc("/v2/reserved_ips", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
-		fmt.Fprint(w, `{"reserved_ips": [{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1"},{"region":{"slug":"nyc3"},"droplet":{"id":2},"ip":"192.168.0.2"}],"meta":{"total":2}}`)
+		fmt.Fprint(w, `{"reserved_ips": [
+			{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1","project_id":"46d8977a-35cd-11ed-909f-43c99bbf6032", "locked":false},
+			{"region":{"slug":"nyc3"},"droplet":{"id":2},"ip":"192.168.0.2","project_id":"46d8977a-35cd-11ed-909f-43c99bbf6032", "locked":false}],
+			"meta":{"total":2}
+		}`)
 	})
 
 	reservedIPs, resp, err := client.ReservedIPs.List(ctx, nil)
@@ -23,8 +27,8 @@ func TestReservedIPs_ListReservedIPs(t *testing.T) {
 	}
 
 	expectedReservedIPs := []ReservedIP{
-		{Region: &Region{Slug: "nyc3"}, Droplet: &Droplet{ID: 1}, IP: "192.168.0.1"},
-		{Region: &Region{Slug: "nyc3"}, Droplet: &Droplet{ID: 2}, IP: "192.168.0.2"},
+		{Region: &Region{Slug: "nyc3"}, Droplet: &Droplet{ID: 1}, IP: "192.168.0.1", Locked: false, ProjectID: "46d8977a-35cd-11ed-909f-43c99bbf6032"},
+		{Region: &Region{Slug: "nyc3"}, Droplet: &Droplet{ID: 2}, IP: "192.168.0.2", Locked: false, ProjectID: "46d8977a-35cd-11ed-909f-43c99bbf6032"},
 	}
 	if !reflect.DeepEqual(reservedIPs, expectedReservedIPs) {
 		t.Errorf("ReservedIPs.List returned reserved IPs %+v, expected %+v", reservedIPs, expectedReservedIPs)
@@ -44,7 +48,11 @@ func TestReservedIPs_ListReservedIPsMultiplePages(t *testing.T) {
 
 	mux.HandleFunc("/v2/reserved_ips", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
-		fmt.Fprint(w, `{"reserved_ips": [{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1"},{"region":{"slug":"nyc3"},"droplet":{"id":2},"ip":"192.168.0.2"}], "links":{"pages":{"next":"http://example.com/v2/reserved_ips/?page=2"}}}`)
+		fmt.Fprint(w, `{"reserved_ips": [
+			{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1","project_id":"46d8977a-35cd-11ed-909f-43c99bbf6032", "locked":false},
+			{"region":{"slug":"nyc3"},"droplet":{"id":2},"ip":"192.168.0.2","project_id":"46d8977a-35cd-11ed-909f-43c99bbf6032", "locked":false}],
+			"links":{"pages":{"next":"http://example.com/v2/reserved_ips/?page=2"}}}
+		`)
 	})
 
 	_, resp, err := client.ReservedIPs.List(ctx, nil)
@@ -61,7 +69,9 @@ func TestReservedIPs_RetrievePageByNumber(t *testing.T) {
 
 	jBlob := `
 	{
-		"reserved_ips": [{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1"},{"region":{"slug":"nyc3"},"droplet":{"id":2},"ip":"192.168.0.2"}],
+		"reserved_ips": [
+			{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1","project_id":"46d8977a-35cd-11ed-909f-43c99bbf6032", "locked":false},
+			{"region":{"slug":"nyc3"},"droplet":{"id":2},"ip":"192.168.0.2","project_id":"46d8977a-35cd-11ed-909f-43c99bbf6032", "locked":false}],
 		"links":{
 			"pages":{
 				"next":"http://example.com/v2/reserved_ips/?page=3",
@@ -92,7 +102,7 @@ func TestReservedIPs_Get(t *testing.T) {
 
 	mux.HandleFunc("/v2/reserved_ips/192.168.0.1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
-		fmt.Fprint(w, `{"reserved_ip":{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1"}}`)
+		fmt.Fprint(w, `{"reserved_ip":{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1","project_id":"46d8977a-35cd-11ed-909f-43c99bbf6032", "locked":false}}`)
 	})
 
 	reservedIP, _, err := client.ReservedIPs.Get(ctx, "192.168.0.1")
@@ -100,7 +110,7 @@ func TestReservedIPs_Get(t *testing.T) {
 		t.Errorf("domain.Get returned error: %v", err)
 	}
 
-	expected := &ReservedIP{Region: &Region{Slug: "nyc3"}, Droplet: &Droplet{ID: 1}, IP: "192.168.0.1"}
+	expected := &ReservedIP{Region: &Region{Slug: "nyc3"}, Droplet: &Droplet{ID: 1}, IP: "192.168.0.1", Locked: false, ProjectID: "46d8977a-35cd-11ed-909f-43c99bbf6032"}
 	if !reflect.DeepEqual(reservedIP, expected) {
 		t.Errorf("ReservedIPs.Get returned %+v, expected %+v", reservedIP, expected)
 	}
@@ -113,6 +123,7 @@ func TestReservedIPs_Create(t *testing.T) {
 	createRequest := &ReservedIPCreateRequest{
 		Region:    "nyc3",
 		DropletID: 1,
+		ProjectID: "46d8977a-35cd-11ed-909f-43c99bbf6032",
 	}
 
 	mux.HandleFunc("/v2/reserved_ips", func(w http.ResponseWriter, r *http.Request) {
@@ -127,7 +138,7 @@ func TestReservedIPs_Create(t *testing.T) {
 			t.Errorf("Request body = %+v, expected %+v", v, createRequest)
 		}
 
-		fmt.Fprint(w, `{"reserved_ip":{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1"}}`)
+		fmt.Fprint(w, `{"reserved_ip":{"region":{"slug":"nyc3"},"droplet":{"id":1},"ip":"192.168.0.1","project_id":"46d8977a-35cd-11ed-909f-43c99bbf6032", "locked":false}}`)
 	})
 
 	reservedIP, _, err := client.ReservedIPs.Create(ctx, createRequest)
@@ -135,7 +146,7 @@ func TestReservedIPs_Create(t *testing.T) {
 		t.Errorf("ReservedIPs.Create returned error: %v", err)
 	}
 
-	expected := &ReservedIP{Region: &Region{Slug: "nyc3"}, Droplet: &Droplet{ID: 1}, IP: "192.168.0.1"}
+	expected := &ReservedIP{Region: &Region{Slug: "nyc3"}, Droplet: &Droplet{ID: 1}, IP: "192.168.0.1", Locked: false, ProjectID: "46d8977a-35cd-11ed-909f-43c99bbf6032"}
 	if !reflect.DeepEqual(reservedIP, expected) {
 		t.Errorf("ReservedIPs.Create returned %+v, expected %+v", reservedIP, expected)
 	}


### PR DESCRIPTION
This exposes the `project_id` attribute in both floating IP and reserved IP request and response bodies. While doing this, I also noticed that we document a `locked` attribute in response bodies that is not exposed in godo. So I've added that as well.