### PR TITLE
APPS-8711: container termination controls

### DIFF
--- a/apps.gen.go
+++ b/apps.gen.go
@@ -388,6 +388,7 @@ type AppJobSpec struct {
 	Alerts []*AppAlertSpec `json:"alerts,omitempty"`
 	// A list of configured log forwarding destinations.
 	LogDestinations []*AppLogDestinationSpec `json:"log_destinations,omitempty"`
+	Termination     *AppJobSpecTermination   `json:"termination,omitempty"`
 }
 
 // AppJobSpecKind  - UNSPECIFIED: Default job type, will auto-complete to POST_DEPLOY kind.  - PRE_DEPLOY: Indicates a job that runs before an app deployment.  - POST_DEPLOY: Indicates a job that runs after an app deployment.  - FAILED_DEPLOY: Indicates a job that runs after a component fails to deploy.
@@ -400,6 +401,12 @@ const (
 	AppJobSpecKind_PostDeploy   AppJobSpecKind = "POST_DEPLOY"
 	AppJobSpecKind_FailedDeploy AppJobSpecKind = "FAILED_DEPLOY"
 )
+
+// AppJobSpecTermination struct for AppJobSpecTermination
+type AppJobSpecTermination struct {
+	// The number of seconds to wait between sending a TERM signal to a container and issuing a KILL which causes immediate shutdown. Default: 120, Minimum 1, Maximum 600.
+	GracePeriodSeconds int32 `json:"grace_period_seconds,omitempty"`
+}
 
 // AppLogDestinationSpec struct for AppLogDestinationSpec
 type AppLogDestinationSpec struct {
@@ -484,27 +491,36 @@ type AppServiceSpec struct {
 	// A list of configured alerts which apply to the component.
 	Alerts []*AppAlertSpec `json:"alerts,omitempty"`
 	// A list of configured log forwarding destinations.
-	LogDestinations []*AppLogDestinationSpec `json:"log_destinations,omitempty"`
+	LogDestinations []*AppLogDestinationSpec   `json:"log_destinations,omitempty"`
+	Termination     *AppServiceSpecTermination `json:"termination,omitempty"`
 }
 
 // AppServiceSpecHealthCheck struct for AppServiceSpecHealthCheck
 type AppServiceSpecHealthCheck struct {
 	// Deprecated. Use http_path instead.
 	Path string `json:"path,omitempty"`
-	// The number of seconds to wait before beginning health checks. Default: 0 seconds; start health checks as soon as the service starts.
+	// The number of seconds to wait before beginning health checks. Default: 0 seconds, Minimum 0, Maximum 3600.
 	InitialDelaySeconds int32 `json:"initial_delay_seconds,omitempty"`
-	// The number of seconds to wait between health checks. Default: 10 seconds.
+	// The number of seconds to wait between health checks. Default: 10 seconds, Minimum 1, Maximum 300.
 	PeriodSeconds int32 `json:"period_seconds,omitempty"`
-	// The number of seconds after which the check times out. Default: 1 second.
+	// The number of seconds after which the check times out. Default: 1 second, Minimum 1, Maximum 120.
 	TimeoutSeconds int32 `json:"timeout_seconds,omitempty"`
-	// The number of successful health checks before considered healthy. Default: 1.
+	// The number of successful health checks before considered healthy. Default: 1, Minimum 1, Maximum 50.
 	SuccessThreshold int32 `json:"success_threshold,omitempty"`
-	// The number of failed health checks before considered unhealthy. Default: 9.
+	// The number of failed health checks before considered unhealthy. Default: 9, Minimum 1, Maximum 50.
 	FailureThreshold int32 `json:"failure_threshold,omitempty"`
 	// The route path used for the HTTP health check ping. If not set, the HTTP health check will be disabled and a TCP health check used instead.
 	HTTPPath string `json:"http_path,omitempty"`
 	// The port on which the health check will be performed. If not set, the health check will be performed on the component's http_port.
 	Port int64 `json:"port,omitempty"`
+}
+
+// AppServiceSpecTermination struct for AppServiceSpecTermination
+type AppServiceSpecTermination struct {
+	// The number of seconds to wait between selecting a container instance for termination and issuing the TERM signal. Selecting a container instance for termination begins an asynchronous drain of new requests on upstream load-balancers. Default: 15 seconds, Minimum 1, Maximum 110.
+	DrainSeconds int32 `json:"drain_seconds,omitempty"`
+	// The number of seconds to wait between sending a TERM signal to a container and issuing a KILL which causes immediate shutdown. Default: 120, Minimum 1, Maximum 600.
+	GracePeriodSeconds int32 `json:"grace_period_seconds,omitempty"`
 }
 
 // AppSpec The desired configuration of an application.
@@ -601,7 +617,14 @@ type AppWorkerSpec struct {
 	// A list of configured alerts which apply to the component.
 	Alerts []*AppAlertSpec `json:"alerts,omitempty"`
 	// A list of configured log forwarding destinations.
-	LogDestinations []*AppLogDestinationSpec `json:"log_destinations,omitempty"`
+	LogDestinations []*AppLogDestinationSpec  `json:"log_destinations,omitempty"`
+	Termination     *AppWorkerSpecTermination `json:"termination,omitempty"`
+}
+
+// AppWorkerSpecTermination struct for AppWorkerSpecTermination
+type AppWorkerSpecTermination struct {
+	// The number of seconds to wait between sending a TERM signal to a container and issuing a KILL which causes immediate shutdown. Default: 120, Minimum 1, Maximum 600.
+	GracePeriodSeconds int32 `json:"grace_period_seconds,omitempty"`
 }
 
 // Buildpack struct for Buildpack

--- a/apps_accessors.go
+++ b/apps_accessors.go
@@ -1261,6 +1261,22 @@ func (a *AppJobSpec) GetSourceDir() string {
 	return a.SourceDir
 }
 
+// GetTermination returns the Termination field.
+func (a *AppJobSpec) GetTermination() *AppJobSpecTermination {
+	if a == nil {
+		return nil
+	}
+	return a.Termination
+}
+
+// GetGracePeriodSeconds returns the GracePeriodSeconds field.
+func (a *AppJobSpecTermination) GetGracePeriodSeconds() int32 {
+	if a == nil {
+		return 0
+	}
+	return a.GracePeriodSeconds
+}
+
 // GetDatadog returns the Datadog field.
 func (a *AppLogDestinationSpec) GetDatadog() *AppLogDestinationSpecDataDog {
 	if a == nil {
@@ -1725,6 +1741,14 @@ func (a *AppServiceSpec) GetSourceDir() string {
 	return a.SourceDir
 }
 
+// GetTermination returns the Termination field.
+func (a *AppServiceSpec) GetTermination() *AppServiceSpecTermination {
+	if a == nil {
+		return nil
+	}
+	return a.Termination
+}
+
 // GetFailureThreshold returns the FailureThreshold field.
 func (a *AppServiceSpecHealthCheck) GetFailureThreshold() int32 {
 	if a == nil {
@@ -1787,6 +1811,22 @@ func (a *AppServiceSpecHealthCheck) GetTimeoutSeconds() int32 {
 		return 0
 	}
 	return a.TimeoutSeconds
+}
+
+// GetDrainSeconds returns the DrainSeconds field.
+func (a *AppServiceSpecTermination) GetDrainSeconds() int32 {
+	if a == nil {
+		return 0
+	}
+	return a.DrainSeconds
+}
+
+// GetGracePeriodSeconds returns the GracePeriodSeconds field.
+func (a *AppServiceSpecTermination) GetGracePeriodSeconds() int32 {
+	if a == nil {
+		return 0
+	}
+	return a.GracePeriodSeconds
 }
 
 // GetAlerts returns the Alerts field.
@@ -2235,6 +2275,22 @@ func (a *AppWorkerSpec) GetSourceDir() string {
 		return ""
 	}
 	return a.SourceDir
+}
+
+// GetTermination returns the Termination field.
+func (a *AppWorkerSpec) GetTermination() *AppWorkerSpecTermination {
+	if a == nil {
+		return nil
+	}
+	return a.Termination
+}
+
+// GetGracePeriodSeconds returns the GracePeriodSeconds field.
+func (a *AppWorkerSpecTermination) GetGracePeriodSeconds() int32 {
+	if a == nil {
+		return 0
+	}
+	return a.GracePeriodSeconds
 }
 
 // GetDescription returns the Description field.

--- a/apps_accessors_test.go
+++ b/apps_accessors_test.go
@@ -1105,6 +1105,20 @@ func TestAppJobSpec_GetSourceDir(tt *testing.T) {
 	a.GetSourceDir()
 }
 
+func TestAppJobSpec_GetTermination(tt *testing.T) {
+	a := &AppJobSpec{}
+	a.GetTermination()
+	a = nil
+	a.GetTermination()
+}
+
+func TestAppJobSpecTermination_GetGracePeriodSeconds(tt *testing.T) {
+	a := &AppJobSpecTermination{}
+	a.GetGracePeriodSeconds()
+	a = nil
+	a.GetGracePeriodSeconds()
+}
+
 func TestAppLogDestinationSpec_GetDatadog(tt *testing.T) {
 	a := &AppLogDestinationSpec{}
 	a.GetDatadog()
@@ -1511,6 +1525,13 @@ func TestAppServiceSpec_GetSourceDir(tt *testing.T) {
 	a.GetSourceDir()
 }
 
+func TestAppServiceSpec_GetTermination(tt *testing.T) {
+	a := &AppServiceSpec{}
+	a.GetTermination()
+	a = nil
+	a.GetTermination()
+}
+
 func TestAppServiceSpecHealthCheck_GetFailureThreshold(tt *testing.T) {
 	a := &AppServiceSpecHealthCheck{}
 	a.GetFailureThreshold()
@@ -1565,6 +1586,20 @@ func TestAppServiceSpecHealthCheck_GetTimeoutSeconds(tt *testing.T) {
 	a.GetTimeoutSeconds()
 	a = nil
 	a.GetTimeoutSeconds()
+}
+
+func TestAppServiceSpecTermination_GetDrainSeconds(tt *testing.T) {
+	a := &AppServiceSpecTermination{}
+	a.GetDrainSeconds()
+	a = nil
+	a.GetDrainSeconds()
+}
+
+func TestAppServiceSpecTermination_GetGracePeriodSeconds(tt *testing.T) {
+	a := &AppServiceSpecTermination{}
+	a.GetGracePeriodSeconds()
+	a = nil
+	a.GetGracePeriodSeconds()
 }
 
 func TestAppSpec_GetAlerts(tt *testing.T) {
@@ -1957,6 +1992,20 @@ func TestAppWorkerSpec_GetSourceDir(tt *testing.T) {
 	a.GetSourceDir()
 	a = nil
 	a.GetSourceDir()
+}
+
+func TestAppWorkerSpec_GetTermination(tt *testing.T) {
+	a := &AppWorkerSpec{}
+	a.GetTermination()
+	a = nil
+	a.GetTermination()
+}
+
+func TestAppWorkerSpecTermination_GetGracePeriodSeconds(tt *testing.T) {
+	a := &AppWorkerSpecTermination{}
+	a.GetGracePeriodSeconds()
+	a = nil
+	a.GetGracePeriodSeconds()
 }
 
 func TestBuildpack_GetDescription(tt *testing.T) {

--- a/apps_test.go
+++ b/apps_test.go
@@ -30,6 +30,10 @@ var (
 			},
 			InstanceSizeSlug: "professional-xs",
 			InstanceCount:    1,
+			Termination: &AppServiceSpecTermination{
+				GracePeriodSeconds: 100,
+				DrainSeconds:       60,
+			},
 		}},
 		Workers: []*AppWorkerSpec{{
 			Name:           "worker-name",
@@ -42,6 +46,9 @@ var (
 			},
 			InstanceSizeSlug: "professional-xs",
 			InstanceCount:    1,
+			Termination: &AppWorkerSpecTermination{
+				GracePeriodSeconds: 100,
+			},
 		}},
 		StaticSites: []*AppStaticSiteSpec{{
 			Name:         "static-name",
@@ -63,6 +70,9 @@ var (
 			},
 			InstanceSizeSlug: "professional-xs",
 			InstanceCount:    1,
+			Termination: &AppJobSpecTermination{
+				GracePeriodSeconds: 100,
+			},
 		}},
 		Databases: []*AppDatabaseSpec{{
 			Name:        "db",


### PR DESCRIPTION
This PR adds a Termination struct to App Platform container components (service, worker, job).  All container components now have the ability to configure the GracePeriodSeconds which defines the wait from sending the SIGTERM signal to begin shutdown, to the SIGKILL (non-ignorable shutdown).  Additionally, services now have a DrainSeconds field to configure a delay between starting termination/removing from load-balancers, and sending the SIGTERM.  