### PR TITLE
Add support for GLB active-passive failover config

### DIFF
--- a/load_balancers.go
+++ b/load_balancers.go
@@ -290,6 +290,10 @@ type GLBSettings struct {
 	TargetPort uint32 `json:"target_port"`
 	// CDNSettings is the CDN configurations
 	CDN *CDNSettings `json:"cdn"`
+	// RegionPriorities embeds regional priority information for regional active-passive failover policy
+	RegionPriorities map[string]uint32 `json:"region_priorities,omitempty"`
+	// FailoverThreshold embeds failover threshold percentage for regional active-passive failover policy
+	FailoverThreshold uint32 `json:"failover_threshold,omitempty"`
 }
 
 // String creates a human-readable description of a GLBSettings
@@ -299,8 +303,10 @@ func (s GLBSettings) String() string {
 
 func (s GLBSettings) deepCopy() *GLBSettings {
 	settings := &GLBSettings{
-		TargetProtocol: s.TargetProtocol,
-		TargetPort:     s.TargetPort,
+		TargetProtocol:    s.TargetProtocol,
+		TargetPort:        s.TargetPort,
+		RegionPriorities:  s.RegionPriorities,
+		FailoverThreshold: s.FailoverThreshold,
 	}
 	if s.CDN != nil {
 		settings.CDN = &CDNSettings{IsEnabled: s.CDN.IsEnabled}

--- a/load_balancers_test.go
+++ b/load_balancers_test.go
@@ -211,7 +211,12 @@ var lbCreateJSONResponse = `
             "target_port": 80,
             "cdn": {
                 "is_enabled": true
-            }
+            },
+            "region_priorities": {
+                "nyc1": 1,
+                "nyc2": 2
+            },
+            "failover_threshold": 10
         },
         "target_load_balancer_ids": [
             "8268a81c-fcf5-423e-a337-bbfe95817f24",
@@ -539,9 +544,11 @@ func TestLoadBalancers_Create(t *testing.T) {
 			{Name: "test-domain-2", IsManaged: true, CertificateID: "test-cert-id-2"},
 		},
 		GLBSettings: &GLBSettings{
-			TargetProtocol: "HTTP",
-			TargetPort:     80,
-			CDN:            &CDNSettings{IsEnabled: true},
+			TargetProtocol:    "HTTP",
+			TargetPort:        80,
+			CDN:               &CDNSettings{IsEnabled: true},
+			RegionPriorities:  map[string]uint32{"nyc1": 1, "nyc2": 2},
+			FailoverThreshold: 10,
 		},
 		TargetLoadBalancerIDs: []string{"8268a81c-fcf5-423e-a337-bbfe95817f24", "8268a81c-fcf6-423e-a337-bbfe95817f24"},
 	}
@@ -624,9 +631,11 @@ func TestLoadBalancers_Create(t *testing.T) {
 			{Name: "test-domain-2", IsManaged: true, CertificateID: "test-cert-id-2"},
 		},
 		GLBSettings: &GLBSettings{
-			TargetProtocol: "HTTP",
-			TargetPort:     80,
-			CDN:            &CDNSettings{IsEnabled: true},
+			TargetProtocol:    "HTTP",
+			TargetPort:        80,
+			CDN:               &CDNSettings{IsEnabled: true},
+			RegionPriorities:  map[string]uint32{"nyc1": 1, "nyc2": 2},
+			FailoverThreshold: 10,
 		},
 		TargetLoadBalancerIDs: []string{"8268a81c-fcf5-423e-a337-bbfe95817f24", "8268a81c-fcf6-423e-a337-bbfe95817f24"},
 	}


### PR DESCRIPTION
Introduce config flag to support active-passive failover policy for Global Load Balancers. 