### PR TITLE
client: don't process body upon 204 response

### DIFF
--- a/godo.go
+++ b/godo.go
@@ -442,7 +442,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*Res
 		return response, err
 	}
 
-	if v != nil {
+	if resp.StatusCode != http.StatusNoContent && v != nil {
 		if w, ok := v.(io.Writer); ok {
 			_, err = io.Copy(w, resp.Body)
 			if err != nil {

--- a/load_balancers_test.go
+++ b/load_balancers_test.go
@@ -543,17 +543,16 @@ func TestLoadBalancers_CreateValidateSucceeds(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		w.WriteHeader(http.StatusAccepted)
+		w.WriteHeader(http.StatusNoContent)
 
 		testMethod(t, r, http.MethodPost)
 		assert.Equal(t, createRequest, v)
-
-		fmt.Fprint(w, lbCreateJSONResponse)
 	})
 
 	loadBalancer, resp, err := client.LoadBalancers.Create(ctx, createRequest)
 	require.NoError(t, err)
-	assert.Equal(t, http.StatusAccepted, resp.StatusCode)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.NotNil(t, resp)
 	assert.Nil(t, nil, loadBalancer)
 }
 


### PR DESCRIPTION
In the HTTP spec [here](https://www.rfc-editor.org/rfc/rfc2616#section-10.2.5):
> The 204 response MUST NOT include a message-body, and thus is always terminated by the first empty line after the header fields.

As such, if we receive a 204 response, we shouldn't expect or do anything with the response body.

This fixes an error where `json.Decode` would return `io.EOF` when the response body was empty, and the returned `*Response` object was `nil`, preventing callers from accessing any of its populated fields.

Also, update `TestLoadBalancers_CreateValidateSucceeds` accordingly to match the expected behavior.