### PR TITLE
apps: add option to get projects data from Apps List endpoint

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -28,7 +28,7 @@ const (
 type AppsService interface {
 	Create(ctx context.Context, create *AppCreateRequest) (*App, *Response, error)
 	Get(ctx context.Context, appID string) (*App, *Response, error)
-	List(ctx context.Context, opts *AppsListOptions) ([]*App, *Response, error)
+	List(ctx context.Context, opts *ListOptions) ([]*App, *Response, error)
 	Update(ctx context.Context, appID string, update *AppUpdateRequest) (*App, *Response, error)
 	Delete(ctx context.Context, appID string) (*Response, error)
 	Propose(ctx context.Context, propose *AppProposeRequest) (*AppProposeResponse, *Response, error)
@@ -181,16 +181,8 @@ func (s *AppsServiceOp) Get(ctx context.Context, appID string) (*App, *Response,
 	return root.App, resp, nil
 }
 
-// AppsListOptions extends ListOptions to add ListApps specific parameters
-type AppsListOptions struct {
-	ListOptions
-
-	// Whether the app responses should include populated project_id fields. The field will be empty if false or if omitted.
-	WithProjects bool `url:"with_projects,omitempty"`
-}
-
 // List apps.
-func (s *AppsServiceOp) List(ctx context.Context, opts *AppsListOptions) ([]*App, *Response, error) {
+func (s *AppsServiceOp) List(ctx context.Context, opts *ListOptions) ([]*App, *Response, error) {
 	path := appsBasePath
 	path, err := addOptions(path, opts)
 	if err != nil {

--- a/apps.go
+++ b/apps.go
@@ -28,7 +28,7 @@ const (
 type AppsService interface {
 	Create(ctx context.Context, create *AppCreateRequest) (*App, *Response, error)
 	Get(ctx context.Context, appID string) (*App, *Response, error)
-	List(ctx context.Context, opts *ListOptions) ([]*App, *Response, error)
+	List(ctx context.Context, opts *AppsListOptions) ([]*App, *Response, error)
 	Update(ctx context.Context, appID string, update *AppUpdateRequest) (*App, *Response, error)
 	Delete(ctx context.Context, appID string) (*Response, error)
 	Propose(ctx context.Context, propose *AppProposeRequest) (*AppProposeResponse, *Response, error)
@@ -181,8 +181,16 @@ func (s *AppsServiceOp) Get(ctx context.Context, appID string) (*App, *Response,
 	return root.App, resp, nil
 }
 
+// AppsListOptions extends ListOptions to add ListApps specific parameters
+type AppsListOptions struct {
+	ListOptions
+
+	// Whether the app responses should include populated project_id fields. The field will be empty if false or if omitted.
+	WithProjects bool `url:"with_projects,omitempty"`
+}
+
 // List apps.
-func (s *AppsServiceOp) List(ctx context.Context, opts *ListOptions) ([]*App, *Response, error) {
+func (s *AppsServiceOp) List(ctx context.Context, opts *AppsListOptions) ([]*App, *Response, error) {
 	path := appsBasePath
 	path, err := addOptions(path, opts)
 	if err != nil {

--- a/apps_test.go
+++ b/apps_test.go
@@ -299,7 +299,7 @@ func TestApps_ListApp(t *testing.T) {
 			json.NewEncoder(w).Encode(&appsRoot{Apps: []*App{{ProjectID: "something"}}, Meta: &Meta{Total: 1}, Links: &Links{}})
 		})
 
-		apps, resp, err := client.Apps.List(ctx, nil)
+		apps, resp, err := client.Apps.List(ctx, &AppsListOptions{WithProjects: true})
 		require.NoError(t, err)
 		assert.Equal(t, "something", apps[0].ProjectID)
 		assert.Equal(t, 1, resp.Meta.Total)

--- a/apps_test.go
+++ b/apps_test.go
@@ -299,7 +299,7 @@ func TestApps_ListApp(t *testing.T) {
 			json.NewEncoder(w).Encode(&appsRoot{Apps: []*App{{ProjectID: "something"}}, Meta: &Meta{Total: 1}, Links: &Links{}})
 		})
 
-		apps, resp, err := client.Apps.List(ctx, &AppsListOptions{WithProjects: true})
+		apps, resp, err := client.Apps.List(ctx, &ListOptions{WithProjects: true})
 		require.NoError(t, err)
 		assert.Equal(t, "something", apps[0].ProjectID)
 		assert.Equal(t, 1, resp.Meta.Total)

--- a/godo.go
+++ b/godo.go
@@ -103,6 +103,9 @@ type ListOptions struct {
 
 	// For paginated result sets, the number of results to include per page.
 	PerPage int `url:"per_page,omitempty"`
+
+	// Whether App responses should include project_id fields. The field will be empty if false or if omitted. (ListApps)
+	WithProjects bool `url:"with_projects,omitempty"`
 }
 
 // TokenListOptions specifies the optional parameters to various List methods that support token pagination.


### PR DESCRIPTION
The ListApps endpoint can be called with a `with_projects` query parameter to tell it whether or not to fetch the project ids for each project. This is an expensive call which is why it isn't done by default.

~I'm not sure how to add support for this without breaking changes, I'm hoping @andrewsomething you've got some ideas 🙏 This way seemed like the least work for devs who have already used this in their code, as well as for the doctl implementation of this function.~

This now is an addition to the ListOptions struct, which shouldn't be a breaking change 👍 