### PR TITLE
Fix Kafka Partition Count

### DIFF
--- a/databases.go
+++ b/databases.go
@@ -297,11 +297,26 @@ type DatabaseDB struct {
 
 // DatabaseTopic represents a Kafka topic
 type DatabaseTopic struct {
-	Name              string       `json:"name"`
-	PartitionCount    *uint32      `json:"partition_count,omitempty"`
-	ReplicationFactor *uint32      `json:"replication_factor,omitempty"`
-	State             string       `json:"state,omitempty"`
-	Config            *TopicConfig `json:"config,omitempty"`
+	Name              string            `json:"name"`
+	Partitions        []*TopicPartition `json:"partitions,omitempty"`
+	ReplicationFactor *uint32           `json:"replication_factor,omitempty"`
+	State             string            `json:"state,omitempty"`
+	Config            *TopicConfig      `json:"config,omitempty"`
+}
+
+// TopicPartition represents the state of a Kafka topic partition
+type TopicPartition struct {
+	EarliestOffset uint64                `json:"earliest_offset,omitempty"`
+	InSyncReplicas uint32                `json:"in_sync_replicas,omitempty"`
+	Id             uint32                `json:"id,omitempty"`
+	Size           uint64                `json:"size,omitempty"`
+	ConsumerGroups []*TopicConsumerGroup `json:"consumer_groups,omitempty"`
+}
+
+// TopicConsumerGroup represents a consumer group for a particular Kafka topic
+type TopicConsumerGroup struct {
+	Name   string `json:"name,omitempty"`
+	Offset uint64 `json:"offset,omitempty"`
 }
 
 // TopicConfig represents all configurable options for a Kafka topic
@@ -342,7 +357,9 @@ type DatabaseCreateTopicRequest struct {
 
 // DatabaseUpdateTopicRequest ...
 type DatabaseUpdateTopicRequest struct {
-	Topic *DatabaseTopic `json:"topic"` // note: `name` field in Topic unused on update
+	PartitionCount    *uint32      `json:"partition_count,omitempty"`
+	ReplicationFactor *uint32      `json:"replication_factor,omitempty"`
+	Config            *TopicConfig `json:"config,omitempty"`
 }
 
 // DatabaseReplica represents a read-only replica of a particular database

--- a/databases_test.go
+++ b/databases_test.go
@@ -2323,7 +2323,6 @@ func TestDatabases_CreateTopic(t *testing.T) {
 
 	want := &DatabaseTopic{
 		Name:              "events",
-		PartitionCount:    &numPartitions,
 		ReplicationFactor: &replicationFactor,
 		Config: &TopicConfig{
 			RetentionMS: &retentionMS,
@@ -2392,12 +2391,10 @@ func TestDatabases_UpdateTopic(t *testing.T) {
 	})
 
 	_, err := client.Databases.UpdateTopic(ctx, dbID, topicName, &DatabaseUpdateTopicRequest{
-		Topic: &DatabaseTopic{
-			PartitionCount:    &numPartitions,
-			ReplicationFactor: &replicationFactor,
-			Config: &TopicConfig{
-				RetentionMS: &retentionMS,
-			},
+		PartitionCount:    &numPartitions,
+		ReplicationFactor: &replicationFactor,
+		Config: &TopicConfig{
+			RetentionMS: &retentionMS,
 		},
 	})
 
@@ -2430,14 +2427,35 @@ func TestDatabases_GetTopic(t *testing.T) {
 	var (
 		dbID              = "deadbeef-dead-4aa5-beef-deadbeef347d"
 		topicName         = "events"
-		numPartitions     = uint32(3)
 		replicationFactor = uint32(2)
 		retentionMS       = int64(1000 * 60)
 	)
 
 	want := &DatabaseTopic{
-		Name:              "events",
-		PartitionCount:    &numPartitions,
+		Name: "events",
+		Partitions: []*TopicPartition{
+			{
+				Size:           0,
+				Id:             0,
+				InSyncReplicas: 2,
+				EarliestOffset: 0,
+				ConsumerGroups: nil,
+			},
+			{
+				Size:           0,
+				Id:             1,
+				InSyncReplicas: 2,
+				EarliestOffset: 0,
+				ConsumerGroups: nil,
+			},
+			{
+				Size:           0,
+				Id:             2,
+				InSyncReplicas: 2,
+				EarliestOffset: 0,
+				ConsumerGroups: nil,
+			},
+		},
 		ReplicationFactor: &replicationFactor,
 		Config: &TopicConfig{
 			RetentionMS: &retentionMS,
@@ -2445,15 +2463,37 @@ func TestDatabases_GetTopic(t *testing.T) {
 	}
 
 	body := `{
-	  "topic": {
-	    "name": "events",
-	    "partition_count": 3,
-	    "replication_factor": 2,
-	    "config": {
-	    	"retention_ms": 60000
-	    }
-	  }
-	}`
+		"topic":{
+		   "name":"events",
+		   "replication_factor":2,
+		   "config":{
+			  "retention_ms":60000
+		   },
+		   "partitions":[
+			  {
+				 "size":0,
+				 "id":0,
+				 "in_sync_replicas":2,
+				 "earliest_offset":0,
+				 "consumer_groups":null
+			  },
+			  {
+				 "size":0,
+				 "id":1,
+				 "in_sync_replicas":2,
+				 "earliest_offset":0,
+				 "consumer_groups":null
+			  },
+			  {
+				 "size":0,
+				 "id":2,
+				 "in_sync_replicas":2,
+				 "earliest_offset":0,
+				 "consumer_groups":null
+			  }
+		   ]
+		}
+	 }`
 
 	path := fmt.Sprintf("/v2/databases/%s/topics/%s", dbID, topicName)
 
@@ -2473,23 +2513,66 @@ func TestDatabases_ListTopics(t *testing.T) {
 
 	var (
 		dbID              = "deadbeef-dead-4aa5-beef-deadbeef347d"
-		numPartitions     = uint32(3)
 		replicationFactor = uint32(2)
 		retentionMS       = int64(1000 * 60)
 	)
 
 	want := []DatabaseTopic{
 		{
-			Name:              "events",
-			PartitionCount:    &numPartitions,
+			Name: "events",
+			Partitions: []*TopicPartition{
+				{
+					Size:           0,
+					Id:             0,
+					InSyncReplicas: 2,
+					EarliestOffset: 0,
+					ConsumerGroups: nil,
+				},
+				{
+					Size:           0,
+					Id:             1,
+					InSyncReplicas: 2,
+					EarliestOffset: 0,
+					ConsumerGroups: nil,
+				},
+				{
+					Size:           0,
+					Id:             2,
+					InSyncReplicas: 2,
+					EarliestOffset: 0,
+					ConsumerGroups: nil,
+				},
+			},
 			ReplicationFactor: &replicationFactor,
 			Config: &TopicConfig{
 				RetentionMS: &retentionMS,
 			},
 		},
 		{
-			Name:              "events_ii",
-			PartitionCount:    &numPartitions,
+			Name: "events_ii",
+			Partitions: []*TopicPartition{
+				{
+					Size:           0,
+					Id:             0,
+					InSyncReplicas: 2,
+					EarliestOffset: 0,
+					ConsumerGroups: nil,
+				},
+				{
+					Size:           0,
+					Id:             1,
+					InSyncReplicas: 2,
+					EarliestOffset: 0,
+					ConsumerGroups: nil,
+				},
+				{
+					Size:           0,
+					Id:             2,
+					InSyncReplicas: 2,
+					EarliestOffset: 0,
+					ConsumerGroups: nil,
+				},
+			},
 			ReplicationFactor: &replicationFactor,
 			Config: &TopicConfig{
 				RetentionMS: &retentionMS,
@@ -2501,7 +2584,29 @@ func TestDatabases_ListTopics(t *testing.T) {
 	  "topics": [
 	  	{
 		    "name": "events",
-		    "partition_count": 3,
+			"partitions":[
+				{
+				   "size":0,
+				   "id":0,
+				   "in_sync_replicas":2,
+				   "earliest_offset":0,
+				   "consumer_groups":null
+				},
+				{
+				   "size":0,
+				   "id":1,
+				   "in_sync_replicas":2,
+				   "earliest_offset":0,
+				   "consumer_groups":null
+				},
+				{
+				   "size":0,
+				   "id":2,
+				   "in_sync_replicas":2,
+				   "earliest_offset":0,
+				   "consumer_groups":null
+				}
+			],
 		    "replication_factor": 2,
 		    "config": {
 		    	"retention_ms": 60000
@@ -2509,7 +2614,29 @@ func TestDatabases_ListTopics(t *testing.T) {
 		  },
 		  {
 		    "name": "events_ii",
-		    "partition_count": 3,
+			"partitions":[
+				{
+				   "size":0,
+				   "id":0,
+				   "in_sync_replicas":2,
+				   "earliest_offset":0,
+				   "consumer_groups":null
+				},
+				{
+				   "size":0,
+				   "id":1,
+				   "in_sync_replicas":2,
+				   "earliest_offset":0,
+				   "consumer_groups":null
+				},
+				{
+				   "size":0,
+				   "id":2,
+				   "in_sync_replicas":2,
+				   "earliest_offset":0,
+				   "consumer_groups":null
+				}
+			],
 		    "replication_factor": 2,
 		    "config": {
 		    	"retention_ms": 60000


### PR DESCRIPTION
**What**

- Changes Get/List operation responses to include `partitions` instead of `partition_count` which is used for Create/Update operations

**Why**

The API response from Get/List includes 1 or many topics with `partitions` in the response rather than `partition_count`. `partition_count` is used when creating the topic, but the response from the API should include the list of partitions that are created.

https://docs.digitalocean.com/reference/api/api-reference/#operation/databases_get_kafka_topic

An example response from the API is included below:

```
{
    "topic": {
        "name": "test-topic-1",
        "partitions": [
            {
                "size": 4096,
                "id": 0,
                "in_sync_replicas": 2,
                "earliest_offset": 0,
                "consumer_groups": null
            },
            {
                "size": 4096,
                "id": 2,
                "in_sync_replicas": 2,
                "earliest_offset": 0,
                "consumer_groups": null
            },
            {
                "size": 4096,
                "id": 1,
                "in_sync_replicas": 2,
                "earliest_offset": 0,
                "consumer_groups": null
            }
        ],
        "replication_factor": 2,
        "state": "active",
        "config": {
            "cleanup_policy": "delete",
            "compression_type": "producer",
            "delete_retention_ms": 86400000,
            "file_delete_delay_ms": 60000,
            "flush_messages": 9223372036854775807,
            "flush_ms": 9223372036854775807,
            "index_interval_bytes": 4096,
            "max_compaction_lag_ms": 9223372036854775807,
            "max_message_bytes": 1048588,
            "message_down_conversion_enable": true,
            "message_format_version": "3.0-IV1",
            "message_timestamp_difference_max_ms": 9223372036854775807,
            "message_timestamp_type": "create_time",
            "min_cleanable_dirty_ratio": 0.5,
            "min_compaction_lag_ms": 0,
            "min_insync_replicas": 1,
            "preallocate": false,
            "retention_bytes": -1,
            "retention_ms": 604800000,
            "segment_bytes": 209715200,
            "segment_index_bytes": 10485760,
            "segment_jitter_ms": 0,
            "segment_ms": 604800000,
            "unclean_leader_election_enable": false
        }
    }
}
```