### PR TITLE
Prepare to release v1.91.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v1.91.1] - 2022-11-23
+
+- #582 - @StephenVarela - Load Balancers: Support new endpoints for http alerts
+
 ## [v1.90.0] - 2022-11-16
 
 - #571 - @kraai - Add WaitForAvailable

--- a/godo.go
+++ b/godo.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.90.0"
+	libraryVersion = "1.91.1"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"


### PR DESCRIPTION
Prepares to release v1.91.1 (v1.91.0 was released without a version bump, so it was deleted).