### PR TITLE
Add support for lb internal network type

### DIFF
--- a/load_balancers.go
+++ b/load_balancers.go
@@ -13,11 +13,15 @@ const (
 	loadBalancersBasePath = "/v2/load_balancers"
 )
 
-// Load Balancer types.
 const (
+	// Load Balancer types
 	LoadBalancerTypeGlobal          = "GLOBAL"
 	LoadBalancerTypeRegional        = "REGIONAL"
 	LoadBalancerTypeRegionalNetwork = "REGIONAL_NETWORK"
+
+	// Load Balancer network types
+	LoadBalancerNetworkTypeExternal = "EXTERNAL"
+	LoadBalancerNetworkTypeInternal = "INTERNAL"
 )
 
 // LoadBalancersService is an interface for managing load balancers with the DigitalOcean API.

--- a/load_balancers.go
+++ b/load_balancers.go
@@ -68,6 +68,7 @@ type LoadBalancer struct {
 	Domains                      []*LBDomain      `json:"domains,omitempty"`
 	GLBSettings                  *GLBSettings     `json:"glb_settings,omitempty"`
 	TargetLoadBalancerIDs        []string         `json:"target_load_balancer_ids,omitempty"`
+	Network                      string           `json:"network,omitempty"`
 }
 
 // String creates a human-readable description of a LoadBalancer.
@@ -101,6 +102,7 @@ func (l LoadBalancer) AsRequest() *LoadBalancerRequest {
 		ProjectID:                    l.ProjectID,
 		HTTPIdleTimeoutSeconds:       l.HTTPIdleTimeoutSeconds,
 		TargetLoadBalancerIDs:        append([]string(nil), l.TargetLoadBalancerIDs...),
+		Network:                      l.Network,
 	}
 
 	if l.DisableLetsEncryptDNSRecords != nil {
@@ -238,6 +240,7 @@ type LoadBalancerRequest struct {
 	Domains                      []*LBDomain      `json:"domains,omitempty"`
 	GLBSettings                  *GLBSettings     `json:"glb_settings,omitempty"`
 	TargetLoadBalancerIDs        []string         `json:"target_load_balancer_ids,omitempty"`
+	Network                      string           `json:"network,omitempty"`
 }
 
 // String creates a human-readable description of a LoadBalancerRequest.

--- a/load_balancers_test.go
+++ b/load_balancers_test.go
@@ -552,7 +552,7 @@ func TestLoadBalancers_Create(t *testing.T) {
 			FailoverThreshold: 10,
 		},
 		TargetLoadBalancerIDs: []string{"8268a81c-fcf5-423e-a337-bbfe95817f24", "8268a81c-fcf6-423e-a337-bbfe95817f24"},
-		Network:               "INTERNAL",
+		Network:               LoadBalancerNetworkTypeInternal,
 	}
 
 	path := "/v2/load_balancers"
@@ -640,7 +640,7 @@ func TestLoadBalancers_Create(t *testing.T) {
 			FailoverThreshold: 10,
 		},
 		TargetLoadBalancerIDs: []string{"8268a81c-fcf5-423e-a337-bbfe95817f24", "8268a81c-fcf6-423e-a337-bbfe95817f24"},
-		Network:               "INTERNAL",
+		Network:               LoadBalancerNetworkTypeInternal,
 	}
 
 	disableLetsEncryptDNSRecords := true

--- a/load_balancers_test.go
+++ b/load_balancers_test.go
@@ -221,7 +221,8 @@ var lbCreateJSONResponse = `
         "target_load_balancer_ids": [
             "8268a81c-fcf5-423e-a337-bbfe95817f24",
             "8268a81c-fcf6-423e-a337-bbfe95817f24"
-        ]
+        ],
+		"network": "INTERNAL"
     }
 }
 `
@@ -551,6 +552,7 @@ func TestLoadBalancers_Create(t *testing.T) {
 			FailoverThreshold: 10,
 		},
 		TargetLoadBalancerIDs: []string{"8268a81c-fcf5-423e-a337-bbfe95817f24", "8268a81c-fcf6-423e-a337-bbfe95817f24"},
+		Network:               "INTERNAL",
 	}
 
 	path := "/v2/load_balancers"
@@ -638,6 +640,7 @@ func TestLoadBalancers_Create(t *testing.T) {
 			FailoverThreshold: 10,
 		},
 		TargetLoadBalancerIDs: []string{"8268a81c-fcf5-423e-a337-bbfe95817f24", "8268a81c-fcf6-423e-a337-bbfe95817f24"},
+		Network:               "INTERNAL",
 	}
 
 	disableLetsEncryptDNSRecords := true


### PR DESCRIPTION
This change introduces network type support for load balancers resources, which defines the type of network the resource will be accessible from.  