### PR TITLE
APPS-8033 Add the RUN_RESTARTED log type

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -21,6 +21,8 @@ const (
 	AppLogTypeDeploy AppLogType = "DEPLOY"
 	// AppLogTypeRun represents run logs.
 	AppLogTypeRun AppLogType = "RUN"
+	// AppLogTypeRunRestarted represents logs of crashed/restarted instances during runtime.
+	AppLogTypeRunRestarted AppLogType = "RUN_RESTARTED"
 )
 
 // AppsService is an interface for interfacing with the App Platform endpoints


### PR DESCRIPTION
This new log type captures "previous" logs so that users that see that their app has seen restarts can fetch those old logs and debug them themselves.