### PR TITLE
LBAAS-2430 Add support for HTTP idle timeout seconds

### DIFF
--- a/load_balancers.go
+++ b/load_balancers.go
@@ -10,6 +10,7 @@ const loadBalancersBasePath = "/v2/load_balancers"
 const forwardingRulesPath = "forwarding_rules"
 
 const dropletsPath = "droplets"
+const defaultHttpIdleTimeout = 60
 
 // LoadBalancersService is an interface for managing load balancers with the DigitalOcean API.
 // See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Load-Balancers
@@ -52,6 +53,7 @@ type LoadBalancer struct {
 	DisableLetsEncryptDNSRecords *bool            `json:"disable_lets_encrypt_dns_records,omitempty"`
 	ValidateOnly                 bool             `json:"validate_only,omitempty"`
 	ProjectID                    string           `json:"project_id,omitempty"`
+	HTTPIdleTimeoutSeconds       *uint64          `json:"http_idle_timeout_seconds,omitempty"`
 }
 
 // String creates a human-readable description of a LoadBalancer.
@@ -83,6 +85,7 @@ func (l LoadBalancer) AsRequest() *LoadBalancerRequest {
 		DisableLetsEncryptDNSRecords: l.DisableLetsEncryptDNSRecords,
 		ValidateOnly:                 l.ValidateOnly,
 		ProjectID:                    l.ProjectID,
+		HTTPIdleTimeoutSeconds:       l.HTTPIdleTimeoutSeconds,
 	}
 
 	if l.DisableLetsEncryptDNSRecords != nil {
@@ -99,6 +102,11 @@ func (l LoadBalancer) AsRequest() *LoadBalancerRequest {
 	}
 	if l.Region != nil {
 		r.Region = l.Region.Slug
+	}
+
+	if l.HTTPIdleTimeoutSeconds == nil {
+		defaultTimeout := uint64(defaultHttpIdleTimeout)
+		r.HTTPIdleTimeoutSeconds = &defaultTimeout
 	}
 	return &r
 }
@@ -168,6 +176,7 @@ type LoadBalancerRequest struct {
 	DisableLetsEncryptDNSRecords *bool            `json:"disable_lets_encrypt_dns_records,omitempty"`
 	ValidateOnly                 bool             `json:"validate_only,omitempty"`
 	ProjectID                    string           `json:"project_id,omitempty"`
+	HTTPIdleTimeoutSeconds       *uint64          `json:"http_idle_timeout_seconds,omitempty"`
 }
 
 // String creates a human-readable description of a LoadBalancerRequest.

--- a/load_balancers_test.go
+++ b/load_balancers_test.go
@@ -68,7 +68,8 @@ var lbListJSONResponse = `
                 21
             ],
             "disable_lets_encrypt_dns_records": true,
-            "project_id": "6929eef6-4e45-11ed-bdc3-0242ac120002"
+            "project_id": "6929eef6-4e45-11ed-bdc3-0242ac120002",
+            "http_idle_timeout_seconds": 60
         }
     ],
     "links":{
@@ -150,7 +151,8 @@ var lbCreateJSONResponse = `
         "redirect_http_to_https":true,
         "vpc_uuid":"880b7f98-f062-404d-b33c-458d545696f6",
         "disable_lets_encrypt_dns_records": true,
-        "project_id": "6929eef6-4e45-11ed-bdc3-0242ac120002"
+        "project_id": "6929eef6-4e45-11ed-bdc3-0242ac120002",
+        "http_idle_timeout_seconds": 60
     }
 }
 `
@@ -212,7 +214,8 @@ var lbGetJSONResponse = `
             21
         ],
         "disable_lets_encrypt_dns_records": false,
-        "project_id": "6929eef6-4e45-11ed-bdc3-0242ac120002"
+        "project_id": "6929eef6-4e45-11ed-bdc3-0242ac120002",
+        "http_idle_timeout_seconds": 60
     }
 }
 `
@@ -278,7 +281,8 @@ var lbUpdateJSONResponse = `
             2,
             21
         ],
-        "project_id": "6929eef6-4e45-11ed-bdc3-0242ac120002"
+        "project_id": "6929eef6-4e45-11ed-bdc3-0242ac120002",
+        "http_idle_timeout_seconds": 60
     }
 }
 `
@@ -297,6 +301,7 @@ func TestLoadBalancers_Get(t *testing.T) {
 
 	loadBalancer, _, err := client.LoadBalancers.Get(ctx, loadBalancerID)
 	require.NoError(t, err)
+	expectedTimeout := uint64(60)
 
 	expected := &LoadBalancer{
 		ID:        "37e6be88-01ec-4ec7-9bc6-a514d4719057",
@@ -336,8 +341,9 @@ func TestLoadBalancers_Get(t *testing.T) {
 			Available: true,
 			Features:  []string{"private_networking", "backups", "ipv6", "metadata", "storage"},
 		},
-		DropletIDs: []int{2, 21},
-		ProjectID:  "6929eef6-4e45-11ed-bdc3-0242ac120002",
+		DropletIDs:             []int{2, 21},
+		ProjectID:              "6929eef6-4e45-11ed-bdc3-0242ac120002",
+		HTTPIdleTimeoutSeconds: &expectedTimeout,
 	}
 
 	disableLetsEncryptDNSRecords := false
@@ -402,6 +408,7 @@ func TestLoadBalancers_Create(t *testing.T) {
 	loadBalancer, _, err := client.LoadBalancers.Create(ctx, createRequest)
 	require.NoError(t, err)
 
+	expectedTimeout := uint64(60)
 	expected := &LoadBalancer{
 		ID:        "8268a81c-fcf5-423e-a337-bbfe95817f23",
 		Name:      "example-lb-01",
@@ -447,11 +454,12 @@ func TestLoadBalancers_Create(t *testing.T) {
 			Available: true,
 			Features:  []string{"private_networking", "backups", "ipv6", "metadata", "storage"},
 		},
-		Tags:                []string{"my-tag"},
-		DropletIDs:          []int{2, 21},
-		RedirectHttpToHttps: true,
-		VPCUUID:             "880b7f98-f062-404d-b33c-458d545696f6",
-		ProjectID:           "6929eef6-4e45-11ed-bdc3-0242ac120002",
+		Tags:                   []string{"my-tag"},
+		DropletIDs:             []int{2, 21},
+		RedirectHttpToHttps:    true,
+		VPCUUID:                "880b7f98-f062-404d-b33c-458d545696f6",
+		ProjectID:              "6929eef6-4e45-11ed-bdc3-0242ac120002",
+		HTTPIdleTimeoutSeconds: &expectedTimeout,
 	}
 
 	disableLetsEncryptDNSRecords := true
@@ -639,6 +647,7 @@ func TestLoadBalancers_Update(t *testing.T) {
 	loadBalancer, _, err := client.LoadBalancers.Update(ctx, loadBalancerID, updateRequest)
 	require.NoError(t, err)
 
+	expectedTimeout := uint64(60)
 	expected := &LoadBalancer{
 		ID:        "8268a81c-fcf5-423e-a337-bbfe95817f23",
 		Name:      "example-lb-01",
@@ -684,6 +693,7 @@ func TestLoadBalancers_Update(t *testing.T) {
 		DropletIDs:                   []int{2, 21},
 		DisableLetsEncryptDNSRecords: nil,
 		ProjectID:                    "6929eef6-4e45-11ed-bdc3-0242ac120002",
+		HTTPIdleTimeoutSeconds:       &expectedTimeout,
 	}
 
 	assert.Equal(t, expected, loadBalancer)
@@ -703,6 +713,7 @@ func TestLoadBalancers_List(t *testing.T) {
 
 	require.NoError(t, err)
 
+	expectedTimeout := uint64(60)
 	expectedLBs := []LoadBalancer{
 		{
 			ID:        "37e6be88-01ec-4ec7-9bc6-a514d4719057",
@@ -741,8 +752,9 @@ func TestLoadBalancers_List(t *testing.T) {
 				Available: true,
 				Features:  []string{"private_networking", "backups", "ipv6", "metadata", "storage"},
 			},
-			DropletIDs: []int{2, 21},
-			ProjectID:  "6929eef6-4e45-11ed-bdc3-0242ac120002",
+			DropletIDs:             []int{2, 21},
+			ProjectID:              "6929eef6-4e45-11ed-bdc3-0242ac120002",
+			HTTPIdleTimeoutSeconds: &expectedTimeout,
 		},
 	}
 	disableLetsEncryptDNSRecords := true
@@ -972,6 +984,7 @@ func TestLoadBalancers_AsRequest(t *testing.T) {
 		TargetPort:     80,
 	}
 
+	expectedIdleTimeout := uint64(60)
 	want := &LoadBalancerRequest{
 		Name:      "test-loadbalancer",
 		Algorithm: "least_connections",
@@ -1003,6 +1016,7 @@ func TestLoadBalancers_AsRequest(t *testing.T) {
 		EnableBackendKeepalive: true,
 		VPCUUID:                "880b7f98-f062-404d-b33c-458d545696f6",
 		ProjectID:              "6929eef6-4e45-11ed-bdc3-0242ac120002",
+		HTTPIdleTimeoutSeconds: &expectedIdleTimeout,
 		ValidateOnly:           true,
 	}
 


### PR DESCRIPTION
Jira: https://jira.internal.digitalocean.com/browse/LBAAS-2430

Setting to default 60s if not specified by the user. FWIW this is the current defaults and will be enforced at the lbapi level as well