### PR TITLE
updated the README file by showing up the build status icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Godo
 
-[![Build Status](https://travis-ci.org/digitalocean/godo.svg)](https://travis-ci.org/digitalocean/godo)
+[![GitHub Actions CI](https://github.com/digitalocean/godo/actions/workflows/ci.yml/badge.svg)](https://github.com/digitalocean/godo/actions/workflows/ci.yml)
 [![GoDoc](https://godoc.org/github.com/digitalocean/godo?status.svg)](https://godoc.org/github.com/digitalocean/godo)
 
 Godo is a Go client library for accessing the DigitalOcean V2 API.


### PR DESCRIPTION
I just noticed a typo in the readme.

**The Build Status contains some kind of icon that is not showing up.**

Now it is resolved by using the GitHub Action CI.