### PR TITLE
test: Replace deprecated io/ioutil with io

### DIFF
--- a/projects_test.go
+++ b/projects_test.go
@@ -3,7 +3,7 @@ package godo
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -233,7 +233,7 @@ func TestProjects_UpdateWithOneAttribute(t *testing.T) {
 	}
 
 	mux.HandleFunc("/v2/projects/project-1", func(w http.ResponseWriter, r *http.Request) {
-		reqBytes, respErr := ioutil.ReadAll(r.Body)
+		reqBytes, respErr := io.ReadAll(r.Body)
 		if respErr != nil {
 			t.Error("projects mock didn't work")
 		}
@@ -278,7 +278,7 @@ func TestProjects_UpdateWithAllAttributes(t *testing.T) {
 	}
 
 	mux.HandleFunc("/v2/projects/project-1", func(w http.ResponseWriter, r *http.Request) {
-		reqBytes, respErr := ioutil.ReadAll(r.Body)
+		reqBytes, respErr := io.ReadAll(r.Body)
 		if respErr != nil {
 			t.Error("projects mock didn't work")
 		}
@@ -505,7 +505,7 @@ func TestProjects_AssignFleetResourcesWithTypes(t *testing.T) {
 
 	mux.HandleFunc("/v2/projects/project-1/resources", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
-		reqBytes, respErr := ioutil.ReadAll(r.Body)
+		reqBytes, respErr := io.ReadAll(r.Body)
 		if respErr != nil {
 			t.Error("projects mock didn't work")
 		}
@@ -564,7 +564,7 @@ func TestProjects_AssignFleetResourcesWithStrings(t *testing.T) {
 
 	mux.HandleFunc("/v2/projects/project-1/resources", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
-		reqBytes, respErr := ioutil.ReadAll(r.Body)
+		reqBytes, respErr := io.ReadAll(r.Body)
 		if respErr != nil {
 			t.Error("projects mock didn't work")
 		}
@@ -623,7 +623,7 @@ func TestProjects_AssignFleetResourcesWithStringsAndTypes(t *testing.T) {
 
 	mux.HandleFunc("/v2/projects/project-1/resources", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
-		reqBytes, respErr := ioutil.ReadAll(r.Body)
+		reqBytes, respErr := io.ReadAll(r.Body)
 		if respErr != nil {
 			t.Error("projects mock didn't work")
 		}

--- a/uptime_test.go
+++ b/uptime_test.go
@@ -3,7 +3,7 @@ package godo
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -251,7 +251,7 @@ func TestUptimeChecks_Update(t *testing.T) {
 	}
 
 	mux.HandleFunc("/v2/uptime/checks/check-id", func(w http.ResponseWriter, r *http.Request) {
-		reqBytes, respErr := ioutil.ReadAll(r.Body)
+		reqBytes, respErr := io.ReadAll(r.Body)
 		if respErr != nil {
 			t.Error("uptime checks mock didn't work")
 		}
@@ -331,7 +331,7 @@ func TestUptimeAlert_Update(t *testing.T) {
 	}
 
 	mux.HandleFunc("/v2/uptime/checks/check-id/alerts/alert-id", func(w http.ResponseWriter, r *http.Request) {
-		reqBytes, respErr := ioutil.ReadAll(r.Body)
+		reqBytes, respErr := io.ReadAll(r.Body)
 		if respErr != nil {
 			t.Error("alerts mock didn't work")
 		}


### PR DESCRIPTION
This PR replaces `ioutil.ReadAll` with `io.ReadAll` in tests.

### Motivation
[io/ioutil](https://pkg.go.dev/io/ioutil) is deprecated:

> Deprecated: As of Go 1.16, the same functionality is now provided by package [io](https://pkg.go.dev/io) or package [os](https://pkg.go.dev/os), and those implementations should be preferred in new code. See the specific function documentation for details.