### PR TITLE
Add ListDatabaseEvents to Godo

### DIFF
--- a/databases.go
+++ b/databases.go
@@ -35,7 +35,7 @@ const (
 	databaseTopicPath                   = databaseBasePath + "/%s/topics/%s"
 	databaseTopicsPath                  = databaseBasePath + "/%s/topics"
 	databaseMetricsCredentialsPath      = databaseBasePath + "/metrics/credentials"
-	databaseProjectEvents               = databaseBasePath + "/%s/events"
+	databaseEvents                      = databaseBasePath + "/%s/events"
 )
 
 // SQL Mode constants allow for MySQL-specific SQL flavor configuration.
@@ -158,7 +158,7 @@ type DatabasesService interface {
 	UpdateTopic(context.Context, string, string, *DatabaseUpdateTopicRequest) (*Response, error)
 	GetMetricsCredentials(context.Context) (*DatabaseMetricsCredentials, *Response, error)
 	UpdateMetricsCredentials(context.Context, *DatabaseUpdateMetricsCredentialsRequest) (*Response, error)
-	ListProjectEvents(context.Context, string) ([]*ProjectEvent, *Response, error)
+	ListDatabaseEvents(context.Context, string) ([]*DatabaseEvent, *Response, error)
 }
 
 // DatabasesServiceOp handles communication with the Databases related methods
@@ -713,21 +713,21 @@ type DatabaseLayout struct {
 	Sizes   []string `json:"sizes"`
 }
 
-// ListProjectEventsResponse contains a list of project events.
-type ListProjectEvents struct {
-	Events []*ProjectEvent `json:"events"`
+// ListDatabaseEvents contains a list of project events.
+type ListDatabaseEvents struct {
+	Events []*DatabaseEvent `json:"events"`
 }
 
-// ProjectEvent contains the information about a project event.
-type ProjectEvent struct {
+// DatbaseEvent contains the information about a Datbase event.
+type DatabaseEvent struct {
 	ID          string `json:"id"`
 	ServiceName string `json:"cluster_name"`
 	EventType   string `json:"event_type"`
 	CreateTime  string `json:"create_time"`
 }
 
-type ListProjectEventsRoot struct {
-	Events []*ProjectEvent `json:"events"`
+type ListDatabaseEventsRoot struct {
+	Events []*DatabaseEvent `json:"events"`
 }
 
 // URN returns a URN identifier for the database
@@ -1537,9 +1537,9 @@ func (svc *DatabasesServiceOp) UpdateMetricsCredentials(ctx context.Context, upd
 	return resp, nil
 }
 
-func (svc *DatabasesServiceOp) ListProjectEvents(ctx context.Context, databaseID string) ([]*ProjectEvent, *Response, error) {
-	path := fmt.Sprintf(databaseProjectEvents, databaseID)
-	root := new(ListProjectEventsRoot)
+func (svc *DatabasesServiceOp) ListDatabaseEvents(ctx context.Context, databaseID string) ([]*DatabaseEvent, *Response, error) {
+	path := fmt.Sprintf(databaseEvents, databaseID)
+	root := new(ListDatabaseEventsRoot)
 	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err

--- a/databases_test.go
+++ b/databases_test.go
@@ -3128,3 +3128,41 @@ func TestDatabases_UpdateMetricsCredentials(t *testing.T) {
 	_, err := client.Databases.UpdateMetricsCredentials(ctx, updateRequest)
 	require.NoError(t, err)
 }
+
+func TestDatabases_ListProjectEvents(t *testing.T) {
+	setup()
+	defer teardown()
+
+	dbID := "deadbeef-dead-4aa5-beef-deadbeef347d"
+
+	path := fmt.Sprintf("/v2/databases/%s/events", dbID)
+
+	want := []*ProjectEvent{
+		{
+			ID:          "pe8u2huh",
+			ServiceName: "customer-events",
+			EventType:   "cluster_create",
+			CreateTime:  "2020-10-29T15:57:38Z",
+		},
+	}
+
+	body := `{
+		"events": [
+		  {
+			"id": "pe8u2huh",
+			"cluster_name": "customer-events",
+			"event_type": "cluster_create",
+			"create_time": "2020-10-29T15:57:38Z"
+		  }
+		]
+	  } `
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, body)
+	})
+
+	got, _, err := client.Databases.ListProjectEvents(ctx, dbID)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}

--- a/databases_test.go
+++ b/databases_test.go
@@ -3129,7 +3129,7 @@ func TestDatabases_UpdateMetricsCredentials(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestDatabases_ListProjectEvents(t *testing.T) {
+func TestDatabases_ListDatabaseEvents(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -3137,7 +3137,7 @@ func TestDatabases_ListProjectEvents(t *testing.T) {
 
 	path := fmt.Sprintf("/v2/databases/%s/events", dbID)
 
-	want := []*ProjectEvent{
+	want := []*DatabaseEvent{
 		{
 			ID:          "pe8u2huh",
 			ServiceName: "customer-events",
@@ -3162,7 +3162,7 @@ func TestDatabases_ListProjectEvents(t *testing.T) {
 		fmt.Fprint(w, body)
 	})
 
-	got, _, err := client.Databases.ListProjectEvents(ctx, dbID)
+	got, _, err := client.Databases.ListDatabaseEvents(ctx, dbID)
 	require.NoError(t, err)
 	require.Equal(t, want, got)
 }


### PR DESCRIPTION
This PR adds support for `Project Events`:

`GET` on `/v2/databases/<database_id>/events` via `Databases.ListProjectEvents` - lists all of the cluster events.

For details: https://docs.digitalocean.com/reference/api/api-reference/#operation/databases_list_events_logs


