### PR TITLE
APPS-8386: Remove unused fields from instance size

### DIFF
--- a/apps.gen.go
+++ b/apps.gen.go
@@ -1109,16 +1109,14 @@ const (
 
 // AppInstanceSize struct for AppInstanceSize
 type AppInstanceSize struct {
-	Name            string                 `json:"name,omitempty"`
-	Slug            string                 `json:"slug,omitempty"`
-	CPUType         AppInstanceSizeCPUType `json:"cpu_type,omitempty"`
-	CPUs            string                 `json:"cpus,omitempty"`
-	MemoryBytes     string                 `json:"memory_bytes,omitempty"`
-	USDPerMonth     string                 `json:"usd_per_month,omitempty"`
-	USDPerSecond    string                 `json:"usd_per_second,omitempty"`
-	TierSlug        string                 `json:"tier_slug,omitempty"`
-	TierUpgradeTo   string                 `json:"tier_upgrade_to,omitempty"`
-	TierDowngradeTo string                 `json:"tier_downgrade_to,omitempty"`
+	Name         string                 `json:"name,omitempty"`
+	Slug         string                 `json:"slug,omitempty"`
+	CPUType      AppInstanceSizeCPUType `json:"cpu_type,omitempty"`
+	CPUs         string                 `json:"cpus,omitempty"`
+	MemoryBytes  string                 `json:"memory_bytes,omitempty"`
+	USDPerMonth  string                 `json:"usd_per_month,omitempty"`
+	USDPerSecond string                 `json:"usd_per_second,omitempty"`
+	TierSlug     string                 `json:"tier_slug,omitempty"`
 	// Indicates if the tier instance size can enable autoscaling.
 	Scalable       bool `json:"scalable,omitempty"`
 	FeaturePreview bool `json:"feature_preview,omitempty"`
@@ -1168,10 +1166,6 @@ type AppProposeResponse struct {
 	Spec              *AppSpec `json:"spec,omitempty"`
 	// The monthly cost of the proposed app in USD.
 	AppCost float32 `json:"app_cost,omitempty"`
-	// The monthly cost of the proposed app in USD using the next pricing plan tier. For example, if you propose an app that uses the Basic tier, the `app_tier_upgrade_cost` field displays the monthly cost of the app if it were to use the Professional tier. If the proposed app already uses the most expensive tier, the field is empty.
-	AppTierUpgradeCost float32 `json:"app_tier_upgrade_cost,omitempty"`
-	// The monthly cost of the proposed app in USD using the previous pricing plan tier. For example, if you propose an app that uses the Professional tier, the `app_tier_downgrade_cost` field displays the monthly cost of the app if it were to use the Basic tier. If the proposed app already uses the lest expensive tier, the field is empty.
-	AppTierDowngradeCost float32 `json:"app_tier_downgrade_cost,omitempty"`
 	// The number of existing starter tier apps the account has.
 	ExistingStarterApps string `json:"existing_starter_apps,omitempty"`
 	// The maximum number of free starter apps the account can have. Any additional starter apps will be charged for. These include apps with only static sites, functions, and databases.

--- a/apps_accessors.go
+++ b/apps_accessors.go
@@ -1093,28 +1093,12 @@ func (a *AppInstanceSize) GetSlug() string {
 	return a.Slug
 }
 
-// GetTierDowngradeTo returns the TierDowngradeTo field.
-func (a *AppInstanceSize) GetTierDowngradeTo() string {
-	if a == nil {
-		return ""
-	}
-	return a.TierDowngradeTo
-}
-
 // GetTierSlug returns the TierSlug field.
 func (a *AppInstanceSize) GetTierSlug() string {
 	if a == nil {
 		return ""
 	}
 	return a.TierSlug
-}
-
-// GetTierUpgradeTo returns the TierUpgradeTo field.
-func (a *AppInstanceSize) GetTierUpgradeTo() string {
-	if a == nil {
-		return ""
-	}
-	return a.TierUpgradeTo
 }
 
 // GetUSDPerMonth returns the USDPerMonth field.
@@ -1419,22 +1403,6 @@ func (a *AppProposeResponse) GetAppNameSuggestion() string {
 		return ""
 	}
 	return a.AppNameSuggestion
-}
-
-// GetAppTierDowngradeCost returns the AppTierDowngradeCost field.
-func (a *AppProposeResponse) GetAppTierDowngradeCost() float32 {
-	if a == nil {
-		return 0
-	}
-	return a.AppTierDowngradeCost
-}
-
-// GetAppTierUpgradeCost returns the AppTierUpgradeCost field.
-func (a *AppProposeResponse) GetAppTierUpgradeCost() float32 {
-	if a == nil {
-		return 0
-	}
-	return a.AppTierUpgradeCost
 }
 
 // GetExistingStarterApps returns the ExistingStarterApps field.

--- a/apps_accessors_test.go
+++ b/apps_accessors_test.go
@@ -958,25 +958,11 @@ func TestAppInstanceSize_GetSlug(tt *testing.T) {
 	a.GetSlug()
 }
 
-func TestAppInstanceSize_GetTierDowngradeTo(tt *testing.T) {
-	a := &AppInstanceSize{}
-	a.GetTierDowngradeTo()
-	a = nil
-	a.GetTierDowngradeTo()
-}
-
 func TestAppInstanceSize_GetTierSlug(tt *testing.T) {
 	a := &AppInstanceSize{}
 	a.GetTierSlug()
 	a = nil
 	a.GetTierSlug()
-}
-
-func TestAppInstanceSize_GetTierUpgradeTo(tt *testing.T) {
-	a := &AppInstanceSize{}
-	a.GetTierUpgradeTo()
-	a = nil
-	a.GetTierUpgradeTo()
 }
 
 func TestAppInstanceSize_GetUSDPerMonth(tt *testing.T) {
@@ -1243,20 +1229,6 @@ func TestAppProposeResponse_GetAppNameSuggestion(tt *testing.T) {
 	a.GetAppNameSuggestion()
 	a = nil
 	a.GetAppNameSuggestion()
-}
-
-func TestAppProposeResponse_GetAppTierDowngradeCost(tt *testing.T) {
-	a := &AppProposeResponse{}
-	a.GetAppTierDowngradeCost()
-	a = nil
-	a.GetAppTierDowngradeCost()
-}
-
-func TestAppProposeResponse_GetAppTierUpgradeCost(tt *testing.T) {
-	a := &AppProposeResponse{}
-	a.GetAppTierUpgradeCost()
-	a = nil
-	a.GetAppTierUpgradeCost()
 }
 
 func TestAppProposeResponse_GetExistingStarterApps(tt *testing.T) {

--- a/apps_test.go
+++ b/apps_test.go
@@ -169,16 +169,18 @@ var (
 	}
 
 	testInstanceSize = AppInstanceSize{
-		Name:            "Basic XXS",
-		Slug:            "basic-xxs",
-		CPUType:         AppInstanceSizeCPUType_Dedicated,
-		CPUs:            "1",
-		MemoryBytes:     "536870912",
-		USDPerMonth:     "5",
-		USDPerSecond:    "0.0000018896447",
-		TierSlug:        "basic",
-		TierUpgradeTo:   "professional-xs",
-		TierDowngradeTo: "basic-xxxs",
+		Name:                  "Basic XXS",
+		Slug:                  "basic-xxs",
+		CPUType:               AppInstanceSizeCPUType_Dedicated,
+		CPUs:                  "1",
+		MemoryBytes:           "536870912",
+		USDPerMonth:           "5",
+		USDPerSecond:          "0.0000018896447",
+		TierSlug:              "basic",
+		BandwidthAllowanceGib: "1",
+		Scalable:              false,
+		SingleInstanceOnly:    true,
+		DeprecationIntent:     true,
 	}
 
 	testAlerts = []*AppAlert{


### PR DESCRIPTION
- Removes `TierUpgradeTo` and `TierDowngradeTo` from app instance size.
- Removes `AppTierUpgradeCost` and `AppTierDowngradeCost` from propose app response.