### PR TITLE
Make Retrys by Default for NewFromToken()

### DIFF
--- a/godo.go
+++ b/godo.go
@@ -227,6 +227,8 @@ func addOptions(s string, opt interface{}) (string, error) {
 	return origURL.String(), nil
 }
 
+// configureRetryableClient will create a retryableclient with default behavior
+// if no godo client is passed. It will then convert the retryableclient to a *http.Client.
 func configureRetryableClient(c *Client, httpClient *http.Client) *http.Client {
 	retryableClient := retryablehttp.NewClient()
 

--- a/godo.go
+++ b/godo.go
@@ -281,7 +281,9 @@ func configureRetryableClient(c *Client, httpClient *http.Client) *http.Client {
 }
 
 // NewFromToken returns a new DigitalOcean API client with the given API
-// token.
+// token. Creating a new DigitalOcean API Client with NewFromToken
+// enables retries and backoffs by default for requests that fail with 429
+// or 500-level response codes using the go-retryablehttp client.
 func NewFromToken(token string) *Client {
 	cleanToken := strings.Trim(strings.TrimSpace(token), "'")
 	ctx := context.Background()


### PR DESCRIPTION
Configures a retryable client with default behavior when a godo client is initialized via NewFromToken(). Also refactored the code a bit to eliminate code duplication. 

If you'd like to test:
```
func main() {
    ctx := context.Background()
    token := "do_token_here"

    client := godo.NewFromToken(token)

    for i := 0; i < 290; i++ {
        println(i)
        _, resp, _ := client.Account.Get(ctx)
        println(resp.StatusCode)
    }
}
```
will yield:
```
2023/08/23 23:43:59 [DEBUG] GET https://api.digitalocean.com/v2/account
117
2023/08/23 23:43:59 [DEBUG] GET https://api.digitalocean.com/v2/account
2023/08/23 23:43:59 [DEBUG] GET https://api.digitalocean.com/v2/account (status: 429): retrying in 7s (4 left)
```

Same behavior is seen for initializing a client via `godo.NewClient()`