### PR TITLE
test: use fmt.Fprintf instead of fmt.Fprintf(fmt.Sprintf(...))

### DIFF
--- a/projects_test.go
+++ b/projects_test.go
@@ -28,7 +28,7 @@ func TestProjects_List(t *testing.T) {
 	mux.HandleFunc("/v2/projects", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		resp, _ := json.Marshal(expectedProjects)
-		fmt.Fprintf(w, `{"projects":%s, "meta": {"total": 2}}`, string(resp))
+		fmt.Fprintf(w, `{"projects":%s, "meta": {"total": 2}}`, resp)
 	})
 
 	projects, resp, err := client.Projects.List(ctx, nil)
@@ -133,7 +133,7 @@ func TestProjects_GetDefault(t *testing.T) {
 	mux.HandleFunc("/v2/projects/default", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		resp, _ := json.Marshal(project)
-		fmt.Fprintf(w, `{"project":%s}`, string(resp))
+		fmt.Fprintf(w, `{"project":%s}`, resp)
 	})
 
 	resp, _, err := client.Projects.GetDefault(ctx)
@@ -158,7 +158,7 @@ func TestProjects_GetWithUUID(t *testing.T) {
 	mux.HandleFunc("/v2/projects/project-1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		resp, _ := json.Marshal(project)
-		fmt.Fprintf(w, `{"project":%s}`, string(resp))
+		fmt.Fprintf(w, `{"project":%s}`, resp)
 	})
 
 	resp, _, err := client.Projects.Get(ctx, "project-1")
@@ -203,7 +203,7 @@ func TestProjects_Create(t *testing.T) {
 		}
 
 		resp, _ := json.Marshal(createResp)
-		fmt.Fprintf(w, fmt.Sprintf(`{"project":%s}`, string(resp)))
+		fmt.Fprintf(w, `{"project":%s}`, resp)
 	})
 
 	project, _, err := client.Projects.Create(ctx, createRequest)
@@ -245,7 +245,7 @@ func TestProjects_UpdateWithOneAttribute(t *testing.T) {
 		}
 
 		resp, _ := json.Marshal(updateResp)
-		fmt.Fprintf(w, fmt.Sprintf(`{"project":%s}`, string(resp)))
+		fmt.Fprintf(w, `{"project":%s}`, resp)
 	})
 
 	project, _, err := client.Projects.Update(ctx, "project-1", updateRequest)
@@ -290,7 +290,7 @@ func TestProjects_UpdateWithAllAttributes(t *testing.T) {
 		}
 
 		resp, _ := json.Marshal(updateResp)
-		fmt.Fprintf(w, fmt.Sprintf(`{"project":%s}`, string(resp)))
+		fmt.Fprintf(w, `{"project":%s}`, resp)
 	})
 
 	project, _, err := client.Projects.Update(ctx, "project-1", updateRequest)
@@ -347,7 +347,7 @@ func TestProjects_ListResources(t *testing.T) {
 	mux.HandleFunc("/v2/projects/project-1/resources", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		resp, _ := json.Marshal(expectedResources)
-		fmt.Fprintf(w, `{"resources":%s, "meta": {"total": 2}}`, string(resp))
+		fmt.Fprintf(w, `{"resources":%s, "meta": {"total": 2}}`, resp)
 	})
 
 	resources, resp, err := client.Projects.ListResources(ctx, "project-1", nil)

--- a/uptime_test.go
+++ b/uptime_test.go
@@ -28,7 +28,7 @@ func TestUptimeChecks_List(t *testing.T) {
 	mux.HandleFunc("/v2/uptime/checks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		resp, _ := json.Marshal(expectedUptimeChecks)
-		fmt.Fprintf(w, `{"checks":%s, "meta": {"total": 2}}`, string(resp))
+		fmt.Fprintf(w, `{"checks":%s, "meta": {"total": 2}}`, resp)
 	})
 
 	uptimeChecks, resp, err := client.UptimeChecks.List(ctx, nil)
@@ -149,7 +149,7 @@ func TestUptimeChecks_GetState(t *testing.T) {
 	mux.HandleFunc("/v2/uptime/checks/check-1/state", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		resp, _ := json.Marshal(uptimeCheckState)
-		fmt.Fprintf(w, `{"state":%s}`, string(resp))
+		fmt.Fprintf(w, `{"state":%s}`, resp)
 	})
 
 	resp, _, err := client.UptimeChecks.GetState(ctx, "check-1")
@@ -174,7 +174,7 @@ func TestUptimeChecks_GetWithID(t *testing.T) {
 	mux.HandleFunc("/v2/uptime/checks/check-1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		resp, _ := json.Marshal(uptimeCheck)
-		fmt.Fprintf(w, `{"check":%s}`, string(resp))
+		fmt.Fprintf(w, `{"check":%s}`, resp)
 	})
 
 	resp, _, err := client.UptimeChecks.Get(ctx, "check-1")
@@ -219,7 +219,7 @@ func TestUptimeChecks_Create(t *testing.T) {
 		}
 
 		resp, _ := json.Marshal(createResp)
-		fmt.Fprintf(w, fmt.Sprintf(`{"check":%s}`, string(resp)))
+		fmt.Fprintf(w, `{"check":%s}`, resp)
 	})
 
 	uptimeCheck, _, err := client.UptimeChecks.Create(ctx, createRequest)
@@ -263,7 +263,7 @@ func TestUptimeChecks_Update(t *testing.T) {
 		}
 
 		resp, _ := json.Marshal(updateResp)
-		fmt.Fprintf(w, fmt.Sprintf(`{"check":%s}`, string(resp)))
+		fmt.Fprintf(w, `{"check":%s}`, resp)
 	})
 
 	uptimeCheck, _, err := client.UptimeChecks.Update(ctx, "check-id", updateRequest)
@@ -343,7 +343,7 @@ func TestUptimeAlert_Update(t *testing.T) {
 		}
 
 		resp, _ := json.Marshal(updateResp)
-		fmt.Fprintf(w, fmt.Sprintf(`{"alert":%s}`, string(resp)))
+		fmt.Fprintf(w, `{"alert":%s}`, resp)
 	})
 
 	alert, _, err := client.UptimeChecks.UpdateAlert(ctx, "check-id", "alert-id", updateRequest)
@@ -395,7 +395,7 @@ func TestUptimeAlert_Create(t *testing.T) {
 		}
 
 		resp, _ := json.Marshal(createResp)
-		fmt.Fprintf(w, fmt.Sprintf(`{"alert":%s}`, string(resp)))
+		fmt.Fprintf(w, `{"alert":%s}`, resp)
 	})
 
 	uptimeCheck, _, err := client.UptimeChecks.CreateAlert(ctx, "check-id", createRequest)
@@ -430,7 +430,7 @@ func TestUptimeAlert_GetWithID(t *testing.T) {
 	mux.HandleFunc("/v2/uptime/checks/check-1/alerts/alert-1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		resp, _ := json.Marshal(alert)
-		fmt.Fprintf(w, `{"alert":%s}`, string(resp))
+		fmt.Fprintf(w, `{"alert":%s}`, resp)
 	})
 
 	resp, _, err := client.UptimeChecks.GetAlert(ctx, "check-1", "alert-1")
@@ -481,7 +481,7 @@ func TestUptimeAlerts_List(t *testing.T) {
 	mux.HandleFunc("/v2/uptime/checks/check-1/alerts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		resp, _ := json.Marshal(expectedAlerts)
-		fmt.Fprintf(w, `{"alerts":%s, "meta": {"total": 2}}`, string(resp))
+		fmt.Fprintf(w, `{"alerts":%s, "meta": {"total": 2}}`, resp)
 	})
 
 	alerts, resp, err := client.UptimeChecks.ListAlerts(ctx, "check-1", nil)


### PR DESCRIPTION
This PR makes the same changes as #621. Additionally, replace `string(resp)` with `resp` because `fmt.Sprintf("%s", string(resp))` is the same as `fmt.Sprintf("%s", resp)` when `resp` has the `[]byte` type.