### PR TITLE
Prep v1.104.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [v1.104.0] - 2023-10-10
+
+- #637 - @mikesmithgh - chore: change uptime alert comparison type
+- #638 - @markusthoemmes - APPS-7700 Add ability to specify digest for an image
+
 ## [v1.103.0] - 2023-10-03
 
 - #635 - @andrewsomething - Bump github.com/stretchr/testify to v1.8.4


### PR DESCRIPTION
Cuts a new release with the recent changes so that we can get them pulled into doctl