### PR TITLE
Add ProxyProtocol to LoadBalancer HealthCheck

### DIFF
--- a/load_balancers.go
+++ b/load_balancers.go
@@ -170,6 +170,7 @@ type HealthCheck struct {
 	ResponseTimeoutSeconds int    `json:"response_timeout_seconds,omitempty"`
 	HealthyThreshold       int    `json:"healthy_threshold,omitempty"`
 	UnhealthyThreshold     int    `json:"unhealthy_threshold,omitempty"`
+	ProxyProtocol          *bool  `json:"proxy_protocol,omitempty"`
 }
 
 // String creates a human-readable description of a HealthCheck.

--- a/load_balancers_test.go
+++ b/load_balancers_test.go
@@ -1181,6 +1181,7 @@ func TestLoadBalancers_AsRequest(t *testing.T) {
 			ResponseTimeoutSeconds: 10,
 			HealthyThreshold:       3,
 			UnhealthyThreshold:     3,
+			ProxyProtocol:          PtrTo(true),
 		},
 		StickySessions: &StickySessions{
 			Type:             "cookies",
@@ -1242,6 +1243,7 @@ func TestLoadBalancers_AsRequest(t *testing.T) {
 			ResponseTimeoutSeconds: 10,
 			HealthyThreshold:       3,
 			UnhealthyThreshold:     3,
+			ProxyProtocol:          PtrTo(true),
 		},
 		StickySessions: &StickySessions{
 			Type:             "cookies",


### PR DESCRIPTION
This will allow customers to enable/disable PROXY protocol on their health checks. If no value is provided then it will default to the LBs PROXY protocol config.