### PR TITLE
apps: update component spec interfaces

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -507,11 +507,22 @@ type AppBuildableComponentSpec interface {
 	GetGitLab() *GitLabSourceSpec
 
 	GetSourceDir() string
-	GetDockerfilePath() string
-	GetBuildCommand() string
-	GetEnvironmentSlug() string
 
 	GetEnvs() []*AppVariableDefinition
+}
+
+// AppDockerBuildableComponentSpec is a component that is buildable from source using Docker.
+type AppDockerBuildableComponentSpec interface {
+	AppBuildableComponentSpec
+
+	GetDockerfilePath() string
+}
+
+// AppCNBBuildableComponentSpec is a component that is buildable from source using cloud native buildpacks.
+type AppCNBBuildableComponentSpec interface {
+	AppBuildableComponentSpec
+
+	GetBuildCommand() string
 }
 
 // AppContainerComponentSpec is a component that runs in a cluster.
@@ -519,9 +530,7 @@ type AppContainerComponentSpec interface {
 	AppBuildableComponentSpec
 
 	GetImage() *ImageSourceSpec
-
 	GetRunCommand() string
-
 	GetInstanceSizeSlug() string
 	GetInstanceCount() int64
 }

--- a/apps_accessors.go
+++ b/apps_accessors.go
@@ -878,14 +878,6 @@ func (a *AppJobSpec) GetDockerfilePath() string {
 	return a.DockerfilePath
 }
 
-// GetEnvironmentSlug returns the EnvironmentSlug field.
-func (a *AppJobSpec) GetEnvironmentSlug() string {
-	if a == nil {
-		return ""
-	}
-	return a.EnvironmentSlug
-}
-
 // GetEnvs returns the Envs field.
 func (a *AppJobSpec) GetEnvs() []*AppVariableDefinition {
 	if a == nil {
@@ -1310,14 +1302,6 @@ func (a *AppServiceSpec) GetDockerfilePath() string {
 	return a.DockerfilePath
 }
 
-// GetEnvironmentSlug returns the EnvironmentSlug field.
-func (a *AppServiceSpec) GetEnvironmentSlug() string {
-	if a == nil {
-		return ""
-	}
-	return a.EnvironmentSlug
-}
-
 // GetEnvs returns the Envs field.
 func (a *AppServiceSpec) GetEnvs() []*AppVariableDefinition {
 	if a == nil {
@@ -1638,14 +1622,6 @@ func (a *AppStaticSiteSpec) GetDockerfilePath() string {
 	return a.DockerfilePath
 }
 
-// GetEnvironmentSlug returns the EnvironmentSlug field.
-func (a *AppStaticSiteSpec) GetEnvironmentSlug() string {
-	if a == nil {
-		return ""
-	}
-	return a.EnvironmentSlug
-}
-
 // GetEnvs returns the Envs field.
 func (a *AppStaticSiteSpec) GetEnvs() []*AppVariableDefinition {
 	if a == nil {
@@ -1836,14 +1812,6 @@ func (a *AppWorkerSpec) GetDockerfilePath() string {
 		return ""
 	}
 	return a.DockerfilePath
-}
-
-// GetEnvironmentSlug returns the EnvironmentSlug field.
-func (a *AppWorkerSpec) GetEnvironmentSlug() string {
-	if a == nil {
-		return ""
-	}
-	return a.EnvironmentSlug
 }
 
 // GetEnvs returns the Envs field.
@@ -2620,14 +2588,6 @@ func (d *DetectResponseComponent) GetDockerfiles() []string {
 		return nil
 	}
 	return d.Dockerfiles
-}
-
-// GetEnvironmentSlug returns the EnvironmentSlug field.
-func (d *DetectResponseComponent) GetEnvironmentSlug() string {
-	if d == nil {
-		return ""
-	}
-	return d.EnvironmentSlug
 }
 
 // GetEnvVars returns the EnvVars field.

--- a/apps_accessors_test.go
+++ b/apps_accessors_test.go
@@ -776,13 +776,6 @@ func TestAppJobSpec_GetDockerfilePath(tt *testing.T) {
 	a.GetDockerfilePath()
 }
 
-func TestAppJobSpec_GetEnvironmentSlug(tt *testing.T) {
-	a := &AppJobSpec{}
-	a.GetEnvironmentSlug()
-	a = nil
-	a.GetEnvironmentSlug()
-}
-
 func TestAppJobSpec_GetEnvs(tt *testing.T) {
 	a := &AppJobSpec{}
 	a.GetEnvs()
@@ -1154,13 +1147,6 @@ func TestAppServiceSpec_GetDockerfilePath(tt *testing.T) {
 	a.GetDockerfilePath()
 }
 
-func TestAppServiceSpec_GetEnvironmentSlug(tt *testing.T) {
-	a := &AppServiceSpec{}
-	a.GetEnvironmentSlug()
-	a = nil
-	a.GetEnvironmentSlug()
-}
-
 func TestAppServiceSpec_GetEnvs(tt *testing.T) {
 	a := &AppServiceSpec{}
 	a.GetEnvs()
@@ -1441,13 +1427,6 @@ func TestAppStaticSiteSpec_GetDockerfilePath(tt *testing.T) {
 	a.GetDockerfilePath()
 }
 
-func TestAppStaticSiteSpec_GetEnvironmentSlug(tt *testing.T) {
-	a := &AppStaticSiteSpec{}
-	a.GetEnvironmentSlug()
-	a = nil
-	a.GetEnvironmentSlug()
-}
-
 func TestAppStaticSiteSpec_GetEnvs(tt *testing.T) {
 	a := &AppStaticSiteSpec{}
 	a.GetEnvs()
@@ -1614,13 +1593,6 @@ func TestAppWorkerSpec_GetDockerfilePath(tt *testing.T) {
 	a.GetDockerfilePath()
 	a = nil
 	a.GetDockerfilePath()
-}
-
-func TestAppWorkerSpec_GetEnvironmentSlug(tt *testing.T) {
-	a := &AppWorkerSpec{}
-	a.GetEnvironmentSlug()
-	a = nil
-	a.GetEnvironmentSlug()
 }
 
 func TestAppWorkerSpec_GetEnvs(tt *testing.T) {
@@ -2300,13 +2272,6 @@ func TestDetectResponseComponent_GetDockerfiles(tt *testing.T) {
 	d.GetDockerfiles()
 	d = nil
 	d.GetDockerfiles()
-}
-
-func TestDetectResponseComponent_GetEnvironmentSlug(tt *testing.T) {
-	d := &DetectResponseComponent{}
-	d.GetEnvironmentSlug()
-	d = nil
-	d.GetEnvironmentSlug()
 }
 
 func TestDetectResponseComponent_GetEnvVars(tt *testing.T) {

--- a/apps_test.go
+++ b/apps_test.go
@@ -658,38 +658,96 @@ func TestApps_Interfaces(t *testing.T) {
 	})
 
 	t.Run("AppBuildableComponentSpec", func(t *testing.T) {
-		for _, impl := range []interface{}{
-			&AppServiceSpec{},
-			&AppWorkerSpec{},
-			&AppJobSpec{},
-			&AppStaticSiteSpec{},
+		for impl, wantMatch := range map[any]bool{
+			&AppServiceSpec{}:    true,
+			&AppWorkerSpec{}:     true,
+			&AppJobSpec{}:        true,
+			&AppStaticSiteSpec{}: true,
+			&AppFunctionsSpec{}:  true,
+
+			&AppDatabaseSpec{}: false,
 		} {
-			if _, ok := impl.(AppBuildableComponentSpec); !ok {
+			_, ok := impl.(AppBuildableComponentSpec)
+			if wantMatch && !ok {
 				t.Fatalf("%T should match interface", impl)
+			} else if !wantMatch && ok {
+				t.Fatalf("%T should NOT match interface", impl)
+			}
+		}
+	})
+
+	t.Run("AppDockerBuildableComponentSpec", func(t *testing.T) {
+		for impl, wantMatch := range map[any]bool{
+			&AppServiceSpec{}:    true,
+			&AppWorkerSpec{}:     true,
+			&AppJobSpec{}:        true,
+			&AppStaticSiteSpec{}: true,
+
+			&AppFunctionsSpec{}: false,
+			&AppDatabaseSpec{}:  false,
+		} {
+			_, ok := impl.(AppDockerBuildableComponentSpec)
+			if wantMatch && !ok {
+				t.Fatalf("%T should match interface", impl)
+			} else if !wantMatch && ok {
+				t.Fatalf("%T should NOT match interface", impl)
+			}
+		}
+	})
+
+	t.Run("AppCNBBuildableComponentSpec", func(t *testing.T) {
+		for impl, wantMatch := range map[any]bool{
+			&AppServiceSpec{}:    true,
+			&AppWorkerSpec{}:     true,
+			&AppJobSpec{}:        true,
+			&AppStaticSiteSpec{}: true,
+
+			&AppFunctionsSpec{}: false,
+			&AppDatabaseSpec{}:  false,
+		} {
+			_, ok := impl.(AppCNBBuildableComponentSpec)
+			if wantMatch && !ok {
+				t.Fatalf("%T should match interface", impl)
+			} else if !wantMatch && ok {
+				t.Fatalf("%T should NOT match interface", impl)
 			}
 		}
 	})
 
 	t.Run("AppContainerComponentSpec", func(t *testing.T) {
-		for _, impl := range []interface{}{
-			&AppServiceSpec{},
-			&AppWorkerSpec{},
-			&AppJobSpec{},
+		for impl, wantMatch := range map[any]bool{
+			&AppServiceSpec{}: true,
+			&AppWorkerSpec{}:  true,
+			&AppJobSpec{}:     true,
+
+			&AppStaticSiteSpec{}: false,
+			&AppFunctionsSpec{}:  false,
+			&AppDatabaseSpec{}:   false,
 		} {
-			if _, ok := impl.(AppContainerComponentSpec); !ok {
+			_, ok := impl.(AppContainerComponentSpec)
+			if wantMatch && !ok {
 				t.Fatalf("%T should match interface", impl)
+			} else if !wantMatch && ok {
+				t.Fatalf("%T should NOT match interface", impl)
 			}
 		}
 	})
 
 	t.Run("AppRoutableComponentSpec", func(t *testing.T) {
-		for _, impl := range []interface{}{
-			&AppServiceSpec{},
-			&AppStaticSiteSpec{},
-			&AppFunctionsSpec{},
+		for impl, wantMatch := range map[any]bool{
+			&AppServiceSpec{}:    true,
+			&AppStaticSiteSpec{}: true,
+			&AppFunctionsSpec{}:  true,
+
+			&AppWorkerSpec{}:   false,
+			&AppJobSpec{}:      false,
+			&AppDatabaseSpec{}: false,
 		} {
-			if _, ok := impl.(AppRoutableComponentSpec); !ok {
+			_, ok := impl.(AppRoutableComponentSpec)
+			if wantMatch && !ok {
 				t.Fatalf("%T should match interface", impl)
+			} else if !wantMatch && ok {
+				t.Fatalf("%T should NOT match interface", impl)
 			}
 		}
 	})
@@ -715,6 +773,20 @@ func TestApps_Interfaces(t *testing.T) {
 		} {
 			if _, ok := impl.(VCSSourceSpec); !ok {
 				t.Fatalf("%T should match interface", impl)
+			}
+		}
+		for impl, wantMatch := range map[any]bool{
+			&GitSourceSpec{}:    true,
+			&GitHubSourceSpec{}: true,
+			&GitLabSourceSpec{}: true,
+
+			&ImageSourceSpec{}: false,
+		} {
+			_, ok := impl.(VCSSourceSpec)
+			if wantMatch && !ok {
+				t.Fatalf("%T should match interface", impl)
+			} else if !wantMatch && ok {
+				t.Fatalf("%T should NOT match interface", impl)
 			}
 		}
 	})


### PR DESCRIPTION
* update interface `AppBuildableComponentSpec` to match functions components
* add interfaces `AppDockerBuildableComponentSpec` and `AppCNBBuildableComponentSpec`
* remove deprecated field/accessor `GetEnvironmentSlug`