### PR TITLE
Prep v1.106.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## [v1.106.0] - 2023-11-14
 
 - #654 - @dweinshenker - Remove unclean_leader_election_enable for topic configuration
-- #653 - @andrewsomething - Prep v1.105.1 release.
+
+## [v1.105.1] - 2023-11-07
+
 - #652 - @andrewsomething - Retry on HTTP/2 internal errors.
 - #648 - @alexandear - test: use fmt.Fprintf instead of fmt.Fprintf(fmt.Sprintf(...))
 - #651 - @alexandear - test: Replace deprecated io/ioutil with io

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Change Log
 
-## [v1.105.1] - 2023-11-07
+## [v1.106.0] - 2023-11-14
 
+- #654 - @dweinshenker - Remove unclean_leader_election_enable for topic configuration
+- #653 - @andrewsomething - Prep v1.105.1 release.
 - #652 - @andrewsomething - Retry on HTTP/2 internal errors.
 - #648 - @alexandear - test: use fmt.Fprintf instead of fmt.Fprintf(fmt.Sprintf(...))
 - #651 - @alexandear - test: Replace deprecated io/ioutil with io

--- a/godo.go
+++ b/godo.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.105.1"
+	libraryVersion = "1.106.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"


### PR DESCRIPTION
Previous release (v1.105.1) didn't get cut:
https://github.com/digitalocean/godo/releases
So this release combines changes in v1.105.1 and after