### PR TITLE
Add Uptime Checks and Alerts Support

### DIFF
--- a/godo.go
+++ b/godo.go
@@ -82,6 +82,7 @@ type Client struct {
 	StorageActions    StorageActionsService
 	Tags              TagsService
 	Tokens            TokensService
+	UptimeChecks      UptimeChecksService
 	VPCs              VPCsService
 
 	// Optional function called after every successful request made to the DO APIs
@@ -252,6 +253,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.StorageActions = &StorageActionsServiceOp{client: c}
 	c.Tags = &TagsServiceOp{client: c}
 	c.Tokens = &TokensServiceOp{client: c}
+	c.UptimeChecks = &UptimeChecksServiceOp{client: c}
 	c.VPCs = &VPCsServiceOp{client: c}
 
 	c.headers = make(map[string]string)

--- a/uptime.go
+++ b/uptime.go
@@ -1,0 +1,324 @@
+package godo
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"path"
+)
+
+const uptimeChecksBasePath = "/v2/uptime/checks"
+
+// UptimeService is an interface for creating and managing Uptime checks with the DigitalOcean API.
+// See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Projects
+type UptimeChecksService interface {
+	List(context.Context, *ListOptions) ([]UptimeCheck, *Response, error)
+	Get(context.Context, string) (*UptimeCheck, *Response, error)
+	GetState(context.Context, string) (*UptimeCheck, *Response, error)
+	Create(context.Context, *CreateUptimeCheckRequest) (*UptimeCheck, *Response, error)
+	Update(context.Context, string, *UpdateUptimeCheckRequest) (*UptimeCheck, *Response, error)
+	Delete(context.Context, string) (*Response, error)
+	GetAlert(context.Context, string, string) (*Alert, *Response, error)
+	ListAlerts(context.Context, *ListOptions, string) ([]Alert, *Response, error)
+	CreateAlert(context.Context, *CreateAlertRequest, string) (*Alert, *Response, error)
+	UpdateAlert(context.Context, string, string, *UpdateAlertRequest) (*Alert, *Response, error)
+	DeleteAlert(context.Context, string, string) (*Response, error)
+}
+
+// UptimeChecksServiceOp handles communication with Uptime Check methods of the DigitalOcean API.
+type UptimeChecksServiceOp struct {
+	client *Client
+}
+
+// UptimeCheck represents a DigitalOcean UptimeCheck configuration.
+type UptimeCheck struct {
+	ID      string   `json:"id"`
+	Name    string   `json:"name"`
+	Type    string   `json:"type"`
+	Target  string   `json:"target"`
+	Regions []string `json:"regions"`
+	Enabled bool     `json:"enabled"`
+}
+
+// Alert represents a DigitalOcean UptimeCheck configuration.
+type Alert struct {
+	ID            string         `json:"id"`
+	Name          string         `json:"name"`
+	Type          string         `json:"type"`
+	Threshold     int            `json:"threshold"`
+	Comparison    string         `json:"comparison"`
+	Notifications *Notifications `json:"notifications"`
+	Period        string         `json:"period"`
+}
+
+// CreateUptimeAlertRequest represents the request to create a new alert.
+type CreateAlertRequest struct {
+	Name          string         `json:"name"`
+	Type          string         `json:"type"`
+	Threshold     int            `json:"threshold"`
+	Comparison    string         `json:"comparison"`
+	Notifications *Notifications `json:"notifications"`
+	Period        string         `json:"period"`
+}
+
+// UpdateUptimeAlertRequest represents the request to create a new alert.
+type UpdateAlertRequest struct {
+	Name          string         `json:"name"`
+	Type          string         `json:"type"`
+	Threshold     int            `json:"threshold"`
+	Comparison    string         `json:"comparison"`
+	Notifications *Notifications `json:"notifications"`
+	Period        string         `json:"period"`
+}
+
+// Notifications represents a DigitalOcean Notifications configuration.
+type Notifications struct {
+	Email []string `json:"email"`
+	Slack []Slack  `json:"slack"`
+}
+
+// Slack represents a DigitalOcean Slack configuration.
+type Slack struct {
+	Channel string `json:"channel"`
+	URL     string `json:"url"`
+}
+
+// CreateUptimeCheckRequest represents the request to create a new uptime check.
+type CreateUptimeCheckRequest struct {
+	Name    string   `json:"name"`
+	Type    string   `json:"type"`
+	Target  string   `json:"target"`
+	Regions []string `json:"regions"`
+	Enabled bool     `json:"enabled"`
+}
+
+// UpdateUptimeCheckRequest represents the request to update uptime check information.
+type UpdateUptimeCheckRequest struct {
+	Name    string   `json:"name"`
+	Type    string   `json:"type"`
+	Target  string   `json:"target"`
+	Regions []string `json:"regions"`
+	Enabled bool     `json:"enabled"`
+}
+
+type uptimeChecksRoot struct {
+	UptimeChecks []UptimeCheck `json:"checks"`
+	Links        *Links        `json:"links"`
+	Meta         *Meta         `json:"meta"`
+}
+
+type alertsRoot struct {
+	Alerts []Alert `json:"alerts"`
+	Links  *Links  `json:"links"`
+	Meta   *Meta   `json:"meta"`
+}
+
+type uptimeCheckRoot struct {
+	UptimeCheck *UptimeCheck `json:"check"`
+}
+
+type alertRoot struct {
+	Alert *Alert `json:"alert"`
+}
+
+var _ UptimeChecksService = &UptimeChecksServiceOp{}
+
+// List Checks.
+func (p *UptimeChecksServiceOp) List(ctx context.Context, opts *ListOptions) ([]UptimeCheck, *Response, error) {
+	path, err := addOptions(uptimeChecksBasePath, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := p.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(uptimeChecksRoot)
+	resp, err := p.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
+	}
+
+	return root.UptimeChecks, resp, err
+}
+
+// GetState of uptime check.
+func (p *UptimeChecksServiceOp) GetState(ctx context.Context, uptimeCheckID string) (*UptimeCheck, *Response, error) {
+	path := path.Join(uptimeChecksBasePath, uptimeCheckID, "/state")
+
+	req, err := p.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(uptimeCheckRoot)
+	resp, err := p.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.UptimeCheck, resp, err
+}
+
+// Get retrieves a single uptime check by its ID.
+func (p *UptimeChecksServiceOp) Get(ctx context.Context, uptimeCheckID string) (*UptimeCheck, *Response, error) {
+	path := path.Join(uptimeChecksBasePath, uptimeCheckID)
+
+	req, err := p.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(uptimeCheckRoot)
+	resp, err := p.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.UptimeCheck, resp, err
+}
+
+// Create a new uptime check.
+func (p *UptimeChecksServiceOp) Create(ctx context.Context, cr *CreateUptimeCheckRequest) (*UptimeCheck, *Response, error) {
+	req, err := p.client.NewRequest(ctx, http.MethodPost, uptimeChecksBasePath, cr)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(uptimeCheckRoot)
+	resp, err := p.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.UptimeCheck, resp, err
+}
+
+// Update an uptime check.
+func (p *UptimeChecksServiceOp) Update(ctx context.Context, uptimeCheckID string, ur *UpdateUptimeCheckRequest) (*UptimeCheck, *Response, error) {
+	path := path.Join(uptimeChecksBasePath, uptimeCheckID)
+	req, err := p.client.NewRequest(ctx, http.MethodPut, path, ur)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(uptimeCheckRoot)
+	resp, err := p.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.UptimeCheck, resp, err
+}
+
+// Delete an existing uptime check.
+func (p *UptimeChecksServiceOp) Delete(ctx context.Context, uptimeCheckID string) (*Response, error) {
+	path := path.Join(uptimeChecksBasePath, uptimeCheckID)
+	req, err := p.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.client.Do(ctx, req, nil)
+}
+
+// alerts
+
+// List alerts for a check.
+func (p *UptimeChecksServiceOp) ListAlerts(ctx context.Context, opts *ListOptions, uptimeCheckID string) ([]Alert, *Response, error) {
+	fullPath := path.Join(uptimeChecksBasePath, uptimeCheckID, "/alerts")
+	path, err := addOptions(fullPath, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := p.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(alertsRoot)
+	resp, err := p.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
+	}
+
+	return root.Alerts, resp, err
+}
+
+// Create a new uptime check alert.
+func (p *UptimeChecksServiceOp) CreateAlert(ctx context.Context, cr *CreateAlertRequest, uptimeCheckID string) (*Alert, *Response, error) {
+	fullPath := path.Join(uptimeChecksBasePath, uptimeCheckID, "/alerts")
+	req, err := p.client.NewRequest(ctx, http.MethodPost, fullPath, cr)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(alertRoot)
+	resp, err := p.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Alert, resp, err
+}
+
+// Get retrieves a single uptime check alert by its ID.
+func (p *UptimeChecksServiceOp) GetAlert(ctx context.Context, uptimeCheckID string, alertID string) (*Alert, *Response, error) {
+	path := fmt.Sprintf("v2/uptime/checks/%s/alerts/%s", uptimeCheckID, alertID)
+
+	req, err := p.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(alertRoot)
+	resp, err := p.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Alert, resp, err
+}
+
+// Update an uptime check's alert.
+func (p *UptimeChecksServiceOp) UpdateAlert(ctx context.Context, uptimeCheckID string, alertID string, ur *UpdateAlertRequest) (*Alert, *Response, error) {
+	path := path.Join(uptimeChecksBasePath, uptimeCheckID, "/alerts/", alertID)
+	req, err := p.client.NewRequest(ctx, http.MethodPut, path, ur)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(alertRoot)
+	resp, err := p.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Alert, resp, err
+}
+
+// Delete an existing uptime check's alert.
+func (p *UptimeChecksServiceOp) DeleteAlert(ctx context.Context, uptimeCheckID string, alertID string) (*Response, error) {
+	path := path.Join(uptimeChecksBasePath, uptimeCheckID, "/alerts/", alertID)
+	req, err := p.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.client.Do(ctx, req, nil)
+}

--- a/uptime_test.go
+++ b/uptime_test.go
@@ -1,0 +1,580 @@
+package godo
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestUptimeChecks_List(t *testing.T) {
+	setup()
+	defer teardown()
+
+	expectedUptimeChecks := []UptimeCheck{
+		{
+			ID:   "uptimecheck-1",
+			Name: "uptimecheck-1",
+		},
+		{
+			ID:   "uptimecheck-2",
+			Name: "uptimecheck-2",
+		},
+	}
+
+	mux.HandleFunc("/v2/uptime/checks", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		resp, _ := json.Marshal(expectedUptimeChecks)
+		fmt.Fprint(w, fmt.Sprintf(`{"checks":%s, "meta": {"total": 2}}`, string(resp)))
+	})
+
+	uptimeChecks, resp, err := client.UptimeChecks.List(ctx, nil)
+	if err != nil {
+		t.Errorf("UptimeChecks.List returned error: %v", err)
+	}
+
+	if !reflect.DeepEqual(uptimeChecks, expectedUptimeChecks) {
+		t.Errorf("UptimeChecks.List returned uptime checks %+v, expected %+v", uptimeChecks, expectedUptimeChecks)
+	}
+
+	expectedMeta := &Meta{Total: 2}
+	if !reflect.DeepEqual(resp.Meta, expectedMeta) {
+		t.Errorf("UptimeChecks.List returned meta %+v, expected %+v", resp.Meta, expectedMeta)
+	}
+}
+
+func TestUptimeChecks_ListWithMultiplePages(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mockResp := `
+	{
+		"checks": [
+			{
+				"uuid": "check-1",
+				"name": "check-1"
+			},
+			{
+				"uuid": "check-2",
+				"name": "check-2"
+			}
+		],
+		"links": {
+			"pages": {
+				"next": "http://example.com/v2/uptime/checks?page=2"
+			}
+		}
+	}`
+
+	mux.HandleFunc("/v2/uptime/checks", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, mockResp)
+	})
+
+	_, resp, err := client.UptimeChecks.List(ctx, nil)
+	if err != nil {
+		t.Errorf("UptimeChecks.List returned error: %v", err)
+	}
+
+	checkCurrentPage(t, resp, 1)
+}
+
+func TestUptimeChecks_ListWithPageNumber(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mockResp := `
+	{
+		"checks": [
+			{
+				"uuid": "check-1",
+				"name": "check-1"
+			},
+			{
+				"uuid": "check-2",
+				"name": "check-2"
+			}
+		],
+		"links": {
+			"pages": {
+				"next": "http://example.com/v2/uptime/checks?page=3",
+				"prev": "http://example.com/v2/uptime/checks?page=1",
+				"last": "http://example.com/v2/uptime/checks?page=3",
+				"first": "http://example.com/v2/uptime/checks?page=1"
+			}
+		}
+	}`
+
+	mux.HandleFunc("/v2/uptime/checks", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, mockResp)
+	})
+
+	_, resp, err := client.UptimeChecks.List(ctx, &ListOptions{Page: 2})
+	if err != nil {
+		t.Errorf("UptimeChecks.List returned error: %v", err)
+	}
+
+	checkCurrentPage(t, resp, 2)
+}
+
+func TestUptimeChecks_GetState(t *testing.T) {
+	setup()
+	defer teardown()
+
+	uptimeCheck := &UptimeCheck{
+		ID:   "check-1",
+		Name: "check-1",
+	}
+
+	mux.HandleFunc("/v2/uptime/checks/check-1/state", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		resp, _ := json.Marshal(uptimeCheck)
+		fmt.Fprint(w, fmt.Sprintf(`{"check":%s}`, string(resp)))
+	})
+
+	resp, _, err := client.UptimeChecks.GetState(ctx, uptimeCheck.ID)
+	if err != nil {
+		t.Errorf("UptimeChecks.GetState returned error: %v", err)
+	}
+
+	if !reflect.DeepEqual(resp, uptimeCheck) {
+		t.Errorf("UptimeChecks.GetState returned %+v, expected %+v", resp, uptimeCheck)
+	}
+}
+
+func TestUptimeChecks_GetWithID(t *testing.T) {
+	setup()
+	defer teardown()
+
+	uptimeCheck := &UptimeCheck{
+		ID:   "check-1",
+		Name: "check-1",
+	}
+
+	mux.HandleFunc("/v2/uptime/checks/check-1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		resp, _ := json.Marshal(uptimeCheck)
+		fmt.Fprint(w, fmt.Sprintf(`{"check":%s}`, string(resp)))
+	})
+
+	resp, _, err := client.UptimeChecks.Get(ctx, "check-1")
+	if err != nil {
+		t.Errorf("UptimeChecks.Get returned error: %v", err)
+	}
+
+	if !reflect.DeepEqual(resp, uptimeCheck) {
+		t.Errorf("UptimeChecks.Get returned %+v, expected %+v", resp, uptimeCheck)
+	}
+}
+
+func TestUptimeChecks_Create(t *testing.T) {
+	setup()
+	defer teardown()
+
+	createRequest := &CreateUptimeCheckRequest{
+		Name:    "my check",
+		Type:    "https",
+		Target:  "https://www.landingpage.com",
+		Enabled: true,
+	}
+
+	createResp := &UptimeCheck{
+		ID:      "check-id",
+		Name:    createRequest.Name,
+		Type:    createRequest.Type,
+		Target:  createRequest.Target,
+		Enabled: createRequest.Enabled,
+	}
+
+	mux.HandleFunc("/v2/uptime/checks", func(w http.ResponseWriter, r *http.Request) {
+		v := new(CreateUptimeCheckRequest)
+		err := json.NewDecoder(r.Body).Decode(v)
+		if err != nil {
+			t.Fatalf("decode json: %v", err)
+		}
+
+		testMethod(t, r, http.MethodPost)
+		if !reflect.DeepEqual(v, createRequest) {
+			t.Errorf("Request body = %+v, expected %+v", v, createRequest)
+		}
+
+		resp, _ := json.Marshal(createResp)
+		fmt.Fprintf(w, fmt.Sprintf(`{"check":%s}`, string(resp)))
+	})
+
+	uptimeCheck, _, err := client.UptimeChecks.Create(ctx, createRequest)
+	if err != nil {
+		t.Errorf("UptimeChecks.Create returned error: %v", err)
+	}
+
+	if !reflect.DeepEqual(uptimeCheck, createResp) {
+		t.Errorf("UptimeChecks.Create returned %+v, expected %+v", uptimeCheck, createResp)
+	}
+}
+
+func TestUptimeChecks_Update(t *testing.T) {
+	setup()
+	defer teardown()
+
+	updateRequest := &UpdateUptimeCheckRequest{
+		Name:    "my check",
+		Type:    "https",
+		Target:  "https://www.landingpage.com",
+		Enabled: true,
+	}
+	updateResp := &UptimeCheck{
+		ID:      "check-id",
+		Name:    updateRequest.Name,
+		Type:    updateRequest.Type,
+		Target:  updateRequest.Target,
+		Enabled: updateRequest.Enabled,
+	}
+
+	mux.HandleFunc("/v2/uptime/checks/check-id", func(w http.ResponseWriter, r *http.Request) {
+		reqBytes, respErr := ioutil.ReadAll(r.Body)
+		if respErr != nil {
+			t.Error("uptime checks mock didn't work")
+		}
+
+		req := strings.TrimSuffix(string(reqBytes), "\n")
+		expectedReq := `{"name":"my check","type":"https","target":"https://www.landingpage.com","regions":null,"enabled":true}`
+		if req != expectedReq {
+			t.Errorf("check req didn't match up:\n expected %+v\n got %+v\n", expectedReq, req)
+		}
+
+		resp, _ := json.Marshal(updateResp)
+		fmt.Fprintf(w, fmt.Sprintf(`{"check":%s}`, string(resp)))
+	})
+
+	uptimeCheck, _, err := client.UptimeChecks.Update(ctx, "check-id", updateRequest)
+	if err != nil {
+		t.Errorf("UptimeChecks.Update returned error: %v", err)
+	}
+	if !reflect.DeepEqual(uptimeCheck, updateResp) {
+		t.Errorf("UptimeChecks.Update returned %+v, expected %+v", uptimeCheck, updateResp)
+	}
+}
+
+func TestUptimeChecks_Delete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/uptime/checks/check-1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+	})
+
+	_, err := client.UptimeChecks.Delete(ctx, "check-1")
+	if err != nil {
+		t.Errorf("UptimeChecks.Delete returned error: %v", err)
+	}
+}
+
+func TestAlert_Delete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/uptime/checks/check-1/alerts/alert-1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+	})
+
+	_, err := client.UptimeChecks.DeleteAlert(ctx, "check-1", "alert-1")
+	if err != nil {
+		t.Errorf("UptimeChecks.Delete returned error: %v", err)
+	}
+}
+
+func TestAlert_Update(t *testing.T) {
+	setup()
+	defer teardown()
+
+	updateRequest := &UpdateAlertRequest{
+		Name:       "my alert",
+		Type:       "latency",
+		Threshold:  300,
+		Comparison: "greater_than",
+		Period:     "2m",
+		Notifications: &Notifications{
+			Email: []string{
+				"email",
+			},
+			Slack: []Slack{},
+		},
+	}
+	updateResp := &Alert{
+		ID:            "alert-id",
+		Name:          updateRequest.Name,
+		Type:          updateRequest.Type,
+		Threshold:     updateRequest.Threshold,
+		Comparison:    updateRequest.Comparison,
+		Period:        updateRequest.Period,
+		Notifications: updateRequest.Notifications,
+	}
+
+	mux.HandleFunc("/v2/uptime/checks/check-id/alerts/alert-id", func(w http.ResponseWriter, r *http.Request) {
+		reqBytes, respErr := ioutil.ReadAll(r.Body)
+		if respErr != nil {
+			t.Error("alerts mock didn't work")
+		}
+
+		req := strings.TrimSuffix(string(reqBytes), "\n")
+		expectedReq := `{"name":"my alert","type":"latency","threshold":300,"comparison":"greater_than","notifications":{"email":["email"],"slack":[]},"period":"2m"}`
+		if req != expectedReq {
+			t.Errorf("check req didn't match up:\n expected %+v\n got %+v\n", expectedReq, req)
+		}
+
+		resp, _ := json.Marshal(updateResp)
+		fmt.Fprintf(w, fmt.Sprintf(`{"alert":%s}`, string(resp)))
+	})
+
+	alert, _, err := client.UptimeChecks.UpdateAlert(ctx, "check-id", "alert-id", updateRequest)
+	if err != nil {
+		t.Errorf("UptimeChecks.UpdateAlertreturned error: %v", err)
+	}
+	if !reflect.DeepEqual(alert, updateResp) {
+		t.Errorf("UptimeChecks.UpdateAlert returned %+v, expected %+v", alert, updateResp)
+	}
+}
+
+func TestAlert_Create(t *testing.T) {
+	setup()
+	defer teardown()
+
+	createRequest := &CreateAlertRequest{
+		Name:       "my alert",
+		Type:       "latency",
+		Threshold:  300,
+		Comparison: "greater_than",
+		Period:     "2m",
+		Notifications: &Notifications{
+			Email: []string{
+				"email",
+			},
+			Slack: []Slack{},
+		},
+	}
+
+	createResp := &Alert{
+		ID:            "alert-id",
+		Name:          createRequest.Name,
+		Type:          createRequest.Type,
+		Threshold:     createRequest.Threshold,
+		Comparison:    createRequest.Comparison,
+		Period:        createRequest.Period,
+		Notifications: createRequest.Notifications,
+	}
+	mux.HandleFunc("/v2/uptime/checks/check-id/alerts", func(w http.ResponseWriter, r *http.Request) {
+		v := new(CreateAlertRequest)
+		err := json.NewDecoder(r.Body).Decode(v)
+		if err != nil {
+			t.Fatalf("decode json: %v", err)
+		}
+
+		testMethod(t, r, http.MethodPost)
+		if !reflect.DeepEqual(v, createRequest) {
+			t.Errorf("Request body = %+v, expected %+v", v, createRequest)
+		}
+
+		resp, _ := json.Marshal(createResp)
+		fmt.Fprintf(w, fmt.Sprintf(`{"alert":%s}`, string(resp)))
+	})
+
+	uptimeCheck, _, err := client.UptimeChecks.CreateAlert(ctx, createRequest, "check-id")
+	if err != nil {
+		t.Errorf("UptimeChecks.CreateAlert returned error: %v", err)
+	}
+
+	if !reflect.DeepEqual(uptimeCheck, createResp) {
+		t.Errorf("UptimeChecks.CreateAlert returned %+v, expected %+v", uptimeCheck, createResp)
+	}
+}
+
+func TestAlert_GetWithID(t *testing.T) {
+	setup()
+	defer teardown()
+
+	alert := &Alert{
+		ID:         "alert-1",
+		Name:       "my alert",
+		Type:       "latency",
+		Threshold:  300,
+		Comparison: "greater_than",
+		Period:     "2m",
+		Notifications: &Notifications{
+			Email: []string{
+				"email",
+			},
+			Slack: []Slack{},
+		},
+	}
+
+	mux.HandleFunc("/v2/uptime/checks/check-1/alerts/alert-1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		resp, _ := json.Marshal(alert)
+		fmt.Fprint(w, fmt.Sprintf(`{"alert":%s}`, string(resp)))
+	})
+
+	resp, _, err := client.UptimeChecks.GetAlert(ctx, "check-1", "alert-1")
+	if err != nil {
+		t.Errorf("UptimeChecks.GetAlert returned error: %v", err)
+	}
+
+	if !reflect.DeepEqual(resp, alert) {
+		t.Errorf("UptimeChecks.GetAlert returned %+v, expected %+v", resp, alert)
+	}
+}
+
+func TestAlerts_List(t *testing.T) {
+	setup()
+	defer teardown()
+
+	expectedAlerts := []Alert{
+		{
+			ID:         "alert-1",
+			Name:       "my alert",
+			Type:       "latency",
+			Threshold:  300,
+			Comparison: "greater_than",
+			Period:     "2m",
+			Notifications: &Notifications{
+				Email: []string{
+					"email",
+				},
+				Slack: []Slack{},
+			},
+		},
+		{
+			ID:         "alert-2",
+			Name:       "my alert",
+			Type:       "latency",
+			Threshold:  300,
+			Comparison: "greater_than",
+			Period:     "2m",
+			Notifications: &Notifications{
+				Email: []string{
+					"email2",
+				},
+				Slack: []Slack{},
+			},
+		},
+	}
+
+	mux.HandleFunc("/v2/uptime/checks/check-1/alerts", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		resp, _ := json.Marshal(expectedAlerts)
+		fmt.Fprint(w, fmt.Sprintf(`{"alerts":%s, "meta": {"total": 2}}`, string(resp)))
+	})
+
+	alerts, resp, err := client.UptimeChecks.ListAlerts(ctx, nil, "check-1")
+	if err != nil {
+		t.Errorf("UptimeChecks.ListAlerts returned error: %v", err)
+	}
+
+	if !reflect.DeepEqual(alerts, expectedAlerts) {
+		t.Errorf("UptimeChecks.ListAlerts returned uptime checks %+v, expected %+v", alerts, expectedAlerts)
+	}
+
+	expectedMeta := &Meta{Total: 2}
+	if !reflect.DeepEqual(resp.Meta, expectedMeta) {
+		t.Errorf("UptimeChecks.List returned meta %+v, expected %+v", resp.Meta, expectedMeta)
+	}
+}
+
+func TestAlerts_ListWithMultiplePages(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mockResp := `
+	{
+		"alerts": [{
+			"id": "alert-1",
+			"name": "Landing page degraded performance",
+			"type": "latency",
+			"threshold": 300,
+			"comparison": "greater_than",
+			"notifications": {
+				"email": [
+					"bob@example.com"
+				],
+				"slack": [{
+					"channel": "Production Alerts",
+					"url": "https://hooks.slack.com/services/T1234567/AAAAAAAA/ZZZZZZ"
+				}]
+			},
+			"period": "2m"
+		}],
+		"links": {
+			"pages": {
+				"next": "http://example.com/v2/uptime/checks/check-1/alerts?page=2"
+			}
+		},
+		"meta": {
+			"total": 1
+		}
+	}`
+
+	mux.HandleFunc("/v2/uptime/checks/check-1/alerts", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, mockResp)
+	})
+
+	_, resp, err := client.UptimeChecks.ListAlerts(ctx, nil, "check-1")
+	if err != nil {
+		t.Errorf("UptimeChecks.ListAlerts returned error: %v", err)
+	}
+
+	checkCurrentPage(t, resp, 1)
+}
+
+func TestAlerts_ListWithPageNumber(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mockResp := `
+	{
+		"alerts": [
+		  {
+			"id": "alert-1",
+			"name": "Landing page degraded performance",
+			"type": "latency",
+			"threshold": 300,
+			"comparison": "greater_than",
+			"notifications": {
+			  "email": [
+				"bob@example.com"
+			  ],
+			  "slack": [
+				{
+				  "channel": "Production Alerts",
+				  "url": "https://hooks.slack.com/services/T1234567/AAAAAAAA/ZZZZZZ"
+				}
+			  ]
+			},
+			"period": "2m"
+		  }
+		],
+		"links": {
+		  "pages": {
+			"next": "http://example.com/v2/uptime/checks?page=3",
+			"prev": "http://example.com/v2/uptime/checks?page=1",
+			"last": "http://example.com/v2/uptime/checks?page=3",
+			"first": "http://example.com/v2/uptime/checks?page=1"
+		  }
+		}
+	  }`
+
+	mux.HandleFunc("/v2/uptime/checks/check-1/alerts", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, mockResp)
+	})
+
+	_, resp, err := client.UptimeChecks.ListAlerts(ctx, &ListOptions{Page: 2}, "check-1")
+	if err != nil {
+		t.Errorf("UptimeChecks.ListAlerts returned error: %v", err)
+	}
+
+	checkCurrentPage(t, resp, 2)
+}


### PR DESCRIPTION
Adding to uptime checks and alerts support to godo (api doc [here](https://docs.digitalocean.com/reference/api/api-reference/#operation/uptime_checks_list)). Adding to terraform-digitalocean-provider next.