### PR TITLE
APPS-7700 Add ability to specify digest for an image

### DIFF
--- a/apps.gen.go
+++ b/apps.gen.go
@@ -975,14 +975,16 @@ type ImageSourceSpec struct {
 	Registry string `json:"registry,omitempty"`
 	// The repository name.
 	Repository string `json:"repository,omitempty"`
-	// The repository tag. Defaults to `latest` if not provided.
-	Tag          string                       `json:"tag,omitempty"`
+	// The repository tag. Defaults to `latest` if not provided and no digest is provided. Cannot be specified if digest is provided.
+	Tag string `json:"tag,omitempty"`
+	// The image digest. Cannot be specified if tag is provided.
+	Digest       string                       `json:"digest,omitempty"`
 	DeployOnPush *ImageSourceSpecDeployOnPush `json:"deploy_on_push,omitempty"`
 }
 
 // ImageSourceSpecDeployOnPush struct for ImageSourceSpecDeployOnPush
 type ImageSourceSpecDeployOnPush struct {
-	// Automatically deploy new images. Only for DOCR images.
+	// Automatically deploy new images. Only for DOCR images. Can't be enabled when a specific digest is specified.
 	Enabled bool `json:"enabled,omitempty"`
 }
 

--- a/apps_accessors.go
+++ b/apps_accessors.go
@@ -3094,6 +3094,14 @@ func (i *ImageSourceSpec) GetDeployOnPush() *ImageSourceSpecDeployOnPush {
 	return i.DeployOnPush
 }
 
+// GetDigest returns the Digest field.
+func (i *ImageSourceSpec) GetDigest() string {
+	if i == nil {
+		return ""
+	}
+	return i.Digest
+}
+
 // GetRegistry returns the Registry field.
 func (i *ImageSourceSpec) GetRegistry() string {
 	if i == nil {

--- a/apps_accessors_test.go
+++ b/apps_accessors_test.go
@@ -2715,6 +2715,13 @@ func TestImageSourceSpec_GetDeployOnPush(tt *testing.T) {
 	i.GetDeployOnPush()
 }
 
+func TestImageSourceSpec_GetDigest(tt *testing.T) {
+	i := &ImageSourceSpec{}
+	i.GetDigest()
+	i = nil
+	i.GetDigest()
+}
+
 func TestImageSourceSpec_GetRegistry(tt *testing.T) {
 	i := &ImageSourceSpec{}
 	i.GetRegistry()


### PR DESCRIPTION
This adds the ability to specifically deploy a precise digest for a given image to avoid having specify unique tags and similar workarounds.