### PR TITLE
Prep v1.86.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v1.86.0] - 2022-09-23
+
+- #561 - @jonfriesen - apps: add docr image deploy on push
+
 ## [v1.85.0] - 2022-09-21
 
 - #560 - @andrewsomething - Bump golang.org/x/net (fixes: #557).

--- a/godo.go
+++ b/godo.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.85.0"
+	libraryVersion = "1.86.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"


### PR DESCRIPTION
Let's cut a release so we can make sure this gets pulled into the next doctl build.