### PR TITLE
DBAAS-3011: Add new public endpoints for dbaas alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [v1.86.0] - 2022-09-23
 
 - #561 - @jonfriesen - apps: add docr image deploy on push
+- #562 - @DWizGuy58 - add public monitoring alert policies for dbaas
 
 ## [v1.85.0] - 2022-09-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Change Log
 
+## Unreleased
+
+- #564 - @DWizGuy58 - add public monitoring alert policies for dbaas
+
 ## [v1.86.0] - 2022-09-23
 
 - #561 - @jonfriesen - apps: add docr image deploy on push
-- #562 - @DWizGuy58 - add public monitoring alert policies for dbaas
 
 ## [v1.85.0] - 2022-09-21
 

--- a/monitoring.go
+++ b/monitoring.go
@@ -31,6 +31,11 @@ const (
 	LoadBalancerConnectionUtilizationPercent = "v1/insights/lbaas/connection_utilization_percent"
 	LoadBalancerDropletHealth                = "v1/insights/lbaas/droplet_health"
 	LoadBalancerTLSUtilizationPercent        = "v1/insights/lbaas/tls_connections_per_second_utilization_percent"
+
+	DbaasFifteenMinuteLoadAverage = "v1/dbaas/alerts/load_15_alerts"
+	DbaasMemoryUtilizationPercent = "v1/dbaas/alerts/memory_utilization_alerts"
+	DbaasDiskUtilizationPercent   = "v1/dbaas/alerts/disk_utilization_alerts"
+	DbaasCPUUtilizationPercent    = "v1/dbaas/alerts/cpu_alerts"
 )
 
 // MonitoringService is an interface for interfacing with the


### PR DESCRIPTION
Adding new public DBAAS rule endpoints to allow `doctl` to validate when creating/updating rules