### PR TITLE
Provide a custom retryablehttp.ErrorHandler for more consistent returns using retries.

### DIFF
--- a/godo.go
+++ b/godo.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -27,9 +26,11 @@ const (
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"
 
-	headerRateLimit     = "RateLimit-Limit"
-	headerRateRemaining = "RateLimit-Remaining"
-	headerRateReset     = "RateLimit-Reset"
+	headerRateLimit             = "RateLimit-Limit"
+	headerRateRemaining         = "RateLimit-Remaining"
+	headerRateReset             = "RateLimit-Reset"
+	headerRequestID             = "x-request-id"
+	internalHeaderRetryAttempts = "X-Godo-Retry-Attempts"
 )
 
 // Client manages communication with DigitalOcean V2 API.
@@ -178,6 +179,9 @@ type ErrorResponse struct {
 
 	// RequestID returned from the API, useful to contact support.
 	RequestID string `json:"request_id"`
+
+	// Attempts is the number of times the request was attempted when retries are enabled.
+	Attempts int
 }
 
 // Rate contains the rate limit for the current client.
@@ -313,6 +317,19 @@ func New(httpClient *http.Client, opts ...ClientOpt) (*Client, error) {
 
 		// if timeout is set, it is maintained before overwriting client with StandardClient()
 		retryableClient.HTTPClient.Timeout = c.HTTPClient.Timeout
+
+		// This custom ErrorHandler is required to provide errors that are consistent
+		// with a *godo.ErrorResponse and a non-nil *godo.Response while providing
+		// insight into retries using an internal header.
+		retryableClient.ErrorHandler = func(resp *http.Response, err error, numTries int) (*http.Response, error) {
+			if resp != nil {
+				resp.Header.Add(internalHeaderRetryAttempts, strconv.Itoa(numTries))
+
+				return resp, err
+			}
+
+			return resp, err
+		}
 
 		var source *oauth2.Transport
 		if _, ok := c.HTTPClient.Transport.(*oauth2.Transport); ok {
@@ -489,7 +506,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*Res
 		// won't reuse it anyway.
 		const maxBodySlurpSize = 2 << 10
 		if resp.ContentLength == -1 || resp.ContentLength <= maxBodySlurpSize {
-			io.CopyN(ioutil.Discard, resp.Body, maxBodySlurpSize)
+			io.CopyN(io.Discard, resp.Body, maxBodySlurpSize)
 		}
 
 		if rerr := resp.Body.Close(); err == nil {
@@ -539,12 +556,17 @@ func DoRequestWithClient(
 }
 
 func (r *ErrorResponse) Error() string {
-	if r.RequestID != "" {
-		return fmt.Sprintf("%v %v: %d (request %q) %v",
-			r.Response.Request.Method, r.Response.Request.URL, r.Response.StatusCode, r.RequestID, r.Message)
+	var attempted string
+	if r.Attempts > 0 {
+		attempted = fmt.Sprintf("; giving up after %d attempt(s)", r.Attempts)
 	}
-	return fmt.Sprintf("%v %v: %d %v",
-		r.Response.Request.Method, r.Response.Request.URL, r.Response.StatusCode, r.Message)
+
+	if r.RequestID != "" {
+		return fmt.Sprintf("%v %v: %d (request %q) %v%s",
+			r.Response.Request.Method, r.Response.Request.URL, r.Response.StatusCode, r.RequestID, r.Message, attempted)
+	}
+	return fmt.Sprintf("%v %v: %d %v%s",
+		r.Response.Request.Method, r.Response.Request.URL, r.Response.StatusCode, r.Message, attempted)
 }
 
 // CheckResponse checks the API response for errors, and returns them if present. A response is considered an
@@ -557,7 +579,7 @@ func CheckResponse(r *http.Response) error {
 	}
 
 	errorResponse := &ErrorResponse{Response: r}
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err == nil && len(data) > 0 {
 		err := json.Unmarshal(data, errorResponse)
 		if err != nil {
@@ -566,7 +588,12 @@ func CheckResponse(r *http.Response) error {
 	}
 
 	if errorResponse.RequestID == "" {
-		errorResponse.RequestID = r.Header.Get("x-request-id")
+		errorResponse.RequestID = r.Header.Get(headerRequestID)
+	}
+
+	attempts, strconvErr := strconv.Atoi(r.Header.Get(internalHeaderRetryAttempts))
+	if strconvErr == nil {
+		errorResponse.Attempts = attempts
 	}
 
 	return errorResponse


### PR DESCRIPTION
This aims to solve a number of inconsistencies/issues when using `WithRetryAndBackoffs`. Currentlywhen a retry happens:

- The final error response from the API is overwritten with the "giving up after x attempt(s)" error message. It does not include the final status code.
- The error gets  double nested. So calling `err.Error()` returns the messy looking `Get "http://127.0.0.1:45035/foo": GET http://127.0.0.1:45035/foo giving up after 4 attempt(s)`
- The `*godo.Response` returned by the resource methods is nil if there is an error. That is not consistent with existing godo or net/http. If there is an HTTP response, even an errpr, it should be returned.

 This uses a custom `ErrorHandler` in order to provide errors that are consistent with a `*godo.ErrorResponse` and a non-nil `*godo.Response` while still providing insight.