### PR TITLE
Bug Fix http2: close connections when receiving too many headers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/net v0.17.0 // indirect
+	golang.org/x/net v0.23.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect


### PR DESCRIPTION
Maintaining HPACK state requires that we parse and process all HEADERS and CONTINUATION frames on a connection. When a request's headers exceed `MaxHeaderBytes`, we don't allocate memory to store the excess headers but we do parse them. This permits an attacker to cause an `HTTP/2` endpoint to read arbitrary amounts of data, all associated with a request which is going to be rejected.

Set a limit on the amount of excess header frames we will process before closing a connection.

## Impact
Given the widespread use of HTTP/2 and its prevalence in internet traffic (estimated to be above 70% by Cloudflare Radar), the impact of this vulnerability is significant. It underscores the critical need for prompt patching and robust security measures to mitigate the risk of exploitation and protect web servers from devastating denial of service (DoS) and security restriction bypass attacks.

```
		size := hf.Size()
		if size > remainSize {
			hdec.SetEmitEnabled(false)
			mh.Truncated = true
			return
		}
		remainSize -= size
```
```
+  uint32_t frameSize = self->mInputFrameDataSize - paddingControlBytes -
+                       priorityLen - paddingLength;
+  if (self->mAggregatedHeaderSize + frameSize >
+      StaticPrefs::network_http_max_response_header_size()) {
+    LOG(("Http2Session %p header exceeds the limit\n", self));
+    return self->SessionError(PROTOCOL_ERROR);
+  }
```
```
----- Digitalocean stack trace -----

 1: 0xca5430 node::Abort() [node]
 2: 0xca54b0 node::errors::SetPrepareStackTraceCallback(v8::FunctionCallbackInfo<v8::Value> const&) [node]
 3: 0xce7156 node::http2::Http2Session::~Http2Session() [node]
 4: 0xce7192 node::http2::Http2Session::~Http2Session() [node]
 5: 0x106f01d v8::internal::GlobalHandles::InvokeFirstPassWeakCallbacks() [node]
 6: 0x10f3215 v8::internal::Heap::PerformGarbageCollection(v8::internal::GarbageCollector, v8::internal::GarbageCollectionReason, char const*) [node]
 7: 0x10f3d7c v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [node]
 8: 0x10ca081 v8::internal::HeapAllocator::AllocateRawWithLightRetrySlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [node]
 9: 0x10cb215 v8::internal::HeapAllocator::AllocateRawWithRetryOrFailSlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [node]
10: 0x10a8866 v8::internal::Factory::NewFillerObject(int, v8::internal::AllocationAlignment, v8::internal::AllocationType, v8::internal::AllocationOrigin) [node]
11: 0x15035f6 v8::internal::Runtime_AllocateInYoungGeneration(int, unsigned long*, v8::internal::Isolate*) [node]
12: 0x7f41df699ef6 
Aborted (core dumped)
```
CVE-2023-45288
CWE-400
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L`