### PR TITLE
Retry on HTTP/2 internal errors.

### DIFF
--- a/godo.go
+++ b/godo.go
@@ -348,6 +348,16 @@ func New(httpClient *http.Client, opts ...ClientOpt) (*Client, error) {
 			return resp, err
 		}
 
+		retryableClient.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
+			// In addition to the default retry policy, we also retry HTTP/2 INTERNAL_ERROR errors.
+			// See: https://github.com/golang/go/issues/51323
+			if err != nil && strings.Contains(err.Error(), "INTERNAL_ERROR") && strings.Contains(reflect.TypeOf(err).String(), "http2") {
+				return true, nil
+			}
+
+			return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
+		}
+
 		var source *oauth2.Transport
 		if _, ok := c.HTTPClient.Transport.(*oauth2.Transport); ok {
 			source = c.HTTPClient.Transport.(*oauth2.Transport)


### PR DESCRIPTION
This adds retries for HTTP/2 `INTERNAL_ERROR` errors to potentially address errors seen with Terraform. Unfortunately, there is not a way for us to mock these while using `github.com/hashicorp/go-retryablehttp`. Though existing test coverage demonstrates that 500 and 429 retries still work as expected. 