### PR TITLE
Add retryablehttp Client Option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,8 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/google/go-querystring v1.1.0
+	github.com/hashicorp/go-retryablehttp v0.7.4
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5
 	golang.org/x/time v0.0.0-20220922220347-f3bd1da661af
@@ -13,7 +14,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-retryablehttp v0.7.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,11 @@ github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hf
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-retryablehttp v0.7.4 h1:ZQgVdpTdAL7WpMIwLzCfbalOcSUdkDZnpUv3/+BxzFA=
+github.com/hashicorp/go-retryablehttp v0.7.4/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -118,6 +123,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,7 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-retryablehttp v0.7.4 h1:ZQgVdpTdAL7WpMIwLzCfbalOcSUdkDZnpUv3/+BxzFA=
 github.com/hashicorp/go-retryablehttp v0.7.4/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=

--- a/godo.go
+++ b/godo.go
@@ -30,7 +30,6 @@ const (
 	headerRateLimit     = "RateLimit-Limit"
 	headerRateRemaining = "RateLimit-Remaining"
 	headerRateReset     = "RateLimit-Reset"
-	headerRetryAfter    = "Retry-After"
 )
 
 // Client manages communication with DigitalOcean V2 API.
@@ -104,6 +103,13 @@ type Client struct {
 // requests that fail with 429 or 500-level response codes using the go-retryablehttp client.
 // RetryConfig.RetryMax must be configured to enable this behavior. RetryConfig.RetryWaitMin and
 // RetryConfig.RetryWaitMax are optional, with the default values being 1.0 and 30.0, respectively.
+//
+// You can use
+//
+//	godo.PtrTo(1.0)
+//
+// to explicitly set the RetryWaitMin and RetryWaitMax values.
+//
 // Note: Opting to use the go-retryablehttp client will overwrite any custom HTTP client passed into New().
 // Only the custom HTTP client's custom transport and timeout will be maintained.
 type RetryConfig struct {
@@ -183,9 +189,6 @@ type Rate struct {
 
 	// The time at which the current rate limit will reset.
 	Reset Timestamp `json:"reset"`
-
-	// The number of seconds the client is expected to wait before making a follow-up HTTP request
-	RetryAfter int `json:"retry-after"`
 }
 
 func addOptions(s string, opt interface{}) (string, error) {
@@ -450,9 +453,6 @@ func (r *Response) populateRate() {
 		if v, _ := strconv.ParseInt(reset, 10, 64); v != 0 {
 			r.Rate.Reset = Timestamp{time.Unix(v, 0)}
 		}
-	}
-	if retryAfter := r.Header.Get(headerRetryAfter); retryAfter != "" {
-		r.Rate.RetryAfter, _ = strconv.Atoi(retryAfter)
 	}
 }
 

--- a/godo.go
+++ b/godo.go
@@ -353,7 +353,8 @@ func SetStaticRateLimit(rps float64) ClientOpt {
 	}
 }
 
-// WithRetryAndBackoffs sets an
+// WithRetryAndBackoffs sets retry values. Setting the RetryConfig.RetryMax value enables automatically retrying requests
+// that fail with 429 or 500-level response codes using the go-retryablehttp client
 func WithRetryAndBackoffs(retryConfig RetryConfig) ClientOpt {
 	return func(c *Client) error {
 		c.RetryConfig.RetryMax = retryConfig.RetryMax

--- a/godo.go
+++ b/godo.go
@@ -101,6 +101,9 @@ type Client struct {
 
 // RetryConfig sets the values used for enabling retries and backoffs for
 // requests that fail with 429 or 500-level response codes using the go-retryablehttp client.
+// RetryConfig.RetryMax must be configured to enable this behavior.
+// Note: Opting to use the go-retryablehttp client will overwrite any custom HTTP client passed into New().
+// Only the custom HTTP client's custom transport and timeout will be maintained.
 type RetryConfig struct {
 	RetryMax     int
 	RetryWaitMin float64 // Minimum time to wait

--- a/godo.go
+++ b/godo.go
@@ -30,6 +30,7 @@ const (
 	headerRateLimit     = "RateLimit-Limit"
 	headerRateRemaining = "RateLimit-Remaining"
 	headerRateReset     = "RateLimit-Reset"
+	headerRetryAfter    = "Retry-After"
 )
 
 // Client manages communication with DigitalOcean V2 API.
@@ -181,6 +182,9 @@ type Rate struct {
 
 	// The time at which the current rate limit will reset.
 	Reset Timestamp `json:"reset"`
+
+	// The number of seconds the client is expected to wait before making a follow-up HTTP request
+	RetryAfter int `json:"retry-after"`
 }
 
 func addOptions(s string, opt interface{}) (string, error) {
@@ -440,6 +444,9 @@ func (r *Response) populateRate() {
 		if v, _ := strconv.ParseInt(reset, 10, 64); v != 0 {
 			r.Rate.Reset = Timestamp{time.Unix(v, 0)}
 		}
+	}
+	if retryAfter := r.Header.Get(headerRetryAfter); retryAfter != "" {
+		r.Rate.RetryAfter, _ = strconv.Atoi(retryAfter)
 	}
 }
 

--- a/godo_test.go
+++ b/godo_test.go
@@ -498,6 +498,7 @@ func TestDo_rateLimit(t *testing.T) {
 		w.Header().Add(headerRateLimit, "60")
 		w.Header().Add(headerRateRemaining, "59")
 		w.Header().Add(headerRateReset, "1372700873")
+		w.Header().Add(headerRetryAfter, "23")
 	})
 
 	var expected int
@@ -507,6 +508,9 @@ func TestDo_rateLimit(t *testing.T) {
 	}
 	if expected = 0; client.Rate.Remaining != expected {
 		t.Errorf("Client rate remaining = %v, got %v", client.Rate.Remaining, expected)
+	}
+	if expected = 0; client.Rate.RetryAfter != expected {
+		t.Errorf("Client rate retry-after = %v, got %v", client.Rate.RetryAfter, expected)
 	}
 	if !client.Rate.Reset.IsZero() {
 		t.Errorf("Client rate reset not initialized to zero value")
@@ -526,6 +530,9 @@ func TestDo_rateLimit(t *testing.T) {
 	}
 	if expected = 59; client.Rate.Remaining != expected {
 		t.Errorf("Client rate remaining = %v, expected %v", client.Rate.Remaining, expected)
+	}
+	if expected = 23; client.Rate.RetryAfter != expected {
+		t.Errorf("Client rate retry-after = %v, expected %v", client.Rate.RetryAfter, expected)
 	}
 	reset := time.Date(2013, 7, 1, 17, 47, 53, 0, time.UTC)
 	if client.Rate.Reset.UTC() != reset {

--- a/godo_test.go
+++ b/godo_test.go
@@ -627,10 +627,16 @@ func TestWithRetryAndBackoffs(t *testing.T) {
 	})
 
 	oauth_client := oauth2.NewClient(oauth2.NoContext, tokenSrc)
+	var waitMax *float64 = new(float64)
+	var waitMin *float64 = new(float64)
+
+	*waitMax = 6.0
+	*waitMin = 3.0
+
 	retryConfig := RetryConfig{
 		RetryMax:     3,
-		RetryWaitMin: 3.0,
-		RetryWaitMax: 6.0,
+		RetryWaitMin: waitMin,
+		RetryWaitMax: waitMax,
 	}
 
 	// Create the client. Use short retry windows so we fail faster.

--- a/godo_test.go
+++ b/godo_test.go
@@ -498,7 +498,6 @@ func TestDo_rateLimit(t *testing.T) {
 		w.Header().Add(headerRateLimit, "60")
 		w.Header().Add(headerRateRemaining, "59")
 		w.Header().Add(headerRateReset, "1372700873")
-		w.Header().Add(headerRetryAfter, "23")
 	})
 
 	var expected int
@@ -508,9 +507,6 @@ func TestDo_rateLimit(t *testing.T) {
 	}
 	if expected = 0; client.Rate.Remaining != expected {
 		t.Errorf("Client rate remaining = %v, got %v", client.Rate.Remaining, expected)
-	}
-	if expected = 0; client.Rate.RetryAfter != expected {
-		t.Errorf("Client rate retry-after = %v, got %v", client.Rate.RetryAfter, expected)
 	}
 	if !client.Rate.Reset.IsZero() {
 		t.Errorf("Client rate reset not initialized to zero value")
@@ -530,9 +526,6 @@ func TestDo_rateLimit(t *testing.T) {
 	}
 	if expected = 59; client.Rate.Remaining != expected {
 		t.Errorf("Client rate remaining = %v, expected %v", client.Rate.Remaining, expected)
-	}
-	if expected = 23; client.Rate.RetryAfter != expected {
-		t.Errorf("Client rate retry-after = %v, expected %v", client.Rate.RetryAfter, expected)
 	}
 	reset := time.Date(2013, 7, 1, 17, 47, 53, 0, time.UTC)
 	if client.Rate.Reset.UTC() != reset {
@@ -627,11 +620,9 @@ func TestWithRetryAndBackoffs(t *testing.T) {
 	})
 
 	oauth_client := oauth2.NewClient(oauth2.NoContext, tokenSrc)
-	var waitMax *float64 = new(float64)
-	var waitMin *float64 = new(float64)
 
-	*waitMax = 6.0
-	*waitMin = 3.0
+	waitMax := PtrTo(6.0)
+	waitMin := PtrTo(3.0)
 
 	retryConfig := RetryConfig{
 		RetryMax:     3,

--- a/godo_test.go
+++ b/godo_test.go
@@ -534,7 +534,6 @@ func TestDo_rateLimit(t *testing.T) {
 	if client.Rate != client.GetRate() {
 		t.Errorf("Client rate is not the same as client.GetRate()")
 	}
-
 }
 
 func TestDo_rateLimitRace(t *testing.T) {


### PR DESCRIPTION
Users can opt to use the httpclient from the retryablehttp package when creating a godo client to enable automatic retries and exponential backoff. 

Users can enable using the retryablehttp httpclient by passing in the `SetRetryMax()` option when creating a client using `New()`. Users can then configure the retryWaitMax, and retryWaitMin values.

This first iteration uses the retryablehttp's `DefaultRetryPolicy` and `DefaultBackOff`. By not explicitly setting them, they are the defaults as shown [here](https://github.com/hashicorp/go-retryablehttp/blob/v0.7.4/client.go#L416-L422).

For the test, I passed in retryMax=2 and retryWaitMax=6.0 seconds and retryWaitMin=6.0s:
```
=== RUN   TestRetryableClient_DefaultRetryPolicy
2023/07/13 11:47:20 [DEBUG] GET http://127.0.0.1:53811/foo
2023/07/13 11:47:20 [DEBUG] GET http://127.0.0.1:53811/foo (status: 500): retrying in 6s (2 left)
2023/07/13 11:47:26 [DEBUG] GET http://127.0.0.1:53811/foo (status: 500): retrying in 6s (1 left)
--- PASS: TestRetryableClient_DefaultRetryPolicy (12.00s)
PASS
ok      github.com/digitalocean/godo    12.706s
```

As you can see, it retries 2 times and waits 6 seconds inbetween retries. I'm not sure how to explicitly check the test captured the number of retries and time between in this test- so open to suggestions. 