### PR TITLE
APPS-8383: Add deprecation intent and bandwidth allowance to app instance size spec

### DIFF
--- a/apps.gen.go
+++ b/apps.gen.go
@@ -1124,6 +1124,10 @@ type AppInstanceSize struct {
 	FeaturePreview bool `json:"feature_preview,omitempty"`
 	// Indicates if the tier instance size allows more than one instance.
 	SingleInstanceOnly bool `json:"single_instance_only,omitempty"`
+	// Indicates if the tier instance size is intended for deprecation.
+	DeprecationIntent bool `json:"deprecation_intent,omitempty"`
+	// The bandwidth allowance in GiB for the tier instance size.
+	BandwidthAllowanceGib string `json:"bandwidth_allowance_gib,omitempty"`
 }
 
 // AppInstanceSizeCPUType the model 'AppInstanceSizeCPUType'

--- a/apps_accessors.go
+++ b/apps_accessors.go
@@ -1013,6 +1013,14 @@ func (a *AppIngressSpecRuleStringMatch) GetPrefix() string {
 	return a.Prefix
 }
 
+// GetBandwidthAllowanceGib returns the BandwidthAllowanceGib field.
+func (a *AppInstanceSize) GetBandwidthAllowanceGib() string {
+	if a == nil {
+		return ""
+	}
+	return a.BandwidthAllowanceGib
+}
+
 // GetCPUs returns the CPUs field.
 func (a *AppInstanceSize) GetCPUs() string {
 	if a == nil {
@@ -1027,6 +1035,14 @@ func (a *AppInstanceSize) GetCPUType() AppInstanceSizeCPUType {
 		return ""
 	}
 	return a.CPUType
+}
+
+// GetDeprecationIntent returns the DeprecationIntent field.
+func (a *AppInstanceSize) GetDeprecationIntent() bool {
+	if a == nil {
+		return false
+	}
+	return a.DeprecationIntent
 }
 
 // GetFeaturePreview returns the FeaturePreview field.

--- a/apps_accessors_test.go
+++ b/apps_accessors_test.go
@@ -902,6 +902,13 @@ func TestAppInstanceSize_GetCPUType(tt *testing.T) {
 	a.GetCPUType()
 }
 
+func TestAppInstanceSize_GetDeprecationIntent(tt *testing.T) {
+	a := &AppInstanceSize{}
+	a.GetDeprecationIntent()
+	a = nil
+	a.GetDeprecationIntent()
+}
+
 func TestAppInstanceSize_GetFeaturePreview(tt *testing.T) {
 	a := &AppInstanceSize{}
 	a.GetFeaturePreview()
@@ -935,6 +942,13 @@ func TestAppInstanceSize_GetSingleInstanceOnly(tt *testing.T) {
 	a.GetSingleInstanceOnly()
 	a = nil
 	a.GetSingleInstanceOnly()
+}
+
+func TestAppInstanceSize_GetBandwidthAllowanceGib(tt *testing.T) {
+	a := &AppInstanceSize{}
+	a.GetBandwidthAllowanceGib()
+	a = nil
+	a.GetBandwidthAllowanceGib()
 }
 
 func TestAppInstanceSize_GetSlug(tt *testing.T) {


### PR DESCRIPTION
[APPS-8302](https://do-internal.atlassian.net/browse/APPS-8302) and [APPS-8303](https://do-internal.atlassian.net/browse/APPS-8303)

[APPS-8302]: https://do-internal.atlassian.net/browse/APPS-8302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APPS-8303]: https://do-internal.atlassian.net/browse/APPS-8303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ