### PR TITLE
Add support for "Validate a Container Registry Name"

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -37,6 +37,7 @@ type RegistryService interface {
 	GetOptions(context.Context) (*RegistryOptions, *Response, error)
 	GetSubscription(context.Context) (*RegistrySubscription, *Response, error)
 	UpdateSubscription(context.Context, *RegistrySubscriptionUpdateRequest) (*RegistrySubscription, *Response, error)
+	ValidateName(context.Context, *RegistryValidateNameRequest) (*Response, error)
 }
 
 var _ RegistryService = &RegistryServiceOp{}
@@ -231,6 +232,12 @@ type registrySubscriptionRoot struct {
 // subscription plan for a registry.
 type RegistrySubscriptionUpdateRequest struct {
 	TierSlug string `json:"tier_slug"`
+}
+
+// RegistryValidateNameRequest represents a request to validate that a
+// container registry name is available for use.
+type RegistryValidateNameRequest struct {
+	Name string `json:"name"`
 }
 
 // Get retrieves the details of a Registry.
@@ -588,4 +595,18 @@ func (svc *RegistryServiceOp) UpdateSubscription(ctx context.Context, request *R
 		return nil, resp, err
 	}
 	return root.Subscription, resp, nil
+}
+
+// ValidateName validates that a container registry name is available for use.
+func (svc *RegistryServiceOp) ValidateName(ctx context.Context, request *RegistryValidateNameRequest) (*Response, error) {
+	path := fmt.Sprintf("%s/validate-name", registryPath)
+	req, err := svc.client.NewRequest(ctx, http.MethodPost, path, request)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := svc.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
 }

--- a/registry_test.go
+++ b/registry_test.go
@@ -942,3 +942,26 @@ func TestRegistry_UpdateSubscription(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, want, got)
 }
+
+func TestRegistry_ValidateName(t *testing.T) {
+	setup()
+	defer teardown()
+
+	validateNameRequest := &RegistryValidateNameRequest{
+		Name: testRegistry,
+	}
+
+	mux.HandleFunc("/v2/registry/validate-name", func(w http.ResponseWriter, r *http.Request) {
+		v := new(RegistryValidateNameRequest)
+		err := json.NewDecoder(r.Body).Decode(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		testMethod(t, r, http.MethodPost)
+		require.Equal(t, v, validateNameRequest)
+	})
+
+	_, err := client.Registry.ValidateName(ctx, validateNameRequest)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
This PR adds a method to support using the [Validate a Container Registry Name](https://docs.digitalocean.com/reference/api/api-reference/#operation/registry_validate_name) endpoint.