### PR TITLE
APPS-6813: update app platform - pending_deployment + timing

### DIFF
--- a/apps.gen.go
+++ b/apps.gen.go
@@ -85,6 +85,7 @@ type App struct {
 	UpdatedAt               time.Time       `json:"updated_at,omitempty"`
 	ActiveDeployment        *Deployment     `json:"active_deployment,omitempty"`
 	InProgressDeployment    *Deployment     `json:"in_progress_deployment,omitempty"`
+	PendingDeployment       *Deployment     `json:"pending_deployment,omitempty"`
 	LastDeploymentCreatedAt time.Time       `json:"last_deployment_created_at,omitempty"`
 	LiveURL                 string          `json:"live_url,omitempty"`
 	Region                  *AppRegion      `json:"region,omitempty"`
@@ -94,7 +95,7 @@ type App struct {
 	Domains                 []*AppDomain    `json:"domains,omitempty"`
 	PinnedDeployment        *Deployment     `json:"pinned_deployment,omitempty"`
 	BuildConfig             *AppBuildConfig `json:"build_config,omitempty"`
-	// The id of the project for the app. This will be empty if there is a lookup failure.
+	// The id of the project for the app. This will be empty if there is a fleet (project) lookup failure.
 	ProjectID string `json:"project_id,omitempty"`
 }
 
@@ -594,6 +595,7 @@ type Deployment struct {
 	PreviousDeploymentID string                  `json:"previous_deployment_id,omitempty"`
 	CauseDetails         *DeploymentCauseDetails `json:"cause_details,omitempty"`
 	LoadBalancerID       string                  `json:"load_balancer_id,omitempty"`
+	Timing               *DeploymentTiming       `json:"timing,omitempty"`
 }
 
 // DeploymentCauseDetails struct for DeploymentCauseDetails
@@ -708,6 +710,30 @@ type DeploymentStaticSite struct {
 	SourceCommitHash string `json:"source_commit_hash,omitempty"`
 	// The list of resolved buildpacks used for a given deployment component.
 	Buildpacks []*Buildpack `json:"buildpacks,omitempty"`
+}
+
+// DeploymentTiming struct for DeploymentTiming
+type DeploymentTiming struct {
+	// Pending describes the time spent waiting for the build to begin. This may include delays related to build concurrency limits.
+	Pending string `json:"pending,omitempty"`
+	// BuildTotal describes total time between the start of the build and its completion.
+	BuildTotal string `json:"build_total,omitempty"`
+	// BuildBillable describes the time spent executing the build. As builds may run concurrently  this may be greater than the build total.
+	BuildBillable string `json:"build_billable,omitempty"`
+	// Components breaks down billable build time by component.
+	Components []*DeploymentTimingComponent `json:"components,omitempty"`
+	// DatabaseProvision describes the time spent creating databases.
+	DatabaseProvision string `json:"database_provision,omitempty"`
+	// Deploying is time spent starting containers and waiting for health checks to pass.
+	Deploying string `json:"deploying,omitempty"`
+}
+
+// DeploymentTimingComponent struct for DeploymentTimingComponent
+type DeploymentTimingComponent struct {
+	// Name of the component.
+	Name string `json:"name,omitempty"`
+	// BuildBillable is the billable build time for this component.
+	BuildBillable string `json:"build_billable,omitempty"`
 }
 
 // DeploymentWorker struct for DeploymentWorker

--- a/apps_accessors.go
+++ b/apps_accessors.go
@@ -110,6 +110,14 @@ func (a *App) GetOwnerUUID() string {
 	return a.OwnerUUID
 }
 
+// GetPendingDeployment returns the PendingDeployment field.
+func (a *App) GetPendingDeployment() *Deployment {
+	if a == nil {
+		return nil
+	}
+	return a.PendingDeployment
+}
+
 // GetPinnedDeployment returns the PinnedDeployment field.
 func (a *App) GetPinnedDeployment() *Deployment {
 	if a == nil {
@@ -2102,6 +2110,14 @@ func (d *Deployment) GetTierSlug() string {
 	return d.TierSlug
 }
 
+// GetTiming returns the Timing field.
+func (d *Deployment) GetTiming() *DeploymentTiming {
+	if d == nil {
+		return nil
+	}
+	return d.Timing
+}
+
 // GetUpdatedAt returns the UpdatedAt field.
 func (d *Deployment) GetUpdatedAt() time.Time {
 	if d == nil {
@@ -2508,6 +2524,70 @@ func (d *DeploymentStaticSite) GetSourceCommitHash() string {
 		return ""
 	}
 	return d.SourceCommitHash
+}
+
+// GetBuildBillable returns the BuildBillable field.
+func (d *DeploymentTiming) GetBuildBillable() string {
+	if d == nil {
+		return ""
+	}
+	return d.BuildBillable
+}
+
+// GetBuildTotal returns the BuildTotal field.
+func (d *DeploymentTiming) GetBuildTotal() string {
+	if d == nil {
+		return ""
+	}
+	return d.BuildTotal
+}
+
+// GetComponents returns the Components field.
+func (d *DeploymentTiming) GetComponents() []*DeploymentTimingComponent {
+	if d == nil {
+		return nil
+	}
+	return d.Components
+}
+
+// GetDatabaseProvision returns the DatabaseProvision field.
+func (d *DeploymentTiming) GetDatabaseProvision() string {
+	if d == nil {
+		return ""
+	}
+	return d.DatabaseProvision
+}
+
+// GetDeploying returns the Deploying field.
+func (d *DeploymentTiming) GetDeploying() string {
+	if d == nil {
+		return ""
+	}
+	return d.Deploying
+}
+
+// GetPending returns the Pending field.
+func (d *DeploymentTiming) GetPending() string {
+	if d == nil {
+		return ""
+	}
+	return d.Pending
+}
+
+// GetBuildBillable returns the BuildBillable field.
+func (d *DeploymentTimingComponent) GetBuildBillable() string {
+	if d == nil {
+		return ""
+	}
+	return d.BuildBillable
+}
+
+// GetName returns the Name field.
+func (d *DeploymentTimingComponent) GetName() string {
+	if d == nil {
+		return ""
+	}
+	return d.Name
 }
 
 // GetBuildpacks returns the Buildpacks field.

--- a/apps_accessors_test.go
+++ b/apps_accessors_test.go
@@ -104,6 +104,13 @@ func TestApp_GetOwnerUUID(tt *testing.T) {
 	a.GetOwnerUUID()
 }
 
+func TestApp_GetPendingDeployment(tt *testing.T) {
+	a := &App{}
+	a.GetPendingDeployment()
+	a = nil
+	a.GetPendingDeployment()
+}
+
 func TestApp_GetPinnedDeployment(tt *testing.T) {
 	a := &App{}
 	a.GetPinnedDeployment()
@@ -1847,6 +1854,13 @@ func TestDeployment_GetTierSlug(tt *testing.T) {
 	d.GetTierSlug()
 }
 
+func TestDeployment_GetTiming(tt *testing.T) {
+	d := &Deployment{}
+	d.GetTiming()
+	d = nil
+	d.GetTiming()
+}
+
 func TestDeployment_GetUpdatedAt(tt *testing.T) {
 	d := &Deployment{}
 	d.GetUpdatedAt()
@@ -2202,6 +2216,62 @@ func TestDeploymentStaticSite_GetSourceCommitHash(tt *testing.T) {
 	d.GetSourceCommitHash()
 	d = nil
 	d.GetSourceCommitHash()
+}
+
+func TestDeploymentTiming_GetBuildBillable(tt *testing.T) {
+	d := &DeploymentTiming{}
+	d.GetBuildBillable()
+	d = nil
+	d.GetBuildBillable()
+}
+
+func TestDeploymentTiming_GetBuildTotal(tt *testing.T) {
+	d := &DeploymentTiming{}
+	d.GetBuildTotal()
+	d = nil
+	d.GetBuildTotal()
+}
+
+func TestDeploymentTiming_GetComponents(tt *testing.T) {
+	d := &DeploymentTiming{}
+	d.GetComponents()
+	d = nil
+	d.GetComponents()
+}
+
+func TestDeploymentTiming_GetDatabaseProvision(tt *testing.T) {
+	d := &DeploymentTiming{}
+	d.GetDatabaseProvision()
+	d = nil
+	d.GetDatabaseProvision()
+}
+
+func TestDeploymentTiming_GetDeploying(tt *testing.T) {
+	d := &DeploymentTiming{}
+	d.GetDeploying()
+	d = nil
+	d.GetDeploying()
+}
+
+func TestDeploymentTiming_GetPending(tt *testing.T) {
+	d := &DeploymentTiming{}
+	d.GetPending()
+	d = nil
+	d.GetPending()
+}
+
+func TestDeploymentTimingComponent_GetBuildBillable(tt *testing.T) {
+	d := &DeploymentTimingComponent{}
+	d.GetBuildBillable()
+	d = nil
+	d.GetBuildBillable()
+}
+
+func TestDeploymentTimingComponent_GetName(tt *testing.T) {
+	d := &DeploymentTimingComponent{}
+	d.GetName()
+	d = nil
+	d.GetName()
 }
 
 func TestDeploymentWorker_GetBuildpacks(tt *testing.T) {


### PR DESCRIPTION
This PR adds the pending_deployment field to the App Platform App object.  Previously, neither the Deployment or Deployment ID was returned on CreateApp or UpdateApp.  This made it difficult to attribute a deployment to the specific action and any effort would require a subsequent call.  App.PendingDeployment will always be set to the resulting deployment for CreateApp and UpdateApp. For GetApp and ListApps it will be set to the most recent non-cancelled deployment if one exists.

Additionally, this PR adds DeploymentTiming information.

**Edit: In draft until API changes are approved and deployed.**