### PR TITLE
update CI for go 1.18 & 1.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [ 1.17.x, 1.18.x ]
+        go-version: [ 1.18.x, 1.19.x ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/tags.go
+++ b/tags.go
@@ -95,7 +95,7 @@ type Tag struct {
 	Resources *TaggedResources `json:"resources,omitempty"`
 }
 
-//TagCreateRequest represents the JSON structure of a request of that type.
+// TagCreateRequest represents the JSON structure of a request of that type.
 type TagCreateRequest struct {
 	Name string `json:"name"`
 }


### PR DESCRIPTION
Update CI to use go 1.18+1.19. This drops CI testing for Go 1.17 which is ok as `godo`'s policy is to ensure support for the two most recent Go versions.