### PR TITLE
Allow configuring go-retryablehttp.Logger

### DIFF
--- a/godo.go
+++ b/godo.go
@@ -114,8 +114,9 @@ type Client struct {
 // Only the custom HTTP client's custom transport and timeout will be maintained.
 type RetryConfig struct {
 	RetryMax     int
-	RetryWaitMin *float64 // Minimum time to wait
-	RetryWaitMax *float64 // Maximum time to wait
+	RetryWaitMin *float64    // Minimum time to wait
+	RetryWaitMax *float64    // Maximum time to wait
+	Logger       interface{} // Customer logger instance. Must implement either go-retryablehttp.Logger or go-retryablehttp.LeveledLogger
 }
 
 // RequestCompletionCallback defines the type of the request callback function
@@ -307,6 +308,9 @@ func New(httpClient *http.Client, opts ...ClientOpt) (*Client, error) {
 			retryableClient.RetryWaitMax = time.Duration(*c.RetryConfig.RetryWaitMax * float64(time.Second))
 		}
 
+		// By default this is nil and does not log.
+		retryableClient.Logger = c.RetryConfig.Logger
+
 		// if timeout is set, it is maintained before overwriting client with StandardClient()
 		retryableClient.HTTPClient.Timeout = c.HTTPClient.Timeout
 
@@ -373,6 +377,7 @@ func WithRetryAndBackoffs(retryConfig RetryConfig) ClientOpt {
 		c.RetryConfig.RetryMax = retryConfig.RetryMax
 		c.RetryConfig.RetryWaitMax = retryConfig.RetryWaitMax
 		c.RetryConfig.RetryWaitMin = retryConfig.RetryWaitMin
+		c.RetryConfig.Logger = retryConfig.Logger
 		return nil
 	}
 }


### PR DESCRIPTION
Historically, godo has not done any logging on its own. When using the new `WithRetryAndBackoffs` option, this is no longer the case. When used, each request is logged to stderr. This is surprising and not always desirable (e.g. for a cli tool like doctl). 

This PR exposes the `go-retryablehttp.Logger` option in the `RetryConfig`. It defaults to `nil` to prevent logging as this matches the historical behavior. A logger can be configured as knowing when/if a request is being retried is useful.