### PR TITLE
Apps: add project id as a parameter to CreateApp and to the App struct

### DIFF
--- a/apps.gen.go
+++ b/apps.gen.go
@@ -94,7 +94,7 @@ type App struct {
 	Domains                 []*AppDomain    `json:"domains,omitempty"`
 	PinnedDeployment        *Deployment     `json:"pinned_deployment,omitempty"`
 	BuildConfig             *AppBuildConfig `json:"build_config,omitempty"`
-	// The id of the project for the app. This will be empty if there is a fleet (project) lookup failure.
+	// The id of the project for the app. This will be empty if there is a lookup failure.
 	ProjectID string `json:"project_id,omitempty"`
 }
 

--- a/apps.gen.go
+++ b/apps.gen.go
@@ -159,7 +159,7 @@ type AppBuildConfig struct {
 
 // AppBuildConfigCNBVersioning struct for AppBuildConfigCNBVersioning
 type AppBuildConfigCNBVersioning struct {
-	// List of versioned buildpacks used for the application.  Buildpacks are only versioned based on the major semver version, threfore exact versions will not be available at the app build config.
+	// List of versioned buildpacks used for the application.  Buildpacks are only versioned based on the major semver version, therefore exact versions will not be available at the app build config.
 	Buildpacks []*Buildpack `json:"buildpacks,omitempty"`
 }
 

--- a/apps.gen.go
+++ b/apps.gen.go
@@ -94,8 +94,6 @@ type App struct {
 	Domains                 []*AppDomain    `json:"domains,omitempty"`
 	PinnedDeployment        *Deployment     `json:"pinned_deployment,omitempty"`
 	BuildConfig             *AppBuildConfig `json:"build_config,omitempty"`
-	// The id of the project for the app. This will be empty if there is a fleet (project) lookup failure. Deprecated in favor of project_id.
-	FleetUUID string `json:"fleet_uuid,omitempty"`
 	// The id of the project for the app. This will be empty if there is a fleet (project) lookup failure.
 	ProjectID string `json:"project_id,omitempty"`
 }

--- a/apps.gen.go
+++ b/apps.gen.go
@@ -94,6 +94,8 @@ type App struct {
 	Domains                 []*AppDomain    `json:"domains,omitempty"`
 	PinnedDeployment        *Deployment     `json:"pinned_deployment,omitempty"`
 	BuildConfig             *AppBuildConfig `json:"build_config,omitempty"`
+	// The UUID of the fleet (a.k.a project) for the app. This will be empty if there is a fleet lookup failure.
+	FleetUUID string `json:"fleet_uuid,omitempty"`
 }
 
 // AppAlertSpec Configuration of an alert for the app or a individual component.
@@ -157,7 +159,7 @@ type AppBuildConfig struct {
 
 // AppBuildConfigCNBVersioning struct for AppBuildConfigCNBVersioning
 type AppBuildConfigCNBVersioning struct {
-	// List of versioned buildpacks used for the application.  Buildpacks are only versioned based on the major semver version, therefore exact versions will not be available at the app build config.
+	// List of versioned buildpacks used for the application.  Buildpacks are only versioned based on the major semver version, threfore exact versions will not be available at the app build config.
 	Buildpacks []*Buildpack `json:"buildpacks,omitempty"`
 }
 
@@ -563,6 +565,8 @@ type AppCORSPolicy struct {
 // AppCreateRequest struct for AppCreateRequest
 type AppCreateRequest struct {
 	Spec *AppSpec `json:"spec"`
+	// Optional. The UUID of the project the app should be assigned.
+	ProjectID string `json:"project_id,omitempty"`
 }
 
 // DeployTemplate struct for DeployTemplate

--- a/apps.gen.go
+++ b/apps.gen.go
@@ -94,8 +94,10 @@ type App struct {
 	Domains                 []*AppDomain    `json:"domains,omitempty"`
 	PinnedDeployment        *Deployment     `json:"pinned_deployment,omitempty"`
 	BuildConfig             *AppBuildConfig `json:"build_config,omitempty"`
-	// The UUID of the fleet (a.k.a project) for the app. This will be empty if there is a fleet lookup failure.
+	// The id of the project for the app. This will be empty if there is a fleet (project) lookup failure. Deprecated in favor of project_id.
 	FleetUUID string `json:"fleet_uuid,omitempty"`
+	// The id of the project for the app. This will be empty if there is a fleet (project) lookup failure.
+	ProjectID string `json:"project_id,omitempty"`
 }
 
 // AppAlertSpec Configuration of an alert for the app or a individual component.

--- a/apps_accessors.go
+++ b/apps_accessors.go
@@ -46,14 +46,6 @@ func (a *App) GetDomains() []*AppDomain {
 	return a.Domains
 }
 
-// GetFleetUUID returns the FleetUUID field.
-func (a *App) GetFleetUUID() string {
-	if a == nil {
-		return ""
-	}
-	return a.FleetUUID
-}
-
 // GetID returns the ID field.
 func (a *App) GetID() string {
 	if a == nil {

--- a/apps_accessors.go
+++ b/apps_accessors.go
@@ -126,6 +126,14 @@ func (a *App) GetPinnedDeployment() *Deployment {
 	return a.PinnedDeployment
 }
 
+// GetProjectID returns the ProjectID field.
+func (a *App) GetProjectID() string {
+	if a == nil {
+		return ""
+	}
+	return a.ProjectID
+}
+
 // GetRegion returns the Region field.
 func (a *App) GetRegion() *AppRegion {
 	if a == nil {

--- a/apps_accessors.go
+++ b/apps_accessors.go
@@ -46,6 +46,14 @@ func (a *App) GetDomains() []*AppDomain {
 	return a.Domains
 }
 
+// GetFleetUUID returns the FleetUUID field.
+func (a *App) GetFleetUUID() string {
+	if a == nil {
+		return ""
+	}
+	return a.FleetUUID
+}
+
 // GetID returns the ID field.
 func (a *App) GetID() string {
 	if a == nil {
@@ -396,6 +404,14 @@ func (a *AppCORSPolicy) GetMaxAge() string {
 		return ""
 	}
 	return a.MaxAge
+}
+
+// GetProjectID returns the ProjectID field.
+func (a *AppCreateRequest) GetProjectID() string {
+	if a == nil {
+		return ""
+	}
+	return a.ProjectID
 }
 
 // GetSpec returns the Spec field.

--- a/apps_accessors_test.go
+++ b/apps_accessors_test.go
@@ -356,6 +356,13 @@ func TestAppCORSPolicy_GetMaxAge(tt *testing.T) {
 	a.GetMaxAge()
 }
 
+func TestAppCreateRequest_GetProjectID(tt *testing.T) {
+	a := &AppCreateRequest{}
+	a.GetProjectID()
+	a = nil
+	a.GetProjectID()
+}
+
 func TestAppCreateRequest_GetSpec(tt *testing.T) {
 	a := &AppCreateRequest{}
 	a.GetSpec()

--- a/apps_accessors_test.go
+++ b/apps_accessors_test.go
@@ -111,6 +111,13 @@ func TestApp_GetPinnedDeployment(tt *testing.T) {
 	a.GetPinnedDeployment()
 }
 
+func TestApp_GetProjectID(tt *testing.T) {
+	a := &App{}
+	a.GetProjectID()
+	a = nil
+	a.GetProjectID()
+}
+
 func TestApp_GetRegion(tt *testing.T) {
 	a := &App{}
 	a.GetRegion()


### PR DESCRIPTION
We're releasing changes to our API that will allow folks to assign it to a specific project rather than their default one. This change enables that in godo so that doctl can do this too.