### PR TITLE
apps: add docr image deploy on push

### DIFF
--- a/apps.gen.go
+++ b/apps.gen.go
@@ -522,6 +522,18 @@ type DeploymentCauseDetailsDigitalOceanUserAction struct {
 	Name DeploymentCauseDetailsDigitalOceanUserActionName `json:"name,omitempty"`
 }
 
+// DeploymentCauseDetailsDOCRPush struct for DeploymentCauseDetailsDOCRPush
+type DeploymentCauseDetailsDOCRPush struct {
+	// The registry name.
+	Registry string `json:"registry,omitempty"`
+	// The repository name.
+	Repository string `json:"repository,omitempty"`
+	// The repository tag.
+	Tag string `json:"tag,omitempty"`
+	// OCI Image digest.
+	ImageDigest string `json:"image_digest,omitempty"`
+}
+
 // DeploymentCauseDetailsGitPush struct for DeploymentCauseDetailsGitPush
 type DeploymentCauseDetailsGitPush struct {
 	GitHub        *GitHubSourceSpec `json:"github,omitempty"`
@@ -584,6 +596,7 @@ type Deployment struct {
 type DeploymentCauseDetails struct {
 	DigitalOceanUserAction *DeploymentCauseDetailsDigitalOceanUserAction `json:"digitalocean_user_action,omitempty"`
 	GitPush                *DeploymentCauseDetailsGitPush                `json:"git_push,omitempty"`
+	DOCRPush               *DeploymentCauseDetailsDOCRPush               `json:"docr_push,omitempty"`
 	Internal               bool                                          `json:"internal,omitempty"`
 	Type                   DeploymentCauseDetailsType                    `json:"type,omitempty"`
 }
@@ -886,7 +899,14 @@ type ImageSourceSpec struct {
 	// The repository name.
 	Repository string `json:"repository,omitempty"`
 	// The repository tag. Defaults to `latest` if not provided.
-	Tag string `json:"tag,omitempty"`
+	Tag          string                       `json:"tag,omitempty"`
+	DeployOnPush *ImageSourceSpecDeployOnPush `json:"deploy_on_push,omitempty"`
+}
+
+// ImageSourceSpecDeployOnPush struct for ImageSourceSpecDeployOnPush
+type ImageSourceSpecDeployOnPush struct {
+	// Automatically deploy new images. Only for DOCR images.
+	Enabled bool `json:"enabled,omitempty"`
 }
 
 // ImageSourceSpecRegistryType  - DOCR: The DigitalOcean container registry type.  - DOCKER_HUB: The DockerHub container registry type.

--- a/apps_accessors.go
+++ b/apps_accessors.go
@@ -2110,6 +2110,14 @@ func (d *DeploymentCauseDetails) GetDigitalOceanUserAction() *DeploymentCauseDet
 	return d.DigitalOceanUserAction
 }
 
+// GetDOCRPush returns the DOCRPush field.
+func (d *DeploymentCauseDetails) GetDOCRPush() *DeploymentCauseDetailsDOCRPush {
+	if d == nil {
+		return nil
+	}
+	return d.DOCRPush
+}
+
 // GetGitPush returns the GitPush field.
 func (d *DeploymentCauseDetails) GetGitPush() *DeploymentCauseDetailsGitPush {
 	if d == nil {
@@ -2172,6 +2180,38 @@ func (d *DeploymentCauseDetailsDigitalOceanUserAction) GetUser() *DeploymentCaus
 		return nil
 	}
 	return d.User
+}
+
+// GetImageDigest returns the ImageDigest field.
+func (d *DeploymentCauseDetailsDOCRPush) GetImageDigest() string {
+	if d == nil {
+		return ""
+	}
+	return d.ImageDigest
+}
+
+// GetRegistry returns the Registry field.
+func (d *DeploymentCauseDetailsDOCRPush) GetRegistry() string {
+	if d == nil {
+		return ""
+	}
+	return d.Registry
+}
+
+// GetRepository returns the Repository field.
+func (d *DeploymentCauseDetailsDOCRPush) GetRepository() string {
+	if d == nil {
+		return ""
+	}
+	return d.Repository
+}
+
+// GetTag returns the Tag field.
+func (d *DeploymentCauseDetailsDOCRPush) GetTag() string {
+	if d == nil {
+		return ""
+	}
+	return d.Tag
 }
 
 // GetCommitAuthor returns the CommitAuthor field.
@@ -2782,6 +2822,14 @@ func (g *GitSourceSpec) GetRepoCloneURL() string {
 	return g.RepoCloneURL
 }
 
+// GetDeployOnPush returns the DeployOnPush field.
+func (i *ImageSourceSpec) GetDeployOnPush() *ImageSourceSpecDeployOnPush {
+	if i == nil {
+		return nil
+	}
+	return i.DeployOnPush
+}
+
 // GetRegistry returns the Registry field.
 func (i *ImageSourceSpec) GetRegistry() string {
 	if i == nil {
@@ -2812,6 +2860,14 @@ func (i *ImageSourceSpec) GetTag() string {
 		return ""
 	}
 	return i.Tag
+}
+
+// GetEnabled returns the Enabled field.
+func (i *ImageSourceSpecDeployOnPush) GetEnabled() bool {
+	if i == nil {
+		return false
+	}
+	return i.Enabled
 }
 
 // GetAppID returns the AppID field.

--- a/apps_accessors_test.go
+++ b/apps_accessors_test.go
@@ -1854,6 +1854,13 @@ func TestDeploymentCauseDetails_GetDigitalOceanUserAction(tt *testing.T) {
 	d.GetDigitalOceanUserAction()
 }
 
+func TestDeploymentCauseDetails_GetDOCRPush(tt *testing.T) {
+	d := &DeploymentCauseDetails{}
+	d.GetDOCRPush()
+	d = nil
+	d.GetDOCRPush()
+}
+
 func TestDeploymentCauseDetails_GetGitPush(tt *testing.T) {
 	d := &DeploymentCauseDetails{}
 	d.GetGitPush()
@@ -1908,6 +1915,34 @@ func TestDeploymentCauseDetailsDigitalOceanUserAction_GetUser(tt *testing.T) {
 	d.GetUser()
 	d = nil
 	d.GetUser()
+}
+
+func TestDeploymentCauseDetailsDOCRPush_GetImageDigest(tt *testing.T) {
+	d := &DeploymentCauseDetailsDOCRPush{}
+	d.GetImageDigest()
+	d = nil
+	d.GetImageDigest()
+}
+
+func TestDeploymentCauseDetailsDOCRPush_GetRegistry(tt *testing.T) {
+	d := &DeploymentCauseDetailsDOCRPush{}
+	d.GetRegistry()
+	d = nil
+	d.GetRegistry()
+}
+
+func TestDeploymentCauseDetailsDOCRPush_GetRepository(tt *testing.T) {
+	d := &DeploymentCauseDetailsDOCRPush{}
+	d.GetRepository()
+	d = nil
+	d.GetRepository()
+}
+
+func TestDeploymentCauseDetailsDOCRPush_GetTag(tt *testing.T) {
+	d := &DeploymentCauseDetailsDOCRPush{}
+	d.GetTag()
+	d = nil
+	d.GetTag()
 }
 
 func TestDeploymentCauseDetailsGitPush_GetCommitAuthor(tt *testing.T) {
@@ -2442,6 +2477,13 @@ func TestGitSourceSpec_GetRepoCloneURL(tt *testing.T) {
 	g.GetRepoCloneURL()
 }
 
+func TestImageSourceSpec_GetDeployOnPush(tt *testing.T) {
+	i := &ImageSourceSpec{}
+	i.GetDeployOnPush()
+	i = nil
+	i.GetDeployOnPush()
+}
+
 func TestImageSourceSpec_GetRegistry(tt *testing.T) {
 	i := &ImageSourceSpec{}
 	i.GetRegistry()
@@ -2468,6 +2510,13 @@ func TestImageSourceSpec_GetTag(tt *testing.T) {
 	i.GetTag()
 	i = nil
 	i.GetTag()
+}
+
+func TestImageSourceSpecDeployOnPush_GetEnabled(tt *testing.T) {
+	i := &ImageSourceSpecDeployOnPush{}
+	i.GetEnabled()
+	i = nil
+	i.GetEnabled()
 }
 
 func TestUpgradeBuildpackRequest_GetAppID(tt *testing.T) {


### PR DESCRIPTION
Adds `DeployOnPush` to DOCR Image specs and related cause detail structs.