### PR TITLE
Deprecate old pointer helpers, use generic one

### DIFF
--- a/billing_history_test.go
+++ b/billing_history_test.go
@@ -46,8 +46,8 @@ func TestBillingHistory_List(t *testing.T) {
 		{
 			Description: "Invoice for May 2018",
 			Amount:      "12.34",
-			InvoiceID:   String("123"),
-			InvoiceUUID: String("example-uuid"),
+			InvoiceID:   PtrTo("123"),
+			InvoiceUUID: PtrTo("example-uuid"),
 			Date:        time.Date(2018, 6, 1, 8, 44, 38, 0, time.UTC),
 			Type:        "Invoice",
 		},

--- a/databases_test.go
+++ b/databases_test.go
@@ -1768,27 +1768,27 @@ func TestDatabases_GetConfigPostgres(t *testing.T) {
 }`
 
 		postgresConfig = PostgreSQLConfig{
-			AutovacuumNaptime:               intPtr(60),
-			AutovacuumVacuumThreshold:       intPtr(50),
-			AutovacuumAnalyzeThreshold:      intPtr(50),
-			AutovacuumVacuumScaleFactor:     float32Ptr(0.2),
-			AutovacuumAnalyzeScaleFactor:    float32Ptr(0.2),
-			AutovacuumVacuumCostDelay:       intPtr(20),
-			AutovacuumVacuumCostLimit:       intPtr(-1),
-			BGWriterFlushAfter:              intPtr(512),
-			BGWriterLRUMaxpages:             intPtr(100),
-			BGWriterLRUMultiplier:           float32Ptr(2),
-			IdleInTransactionSessionTimeout: intPtr(0),
-			JIT:                             boolPtr(true),
-			LogAutovacuumMinDuration:        intPtr(-1),
-			LogMinDurationStatement:         intPtr(-1),
-			MaxPreparedTransactions:         intPtr(0),
-			MaxParallelWorkers:              intPtr(8),
-			MaxParallelWorkersPerGather:     intPtr(2),
-			TempFileLimit:                   intPtr(-1),
-			WalSenderTimeout:                intPtr(60000),
-			BackupHour:                      intPtr(18),
-			BackupMinute:                    intPtr(26),
+			AutovacuumNaptime:               PtrTo(60),
+			AutovacuumVacuumThreshold:       PtrTo(50),
+			AutovacuumAnalyzeThreshold:      PtrTo(50),
+			AutovacuumVacuumScaleFactor:     PtrTo(float32(0.2)),
+			AutovacuumAnalyzeScaleFactor:    PtrTo(float32(0.2)),
+			AutovacuumVacuumCostDelay:       PtrTo(20),
+			AutovacuumVacuumCostLimit:       PtrTo(-1),
+			BGWriterFlushAfter:              PtrTo(512),
+			BGWriterLRUMaxpages:             PtrTo(100),
+			BGWriterLRUMultiplier:           PtrTo(float32(2)),
+			IdleInTransactionSessionTimeout: PtrTo(0),
+			JIT:                             PtrTo(true),
+			LogAutovacuumMinDuration:        PtrTo(-1),
+			LogMinDurationStatement:         PtrTo(-1),
+			MaxPreparedTransactions:         PtrTo(0),
+			MaxParallelWorkers:              PtrTo(8),
+			MaxParallelWorkersPerGather:     PtrTo(2),
+			TempFileLimit:                   PtrTo(-1),
+			WalSenderTimeout:                PtrTo(60000),
+			BackupHour:                      PtrTo(18),
+			BackupMinute:                    PtrTo(26),
 		}
 	)
 
@@ -1810,10 +1810,10 @@ func TestDatabases_UpdateConfigPostgres(t *testing.T) {
 		dbID           = "deadbeef-dead-4aa5-beef-deadbeef347d"
 		path           = fmt.Sprintf("/v2/databases/%s/config", dbID)
 		postgresConfig = &PostgreSQLConfig{
-			AutovacuumNaptime:          intPtr(75),
-			AutovacuumVacuumThreshold:  intPtr(45),
-			AutovacuumAnalyzeThreshold: intPtr(45),
-			MaxPreparedTransactions:    intPtr(0),
+			AutovacuumNaptime:          PtrTo(75),
+			AutovacuumVacuumThreshold:  PtrTo(45),
+			AutovacuumAnalyzeThreshold: PtrTo(45),
+			MaxPreparedTransactions:    PtrTo(0),
 		}
 	)
 
@@ -1859,14 +1859,14 @@ func TestDatabases_GetConfigRedis(t *testing.T) {
 }`
 
 		redisConfig = RedisConfig{
-			RedisMaxmemoryPolicy:      strPtr("allkeys-lru"),
-			RedisLFULogFactor:         intPtr(10),
-			RedisLFUDecayTime:         intPtr(1),
-			RedisSSL:                  boolPtr(true),
-			RedisTimeout:              intPtr(300),
-			RedisNotifyKeyspaceEvents: strPtr(""),
-			RedisPersistence:          strPtr("off"),
-			RedisACLChannelsDefault:   strPtr("allchannels"),
+			RedisMaxmemoryPolicy:      PtrTo("allkeys-lru"),
+			RedisLFULogFactor:         PtrTo(10),
+			RedisLFUDecayTime:         PtrTo(1),
+			RedisSSL:                  PtrTo(true),
+			RedisTimeout:              PtrTo(300),
+			RedisNotifyKeyspaceEvents: PtrTo(""),
+			RedisPersistence:          PtrTo("off"),
+			RedisACLChannelsDefault:   PtrTo("allchannels"),
 		}
 	)
 
@@ -1888,9 +1888,9 @@ func TestDatabases_UpdateConfigRedis(t *testing.T) {
 		dbID        = "deadbeef-dead-4aa5-beef-deadbeef347d"
 		path        = fmt.Sprintf("/v2/databases/%s/config", dbID)
 		redisConfig = &RedisConfig{
-			RedisMaxmemoryPolicy:      strPtr("allkeys-lru"),
-			RedisLFULogFactor:         intPtr(10),
-			RedisNotifyKeyspaceEvents: strPtr(""),
+			RedisMaxmemoryPolicy:      PtrTo("allkeys-lru"),
+			RedisLFULogFactor:         PtrTo(10),
+			RedisNotifyKeyspaceEvents: PtrTo(""),
 		}
 	)
 
@@ -1941,7 +1941,7 @@ func TestDatabases_UpdateConfigRedisNormalizeEvictionPolicy(t *testing.T) {
 			dbID        = "deadbeef-dead-4aa5-beef-deadbeef347d"
 			path        = fmt.Sprintf("/v2/databases/%s/config", dbID)
 			redisConfig = &RedisConfig{
-				RedisMaxmemoryPolicy: strPtr(tt.input),
+				RedisMaxmemoryPolicy: PtrTo(tt.input),
 			}
 		)
 
@@ -1987,16 +1987,16 @@ func TestDatabases_GetConfigMySQL(t *testing.T) {
 }`
 
 		mySQLConfig = MySQLConfig{
-			SQLMode:                     strPtr("ANSI,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,STRICT_ALL_TABLES"),
-			SQLRequirePrimaryKey:        boolPtr(true),
-			InnodbFtMinTokenSize:        intPtr(3),
-			InnodbFtServerStopwordTable: strPtr(""),
-			InnodbPrintAllDeadlocks:     boolPtr(false),
-			InnodbRollbackOnTimeout:     boolPtr(false),
-			SlowQueryLog:                boolPtr(false),
-			LongQueryTime:               float32Ptr(10),
-			BackupHour:                  intPtr(21),
-			BackupMinute:                intPtr(59),
+			SQLMode:                     PtrTo("ANSI,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,STRICT_ALL_TABLES"),
+			SQLRequirePrimaryKey:        PtrTo(true),
+			InnodbFtMinTokenSize:        PtrTo(3),
+			InnodbFtServerStopwordTable: PtrTo(""),
+			InnodbPrintAllDeadlocks:     PtrTo(false),
+			InnodbRollbackOnTimeout:     PtrTo(false),
+			SlowQueryLog:                PtrTo(false),
+			LongQueryTime:               PtrTo(float32(10)),
+			BackupHour:                  PtrTo(21),
+			BackupMinute:                PtrTo(59),
 		}
 	)
 
@@ -2018,9 +2018,9 @@ func TestDatabases_UpdateConfigMySQL(t *testing.T) {
 		dbID        = "deadbeef-dead-4aa5-beef-deadbeef347d"
 		path        = fmt.Sprintf("/v2/databases/%s/config", dbID)
 		mySQLConfig = &MySQLConfig{
-			SQLRequirePrimaryKey:        boolPtr(true),
-			InnodbFtMinTokenSize:        intPtr(3),
-			InnodbFtServerStopwordTable: strPtr(""),
+			SQLRequirePrimaryKey:        PtrTo(true),
+			InnodbFtMinTokenSize:        PtrTo(3),
+			InnodbFtServerStopwordTable: PtrTo(""),
 		}
 	)
 

--- a/godo.go
+++ b/godo.go
@@ -505,8 +505,15 @@ func (r Rate) String() string {
 	return Stringify(r)
 }
 
+// PtrTo returns a pointer to the provided input.
+func PtrTo[T any](v T) *T {
+	return &v
+}
+
 // String is a helper routine that allocates a new string value
 // to store v and returns a pointer to it.
+//
+// Deprecated: Use PtrTo instead.
 func String(v string) *string {
 	p := new(string)
 	*p = v
@@ -516,6 +523,8 @@ func String(v string) *string {
 // Int is a helper routine that allocates a new int32 value
 // to store v and returns a pointer to it, but unlike Int32
 // its argument value is an int.
+//
+// Deprecated: Use PtrTo instead.
 func Int(v int) *int {
 	p := new(int)
 	*p = v
@@ -524,6 +533,8 @@ func Int(v int) *int {
 
 // Bool is a helper routine that allocates a new bool value
 // to store v and returns a pointer to it.
+//
+// Deprecated: Use PtrTo instead.
 func Bool(v bool) *bool {
 	p := new(bool)
 	*p = v

--- a/godo_test.go
+++ b/godo_test.go
@@ -788,19 +788,3 @@ func TestCustomBaseURL_badURL(t *testing.T) {
 
 	testURLParseError(t, err)
 }
-
-func intPtr(val int) *int {
-	return &val
-}
-
-func boolPtr(val bool) *bool {
-	return &val
-}
-
-func float32Ptr(val float32) *float32 {
-	return &val
-}
-
-func strPtr(val string) *string {
-	return &val
-}

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -492,7 +492,7 @@ func TestKubernetesClusters_GetCredentials_WithExpirySeconds(t *testing.T) {
 		fmt.Fprint(w, jBlob)
 	})
 	got, _, err := kubeSvc.GetCredentials(ctx, "deadbeef-dead-4aa5-beef-deadbeef347d", &KubernetesClusterCredentialsGetRequest{
-		ExpirySeconds: intPtr(60 * 60),
+		ExpirySeconds: PtrTo(60 * 60),
 	})
 	require.NoError(t, err)
 	require.Equal(t, want, got)
@@ -880,7 +880,7 @@ func TestKubernetesClusters_Update_FalseAutoUpgrade(t *testing.T) {
 		},
 	}
 	updateRequest := &KubernetesClusterUpdateRequest{
-		AutoUpgrade: boolPtr(false),
+		AutoUpgrade: PtrTo(false),
 	}
 
 	jBlob := `
@@ -1330,7 +1330,7 @@ func TestKubernetesClusters_UpdateNodePool(t *testing.T) {
 	}
 	updateRequest := &KubernetesNodePoolUpdateRequest{
 		Name:  "a better name",
-		Count: intPtr(4),
+		Count: PtrTo(4),
 		Tags:  []string{"tag-1", "tag-2"},
 	}
 
@@ -1384,7 +1384,7 @@ func TestKubernetesClusters_UpdateNodePool_ZeroCount(t *testing.T) {
 		MaxNodes:  0,
 	}
 	updateRequest := &KubernetesNodePoolUpdateRequest{
-		Count: intPtr(0),
+		Count: PtrTo(0),
 	}
 
 	jBlob := `
@@ -1439,9 +1439,9 @@ func TestKubernetesClusters_UpdateNodePool_AutoScale(t *testing.T) {
 		MaxNodes:  10,
 	}
 	updateRequest := &KubernetesNodePoolUpdateRequest{
-		AutoScale: boolPtr(true),
-		MinNodes:  intPtr(0),
-		MaxNodes:  intPtr(10),
+		AutoScale: PtrTo(true),
+		MinNodes:  PtrTo(0),
+		MaxNodes:  PtrTo(10),
 	}
 
 	jBlob := `

--- a/registry_test.go
+++ b/registry_test.go
@@ -167,13 +167,13 @@ func TestRegistry_DockerCredentials(t *testing.T) {
 		},
 		{
 			name:                  "read-only + custom expiry",
-			params:                &RegistryDockerCredentialsRequest{ExpirySeconds: intPtr(60 * 60)},
+			params:                &RegistryDockerCredentialsRequest{ExpirySeconds: PtrTo(60 * 60)},
 			expectedReadWrite:     "false",
 			expectedExpirySeconds: "3600",
 		},
 		{
 			name:                  "read/write + custom expiry",
-			params:                &RegistryDockerCredentialsRequest{ReadWrite: true, ExpirySeconds: intPtr(60 * 60)},
+			params:                &RegistryDockerCredentialsRequest{ReadWrite: true, ExpirySeconds: PtrTo(60 * 60)},
 			expectedReadWrite:     "true",
 			expectedExpirySeconds: "3600",
 		},
@@ -488,7 +488,7 @@ func TestRegistry_ListManifests(t *testing.T) {
 				{
 					"digest": "sha256:blob1",
 					"compressed_size_bytes": 998
-				}, 
+				},
 				{
 
 					"digest": "sha256:blob2",

--- a/vpcs_test.go
+++ b/vpcs_test.go
@@ -174,7 +174,7 @@ func TestVPCs_Update(t *testing.T) {
 			req: &VPCUpdateRequest{
 				Name:        "my-new-vpc",
 				Description: "vpc description",
-				Default:     boolPtr(false),
+				Default:     PtrTo(false),
 			},
 			mockResponse: `
 			{
@@ -192,7 +192,7 @@ func TestVPCs_Update(t *testing.T) {
 			req: &VPCUpdateRequest{
 				Name:        "my-new-vpc",
 				Description: "vpc description",
-				Default:     boolPtr(true),
+				Default:     PtrTo(true),
 			},
 			mockResponse: `
 			{


### PR DESCRIPTION
Deprecates and changes all of the uses of the various pointer-to style helpers in favour of using a generic one.

I've seen more and more of the `*type` struct fields pop up in new features, so I figure this might offer a more consistent way to create a pointer to a type, rather having to use an old type specific one or have users create their own.

Most of this is PR is changing the use of old test helpers to use the new func. The implementation of the new func [here](https://github.com/digitalocean/godo/pull/579/files#diff-ec6977d0d43eaf44c51775905e491c046f65b6471ed410ca098857ac94f53ecb).