### PR TITLE
DBAAS-3906: Include updatePool for DB Clusters

### DIFF
--- a/databases.go
+++ b/databases.go
@@ -916,6 +916,19 @@ func (svc *DatabasesServiceOp) DeletePool(ctx context.Context, databaseID, name 
 // UpdatePool will update an existing database connection pool
 func (svc *DatabasesServiceOp) UpdatePool(ctx context.Context, databaseID, name string, updatePool *DatabaseUpdatePoolRequest) (*Response, error) {
 	path := fmt.Sprintf(databasePoolPath, databaseID, name)
+
+	if updatePool.Mode == "" {
+		return nil, NewArgError("mode", "cannot be empty")
+	}
+
+	if updatePool.Database == "" {
+		return nil, NewArgError("database", "cannot be empty")
+	}
+
+	if updatePool.Size == 0 {
+		return nil, NewArgError("size", "must be greater than 0")
+	}
+
 	req, err := svc.client.NewRequest(ctx, http.MethodPut, path, updatePool)
 	if err != nil {
 		return nil, err

--- a/databases.go
+++ b/databases.go
@@ -926,7 +926,7 @@ func (svc *DatabasesServiceOp) UpdatePool(ctx context.Context, databaseID, name 
 	}
 
 	if updatePool.Size < 1 {
-		return nil, NewArgError("size", "must be greater than 0")
+		return nil, NewArgError("size", "cannot be less than 1")
 	}
 
 	req, err := svc.client.NewRequest(ctx, http.MethodPut, path, updatePool)

--- a/databases.go
+++ b/databases.go
@@ -925,7 +925,7 @@ func (svc *DatabasesServiceOp) UpdatePool(ctx context.Context, databaseID, name 
 		return nil, NewArgError("database", "cannot be empty")
 	}
 
-	if updatePool.Size == 0 {
+	if updatePool.Size < 1 {
 		return nil, NewArgError("size", "must be greater than 0")
 	}
 

--- a/databases.go
+++ b/databases.go
@@ -917,6 +917,10 @@ func (svc *DatabasesServiceOp) DeletePool(ctx context.Context, databaseID, name 
 func (svc *DatabasesServiceOp) UpdatePool(ctx context.Context, databaseID, name string, updatePool *DatabaseUpdatePoolRequest) (*Response, error) {
 	path := fmt.Sprintf(databasePoolPath, databaseID, name)
 
+	if updatePool == nil {
+		return nil, NewArgError("updatePool", "cannot be nil")
+	}
+
 	if updatePool.Mode == "" {
 		return nil, NewArgError("mode", "cannot be empty")
 	}

--- a/databases.go
+++ b/databases.go
@@ -124,6 +124,7 @@ type DatabasesService interface {
 	CreatePool(context.Context, string, *DatabaseCreatePoolRequest) (*DatabasePool, *Response, error)
 	GetPool(context.Context, string, string) (*DatabasePool, *Response, error)
 	DeletePool(context.Context, string, string) (*Response, error)
+	UpdatePool(context.Context, string, string, *DatabaseUpdatePoolRequest) (*Response, error)
 	GetReplica(context.Context, string, string) (*DatabaseReplica, *Response, error)
 	ListReplicas(context.Context, string, *ListOptions) ([]DatabaseReplica, *Response, error)
 	CreateReplica(context.Context, string, *DatabaseCreateReplicaRequest) (*DatabaseReplica, *Response, error)
@@ -294,6 +295,14 @@ type DatabasePool struct {
 type DatabaseCreatePoolRequest struct {
 	User     string `json:"user"`
 	Name     string `json:"name"`
+	Size     int    `json:"size"`
+	Database string `json:"db"`
+	Mode     string `json:"mode"`
+}
+
+// DatabaseUpdatePoolRequest is used to update a database connection pool
+type DatabaseUpdatePoolRequest struct {
+	User     string `json:"user"`
 	Size     int    `json:"size"`
 	Database string `json:"db"`
 	Mode     string `json:"mode"`
@@ -894,6 +903,20 @@ func (svc *DatabasesServiceOp) CreatePool(ctx context.Context, databaseID string
 func (svc *DatabasesServiceOp) DeletePool(ctx context.Context, databaseID, name string) (*Response, error) {
 	path := fmt.Sprintf(databasePoolPath, databaseID, name)
 	req, err := svc.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := svc.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}
+
+// UpdatePool will update an existing database connection pool
+func (svc *DatabasesServiceOp) UpdatePool(ctx context.Context, databaseID, name string, updatePool *DatabaseUpdatePoolRequest) (*Response, error) {
+	path := fmt.Sprintf(databasePoolPath, databaseID, name)
+	req, err := svc.client.NewRequest(ctx, http.MethodPut, path, updatePool)
 	if err != nil {
 		return nil, err
 	}

--- a/databases_test.go
+++ b/databases_test.go
@@ -1059,6 +1059,27 @@ func TestDatabases_DeletePool(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestDatabases_UpdatePool(t *testing.T) {
+	setup()
+	defer teardown()
+
+	dbID := "deadbeef-dead-4aa5-beef-deadbeef347d"
+
+	path := fmt.Sprintf("/v2/databases/%s/pools/pool", dbID)
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPut)
+	})
+
+	_, err := client.Databases.UpdatePool(ctx, dbID, "pool", &DatabaseUpdatePoolRequest{
+		User:     "user",
+		Size:     12,
+		Database: "db",
+		Mode:     "transaction",
+	})
+	require.NoError(t, err)
+}
+
 func TestDatabases_GetReplica(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
Adds `updatePool` + updates`DatabaseService`, allows for Postgres pool updates through godo,  makes a PUT request to `/v2/databases/$uuid/pools/$poolname`.

```go
import (
    "context"
    "github.com/digitalocean/godo"
)

func main() {

    pat := "..."
    dbUUID := "..."
    client := godo.NewFromToken(pat)
    
    _, err := client.Databases.UpdatePool(context.Background(), dbUUID, "backend-pool", &godo.DatabaseUpdatePoolRequest{
        User:     "username",
        Size:     14,
        Database: "defaultdb",
        Mode:     "transaction",
    })
}
```