### PR TITLE
APPS-8790 Add support to App Platform Log Forwarding for an OpenSearch DBaaS cluster destination.

### DIFF
--- a/apps.gen.go
+++ b/apps.gen.go
@@ -1158,7 +1158,8 @@ type AppInstanceSize struct {
 	// (Deprecated) The slug of the corresponding downgradable instance size on the lower tier.
 	TierDowngradeTo string `json:"tier_downgrade_to,omitempty"`
 	// Indicates if the tier instance size can enable autoscaling.
-	Scalable       bool `json:"scalable,omitempty"`
+	Scalable bool `json:"scalable,omitempty"`
+	// (Deprecated) Indicates if the tier instance size is in feature preview state.
 	FeaturePreview bool `json:"feature_preview,omitempty"`
 	// Indicates if the tier instance size allows more than one instance.
 	SingleInstanceOnly bool `json:"single_instance_only,omitempty"`

--- a/apps.gen.go
+++ b/apps.gen.go
@@ -446,11 +446,13 @@ type AppLogDestinationSpecLogtail struct {
 
 // AppLogDestinationSpecOpenSearch OpenSearch configuration.
 type AppLogDestinationSpecOpenSearch struct {
-	// OpenSearch API Endpoint. Only HTTPS is supported. Format: https://<host>:<port>.
-	Endpoint  string               `json:"endpoint"`
+	// OpenSearch API Endpoint. Only HTTPS is supported. Format: https://<host>:<port>. Cannot be specified if `cluster_name` is also specified.
+	Endpoint  string               `json:"endpoint,omitempty"`
 	BasicAuth *OpenSearchBasicAuth `json:"basic_auth,omitempty"`
 	// The index name to use for the logs. If not set, the default index name is \"logs\".
 	IndexName string `json:"index_name,omitempty"`
+	// The name of a DigitalOcean DBaaS OpenSearch cluster to use as a log forwarding destination. Cannot be specified if `endpoint` is also specified.
+	ClusterName string `json:"cluster_name,omitempty"`
 }
 
 // AppLogDestinationSpecPapertrail Papertrail configuration.
@@ -1184,10 +1186,10 @@ type ListBuildpacksResponse struct {
 
 // OpenSearchBasicAuth Configure Username and/or Password for Basic authentication.
 type OpenSearchBasicAuth struct {
-	// Username to authenticate with.
-	User string `json:"user"`
-	// Password for user defined in User.
-	Password string `json:"password"`
+	// Username to authenticate with. Only required when `endpoint` is set. Defaults to `doadmin` when `cluster_name` is set.
+	User string `json:"user,omitempty"`
+	// Password for user defined in User. Is required when `endpoint` is set. Cannot be set if using a DigitalOcean DBaaS OpenSearch cluster.
+	Password string `json:"password,omitempty"`
 }
 
 // AppProposeRequest struct for AppProposeRequest

--- a/apps_accessors.go
+++ b/apps_accessors.go
@@ -1389,6 +1389,14 @@ func (a *AppLogDestinationSpecOpenSearch) GetBasicAuth() *OpenSearchBasicAuth {
 	return a.BasicAuth
 }
 
+// GetClusterName returns the ClusterName field.
+func (a *AppLogDestinationSpecOpenSearch) GetClusterName() string {
+	if a == nil {
+		return ""
+	}
+	return a.ClusterName
+}
+
 // GetEndpoint returns the Endpoint field.
 func (a *AppLogDestinationSpecOpenSearch) GetEndpoint() string {
 	if a == nil {

--- a/apps_accessors_test.go
+++ b/apps_accessors_test.go
@@ -1217,6 +1217,13 @@ func TestAppLogDestinationSpecOpenSearch_GetBasicAuth(tt *testing.T) {
 	a.GetBasicAuth()
 }
 
+func TestAppLogDestinationSpecOpenSearch_GetClusterName(tt *testing.T) {
+	a := &AppLogDestinationSpecOpenSearch{}
+	a.GetClusterName()
+	a = nil
+	a.GetClusterName()
+}
+
 func TestAppLogDestinationSpecOpenSearch_GetEndpoint(tt *testing.T) {
 	a := &AppLogDestinationSpecOpenSearch{}
 	a.GetEndpoint()


### PR DESCRIPTION
This PR adds support to App Platform Log Forwarding for an OpenSearch DBaaS cluster destination.

**DO NOT MERGE UNTIL 2024-06-20**