### PR TITLE
Add UpgradeMajorVersion to godo

### DIFF
--- a/databases.go
+++ b/databases.go
@@ -9,27 +9,28 @@ import (
 )
 
 const (
-	databaseBasePath           = "/v2/databases"
-	databaseSinglePath         = databaseBasePath + "/%s"
-	databaseCAPath             = databaseBasePath + "/%s/ca"
-	databaseConfigPath         = databaseBasePath + "/%s/config"
-	databaseResizePath         = databaseBasePath + "/%s/resize"
-	databaseMigratePath        = databaseBasePath + "/%s/migrate"
-	databaseMaintenancePath    = databaseBasePath + "/%s/maintenance"
-	databaseBackupsPath        = databaseBasePath + "/%s/backups"
-	databaseUsersPath          = databaseBasePath + "/%s/users"
-	databaseUserPath           = databaseBasePath + "/%s/users/%s"
-	databaseResetUserAuthPath  = databaseUserPath + "/reset_auth"
-	databaseDBPath             = databaseBasePath + "/%s/dbs/%s"
-	databaseDBsPath            = databaseBasePath + "/%s/dbs"
-	databasePoolPath           = databaseBasePath + "/%s/pools/%s"
-	databasePoolsPath          = databaseBasePath + "/%s/pools"
-	databaseReplicaPath        = databaseBasePath + "/%s/replicas/%s"
-	databaseReplicasPath       = databaseBasePath + "/%s/replicas"
-	databaseEvictionPolicyPath = databaseBasePath + "/%s/eviction_policy"
-	databaseSQLModePath        = databaseBasePath + "/%s/sql_mode"
-	databaseFirewallRulesPath  = databaseBasePath + "/%s/firewall"
-	databaseOptionsPath        = databaseBasePath + "/options"
+	databaseBasePath                = "/v2/databases"
+	databaseSinglePath              = databaseBasePath + "/%s"
+	databaseCAPath                  = databaseBasePath + "/%s/ca"
+	databaseConfigPath              = databaseBasePath + "/%s/config"
+	databaseResizePath              = databaseBasePath + "/%s/resize"
+	databaseMigratePath             = databaseBasePath + "/%s/migrate"
+	databaseMaintenancePath         = databaseBasePath + "/%s/maintenance"
+	databaseBackupsPath             = databaseBasePath + "/%s/backups"
+	databaseUsersPath               = databaseBasePath + "/%s/users"
+	databaseUserPath                = databaseBasePath + "/%s/users/%s"
+	databaseResetUserAuthPath       = databaseUserPath + "/reset_auth"
+	databaseDBPath                  = databaseBasePath + "/%s/dbs/%s"
+	databaseDBsPath                 = databaseBasePath + "/%s/dbs"
+	databasePoolPath                = databaseBasePath + "/%s/pools/%s"
+	databasePoolsPath               = databaseBasePath + "/%s/pools"
+	databaseReplicaPath             = databaseBasePath + "/%s/replicas/%s"
+	databaseReplicasPath            = databaseBasePath + "/%s/replicas"
+	databaseEvictionPolicyPath      = databaseBasePath + "/%s/eviction_policy"
+	databaseSQLModePath             = databaseBasePath + "/%s/sql_mode"
+	databaseFirewallRulesPath       = databaseBasePath + "/%s/firewall"
+	databaseOptionsPath             = databaseBasePath + "/options"
+	databaseUpgradeMajorVersionPath = databaseBasePath + "/%s/upgrade"
 )
 
 // SQL Mode constants allow for MySQL-specific SQL flavor configuration.
@@ -141,6 +142,7 @@ type DatabasesService interface {
 	UpdateRedisConfig(context.Context, string, *RedisConfig) (*Response, error)
 	UpdateMySQLConfig(context.Context, string, *MySQLConfig) (*Response, error)
 	ListOptions(todo context.Context) (*DatabaseOptions, *Response, error)
+	UpgradeMajorVersion(context.Context, string, string) (*Response, error)
 }
 
 // DatabasesServiceOp handles communication with the Databases related methods
@@ -519,6 +521,10 @@ type databaseReplicasRoot struct {
 
 type evictionPolicyRoot struct {
 	EvictionPolicy string `json:"eviction_policy"`
+}
+
+type majorVersionUpgradeRoot struct {
+	Version string `json:"version"`
 }
 
 type sqlModeRoot struct {
@@ -1178,4 +1184,21 @@ func (svc *DatabasesServiceOp) ListOptions(ctx context.Context) (*DatabaseOption
 	}
 
 	return root.Options, resp, nil
+}
+
+// UpgradeMajorVersion upgrades the major version of a cluster.
+func (svc *DatabasesServiceOp) UpgradeMajorVersion(ctx context.Context, databaseID string, version string) (*Response, error) {
+	path := fmt.Sprintf(databaseUpgradeMajorVersionPath, databaseID)
+	root := &majorVersionUpgradeRoot{Version: version}
+	req, err := svc.client.NewRequest(ctx, http.MethodPut, path, root)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := svc.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
 }

--- a/databases.go
+++ b/databases.go
@@ -143,7 +143,7 @@ type DatabasesService interface {
 	UpdateRedisConfig(context.Context, string, *RedisConfig) (*Response, error)
 	UpdateMySQLConfig(context.Context, string, *MySQLConfig) (*Response, error)
 	ListOptions(todo context.Context) (*DatabaseOptions, *Response, error)
-	UpgradeMajorVersion(context.Context, string, string) (*Response, error)
+	UpgradeMajorVersion(context.Context, string, *UpgradeVersionRequest) (*Response, error)
 }
 
 // DatabasesServiceOp handles communication with the Databases related methods
@@ -532,7 +532,7 @@ type evictionPolicyRoot struct {
 	EvictionPolicy string `json:"eviction_policy"`
 }
 
-type majorVersionUpgradeRoot struct {
+type UpgradeVersionRequest struct {
 	Version string `json:"version"`
 }
 
@@ -1227,10 +1227,9 @@ func (svc *DatabasesServiceOp) ListOptions(ctx context.Context) (*DatabaseOption
 }
 
 // UpgradeMajorVersion upgrades the major version of a cluster.
-func (svc *DatabasesServiceOp) UpgradeMajorVersion(ctx context.Context, databaseID string, version string) (*Response, error) {
+func (svc *DatabasesServiceOp) UpgradeMajorVersion(ctx context.Context, databaseID string, upgradeReq *UpgradeVersionRequest) (*Response, error) {
 	path := fmt.Sprintf(databaseUpgradeMajorVersionPath, databaseID)
-	root := &majorVersionUpgradeRoot{Version: version}
-	req, err := svc.client.NewRequest(ctx, http.MethodPut, path, root)
+	req, err := svc.client.NewRequest(ctx, http.MethodPut, path, upgradeReq)
 	if err != nil {
 		return nil, err
 	}

--- a/databases_test.go
+++ b/databases_test.go
@@ -2042,3 +2042,25 @@ func TestDatabases_UpdateConfigMySQL(t *testing.T) {
 	_, err := client.Databases.UpdateMySQLConfig(ctx, dbID, mySQLConfig)
 	require.NoError(t, err)
 }
+
+func TestDatabases_UpgradeMajorVersion(t *testing.T) {
+	setup()
+	defer teardown()
+
+	var (
+		dbID           = "deadbeef-dead-4aa5-beef-deadbeef347d"
+		path           = fmt.Sprintf("/v2/databases/%s/upgrade", dbID)
+		upgradeVersion = "14"
+	)
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPut)
+		var b majorVersionUpgradeRoot
+		decoder := json.NewDecoder(r.Body)
+		err := decoder.Decode(&b)
+		require.NoError(t, err)
+		assert.Equal(t, b.Version, upgradeVersion)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	_, err := client.Databases.UpgradeMajorVersion(ctx, dbID, upgradeVersion)
+	require.NoError(t, err)
+}

--- a/databases_test.go
+++ b/databases_test.go
@@ -2069,19 +2069,21 @@ func TestDatabases_UpgradeMajorVersion(t *testing.T) {
 	defer teardown()
 
 	var (
-		dbID           = "deadbeef-dead-4aa5-beef-deadbeef347d"
-		path           = fmt.Sprintf("/v2/databases/%s/upgrade", dbID)
-		upgradeVersion = "14"
+		dbID              = "deadbeef-dead-4aa5-beef-deadbeef347d"
+		path              = fmt.Sprintf("/v2/databases/%s/upgrade", dbID)
+		upgradeVersionReq = &UpgradeVersionRequest{
+			Version: "14",
+		}
 	)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
-		var b majorVersionUpgradeRoot
+		var b UpgradeVersionRequest
 		decoder := json.NewDecoder(r.Body)
 		err := decoder.Decode(&b)
 		require.NoError(t, err)
-		assert.Equal(t, b.Version, upgradeVersion)
+		assert.Equal(t, b.Version, upgradeVersionReq.Version)
 		w.WriteHeader(http.StatusNoContent)
 	})
-	_, err := client.Databases.UpgradeMajorVersion(ctx, dbID, upgradeVersion)
+	_, err := client.Databases.UpgradeMajorVersion(ctx, dbID, upgradeVersionReq)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
**What**

- Exposes `/v2/databases/{uuid}/upgrade` path to allow for major version upgrades to be made (if valid according to the cluster type, current version, available versions, etc.)