### PR TITLE
Drop required Go version to 1.20 and document policy.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [v1.104.1] - 2023-10-10
+
+* #640 - @andrewsomething - Drop required Go version to 1.20 and document policy.
+* #640 - @andrewsomething - Fix library version.
+
 ## [v1.104.0] - 2023-10-10
 
 - #637 - @mikesmithgh - chore: change uptime alert comparison type

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,3 +67,11 @@ github-changelog-generator -org digitalocean -repo godo
 5. Update the `Tag version` and `Release title` field with the new godo version.  Be sure the version has a `v` prefixed in both places. Ex `v1.8.0`.
 6. Copy the changelog bullet points to the description field.
 7. Publish the release.
+
+## Go Version Support
+
+This project follows the support [policy of Go](https://go.dev/doc/devel/release#policy)
+as its support policy. The two latest major releases of Go are supported by the project.
+[CI workflows](.github/workflows/ci.yml) should test against both supported versions.
+[go.mod](./go.mod) should specify the oldest of the supported versions to give
+downstream users of godo flexibility.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/digitalocean/godo
 
-go 1.21
+go 1.20
 
 require (
 	github.com/google/go-querystring v1.1.0

--- a/godo.go
+++ b/godo.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.103.0"
+	libraryVersion = "1.104.1"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"


### PR DESCRIPTION
A quick bug fix release addressing two issues with the last release:
- [As noted here](https://github.com/digitalocean/godo/pull/634#discussion_r1355310187), setting `go 1.21` in `go.mod` prevents users from easily using the most recent release with Go 1.20 which we support. 
- I neglected to bump the library version in v1.104.0