### PR TITLE
APPS-8732 - Add OpenSearch as a Log Destination for App Platform.

### DIFF
--- a/apps.gen.go
+++ b/apps.gen.go
@@ -221,6 +221,7 @@ const (
 	AppDatabaseSpecEngine_PG      AppDatabaseSpecEngine = "PG"
 	AppDatabaseSpecEngine_Redis   AppDatabaseSpecEngine = "REDIS"
 	AppDatabaseSpecEngine_MongoDB AppDatabaseSpecEngine = "MONGODB"
+	AppDatabaseSpecEngine_Kafka   AppDatabaseSpecEngine = "KAFKA"
 )
 
 // AppDedicatedIp Represents a dedicated egress ip.
@@ -415,6 +416,7 @@ type AppLogDestinationSpec struct {
 	Papertrail  *AppLogDestinationSpecPapertrail `json:"papertrail,omitempty"`
 	Datadog     *AppLogDestinationSpecDataDog    `json:"datadog,omitempty"`
 	Logtail     *AppLogDestinationSpecLogtail    `json:"logtail,omitempty"`
+	OpenSearch  *AppLogDestinationSpecOpenSearch `json:"open_search,omitempty"`
 	Endpoint    string                           `json:"endpoint,omitempty"`
 	TLSInsecure bool                             `json:"tls_insecure,omitempty"`
 	Headers     []*AppLogDestinationSpecHeader   `json:"headers,omitempty"`
@@ -440,6 +442,15 @@ type AppLogDestinationSpecHeader struct {
 type AppLogDestinationSpecLogtail struct {
 	// Logtail token.
 	Token string `json:"token"`
+}
+
+// AppLogDestinationSpecOpenSearch OpenSearch configuration.
+type AppLogDestinationSpecOpenSearch struct {
+	// OpenSearch API Endpoint. Only HTTPS is supported. Format: https://<host>:<port>. Default port is 9300.
+	Endpoint  string               `json:"endpoint"`
+	BasicAuth *OpenSearchBasicAuth `json:"basic_auth,omitempty"`
+	// The index name to use for the logs. If not set, the default index name is \"logs\".
+	IndexName string `json:"index_name,omitempty"`
 }
 
 // AppLogDestinationSpecPapertrail Papertrail configuration.
@@ -1169,6 +1180,14 @@ const (
 type ListBuildpacksResponse struct {
 	// List of the available buildpacks on App Platform.
 	Buildpacks []*Buildpack `json:"buildpacks,omitempty"`
+}
+
+// OpenSearchBasicAuth Configure Username and/or Password for Basic authentication.
+type OpenSearchBasicAuth struct {
+	// Username to authenticate with.
+	User string `json:"user"`
+	// Password for user defined in User.
+	Password string `json:"password"`
 }
 
 // AppProposeRequest struct for AppProposeRequest

--- a/apps_accessors.go
+++ b/apps_accessors.go
@@ -1317,6 +1317,14 @@ func (a *AppLogDestinationSpec) GetName() string {
 	return a.Name
 }
 
+// GetOpenSearch returns the OpenSearch field.
+func (a *AppLogDestinationSpec) GetOpenSearch() *AppLogDestinationSpecOpenSearch {
+	if a == nil {
+		return nil
+	}
+	return a.OpenSearch
+}
+
 // GetPapertrail returns the Papertrail field.
 func (a *AppLogDestinationSpec) GetPapertrail() *AppLogDestinationSpecPapertrail {
 	if a == nil {
@@ -1371,6 +1379,30 @@ func (a *AppLogDestinationSpecLogtail) GetToken() string {
 		return ""
 	}
 	return a.Token
+}
+
+// GetBasicAuth returns the BasicAuth field.
+func (a *AppLogDestinationSpecOpenSearch) GetBasicAuth() *OpenSearchBasicAuth {
+	if a == nil {
+		return nil
+	}
+	return a.BasicAuth
+}
+
+// GetEndpoint returns the Endpoint field.
+func (a *AppLogDestinationSpecOpenSearch) GetEndpoint() string {
+	if a == nil {
+		return ""
+	}
+	return a.Endpoint
+}
+
+// GetIndexName returns the IndexName field.
+func (a *AppLogDestinationSpecOpenSearch) GetIndexName() string {
+	if a == nil {
+		return ""
+	}
+	return a.IndexName
 }
 
 // GetEndpoint returns the Endpoint field.
@@ -3531,6 +3563,22 @@ func (l *ListBuildpacksResponse) GetBuildpacks() []*Buildpack {
 		return nil
 	}
 	return l.Buildpacks
+}
+
+// GetPassword returns the Password field.
+func (o *OpenSearchBasicAuth) GetPassword() string {
+	if o == nil {
+		return ""
+	}
+	return o.Password
+}
+
+// GetUser returns the User field.
+func (o *OpenSearchBasicAuth) GetUser() string {
+	if o == nil {
+		return ""
+	}
+	return o.User
 }
 
 // GetAppID returns the AppID field.

--- a/apps_accessors_test.go
+++ b/apps_accessors_test.go
@@ -888,6 +888,13 @@ func TestAppIngressSpecRuleStringMatch_GetPrefix(tt *testing.T) {
 	a.GetPrefix()
 }
 
+func TestAppInstanceSize_GetBandwidthAllowanceGib(tt *testing.T) {
+	a := &AppInstanceSize{}
+	a.GetBandwidthAllowanceGib()
+	a = nil
+	a.GetBandwidthAllowanceGib()
+}
+
 func TestAppInstanceSize_GetCPUs(tt *testing.T) {
 	a := &AppInstanceSize{}
 	a.GetCPUs()
@@ -942,13 +949,6 @@ func TestAppInstanceSize_GetSingleInstanceOnly(tt *testing.T) {
 	a.GetSingleInstanceOnly()
 	a = nil
 	a.GetSingleInstanceOnly()
-}
-
-func TestAppInstanceSize_GetBandwidthAllowanceGib(tt *testing.T) {
-	a := &AppInstanceSize{}
-	a.GetBandwidthAllowanceGib()
-	a = nil
-	a.GetBandwidthAllowanceGib()
 }
 
 func TestAppInstanceSize_GetSlug(tt *testing.T) {
@@ -1154,6 +1154,13 @@ func TestAppLogDestinationSpec_GetName(tt *testing.T) {
 	a.GetName()
 }
 
+func TestAppLogDestinationSpec_GetOpenSearch(tt *testing.T) {
+	a := &AppLogDestinationSpec{}
+	a.GetOpenSearch()
+	a = nil
+	a.GetOpenSearch()
+}
+
 func TestAppLogDestinationSpec_GetPapertrail(tt *testing.T) {
 	a := &AppLogDestinationSpec{}
 	a.GetPapertrail()
@@ -1201,6 +1208,27 @@ func TestAppLogDestinationSpecLogtail_GetToken(tt *testing.T) {
 	a.GetToken()
 	a = nil
 	a.GetToken()
+}
+
+func TestAppLogDestinationSpecOpenSearch_GetBasicAuth(tt *testing.T) {
+	a := &AppLogDestinationSpecOpenSearch{}
+	a.GetBasicAuth()
+	a = nil
+	a.GetBasicAuth()
+}
+
+func TestAppLogDestinationSpecOpenSearch_GetEndpoint(tt *testing.T) {
+	a := &AppLogDestinationSpecOpenSearch{}
+	a.GetEndpoint()
+	a = nil
+	a.GetEndpoint()
+}
+
+func TestAppLogDestinationSpecOpenSearch_GetIndexName(tt *testing.T) {
+	a := &AppLogDestinationSpecOpenSearch{}
+	a.GetIndexName()
+	a = nil
+	a.GetIndexName()
 }
 
 func TestAppLogDestinationSpecPapertrail_GetEndpoint(tt *testing.T) {
@@ -3091,6 +3119,20 @@ func TestListBuildpacksResponse_GetBuildpacks(tt *testing.T) {
 	l.GetBuildpacks()
 	l = nil
 	l.GetBuildpacks()
+}
+
+func TestOpenSearchBasicAuth_GetPassword(tt *testing.T) {
+	o := &OpenSearchBasicAuth{}
+	o.GetPassword()
+	o = nil
+	o.GetPassword()
+}
+
+func TestOpenSearchBasicAuth_GetUser(tt *testing.T) {
+	o := &OpenSearchBasicAuth{}
+	o.GetUser()
+	o = nil
+	o.GetUser()
 }
 
 func TestResetDatabasePasswordRequest_GetAppID(tt *testing.T) {


### PR DESCRIPTION
This PR adds OpenSearch as a Log Destination for App Platform.