### PR TITLE
Rename control plane permission to control plane firewall

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -76,20 +76,20 @@ type KubernetesClusterCreateRequest struct {
 
 	NodePools []*KubernetesNodePoolCreateRequest `json:"node_pools,omitempty"`
 
-	MaintenancePolicy      *KubernetesMaintenancePolicy      `json:"maintenance_policy"`
-	AutoUpgrade            bool                              `json:"auto_upgrade"`
-	SurgeUpgrade           bool                              `json:"surge_upgrade"`
-	ControlPlanePermission *KubernetesControlPlanePermission `json:"control_plane_permission,omitempty"`
+	MaintenancePolicy    *KubernetesMaintenancePolicy    `json:"maintenance_policy"`
+	AutoUpgrade          bool                            `json:"auto_upgrade"`
+	SurgeUpgrade         bool                            `json:"surge_upgrade"`
+	ControlPlaneFirewall *KubernetesControlPlaneFirewall `json:"control_plane_firewall,omitempty"`
 }
 
 // KubernetesClusterUpdateRequest represents a request to update a Kubernetes cluster.
 type KubernetesClusterUpdateRequest struct {
-	Name                   string                            `json:"name,omitempty"`
-	Tags                   []string                          `json:"tags,omitempty"`
-	MaintenancePolicy      *KubernetesMaintenancePolicy      `json:"maintenance_policy,omitempty"`
-	AutoUpgrade            *bool                             `json:"auto_upgrade,omitempty"`
-	SurgeUpgrade           bool                              `json:"surge_upgrade,omitempty"`
-	ControlPlanePermission *KubernetesControlPlanePermission `json:"control_plane_permission,omitempty"`
+	Name                 string                          `json:"name,omitempty"`
+	Tags                 []string                        `json:"tags,omitempty"`
+	MaintenancePolicy    *KubernetesMaintenancePolicy    `json:"maintenance_policy,omitempty"`
+	AutoUpgrade          *bool                           `json:"auto_upgrade,omitempty"`
+	SurgeUpgrade         bool                            `json:"surge_upgrade,omitempty"`
+	ControlPlaneFirewall *KubernetesControlPlaneFirewall `json:"control_plane_firewall,omitempty"`
 
 	// Convert cluster to run highly available control plane
 	HA *bool `json:"ha,omitempty"`
@@ -203,11 +203,11 @@ type KubernetesCluster struct {
 
 	NodePools []*KubernetesNodePool `json:"node_pools,omitempty"`
 
-	MaintenancePolicy      *KubernetesMaintenancePolicy      `json:"maintenance_policy,omitempty"`
-	AutoUpgrade            bool                              `json:"auto_upgrade,omitempty"`
-	SurgeUpgrade           bool                              `json:"surge_upgrade,omitempty"`
-	RegistryEnabled        bool                              `json:"registry_enabled,omitempty"`
-	ControlPlanePermission *KubernetesControlPlanePermission `json:"control_plane_permission,omitempty"`
+	MaintenancePolicy    *KubernetesMaintenancePolicy    `json:"maintenance_policy,omitempty"`
+	AutoUpgrade          bool                            `json:"auto_upgrade,omitempty"`
+	SurgeUpgrade         bool                            `json:"surge_upgrade,omitempty"`
+	RegistryEnabled      bool                            `json:"registry_enabled,omitempty"`
+	ControlPlaneFirewall *KubernetesControlPlaneFirewall `json:"control_plane_firewall,omitempty"`
 
 	Status    *KubernetesClusterStatus `json:"status,omitempty"`
 	CreatedAt time.Time                `json:"created_at,omitempty"`
@@ -243,8 +243,8 @@ type KubernetesMaintenancePolicy struct {
 	Day       KubernetesMaintenancePolicyDay `json:"day"`
 }
 
-// KubernetesControlPlanePermission represents Kubernetes cluster control plane permission.
-type KubernetesControlPlanePermission struct {
+// KubernetesControlPlaneFirewall represents Kubernetes cluster control plane firewall.
+type KubernetesControlPlaneFirewall struct {
 	Enabled          *bool    `json:"enabled"`
 	AllowedAddresses []string `json:"allowed_addresses"`
 }

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -569,7 +569,7 @@ func TestKubernetesClusters_Create(t *testing.T) {
 			StartTime: "00:00",
 			Day:       KubernetesMaintenanceDayMonday,
 		},
-		ControlPlanePermission: &KubernetesControlPlanePermission{
+		ControlPlaneFirewall: &KubernetesControlPlaneFirewall{
 			Enabled: &enabled,
 			AllowedAddresses: []string{
 				"1.2.3.4/32",
@@ -633,7 +633,7 @@ func TestKubernetesClusters_Create(t *testing.T) {
 			"start_time": "00:00",
 			"day": "monday"
 		},
-        "control_plane_permission": {
+        "control_plane_firewall": {
              "enabled": true,
              "allowed_addresses": [
                  "1.2.3.4/32"
@@ -797,7 +797,7 @@ func TestKubernetesClusters_Update(t *testing.T) {
 			StartTime: "00:00",
 			Day:       KubernetesMaintenanceDayMonday,
 		},
-		ControlPlanePermission: &KubernetesControlPlanePermission{
+		ControlPlaneFirewall: &KubernetesControlPlaneFirewall{
 			Enabled: &enabled,
 			AllowedAddresses: []string{
 				"1.2.3.4/32",
@@ -809,7 +809,7 @@ func TestKubernetesClusters_Update(t *testing.T) {
 		Tags:              want.Tags,
 		MaintenancePolicy: want.MaintenancePolicy,
 		SurgeUpgrade:      true,
-		ControlPlanePermission: &KubernetesControlPlanePermission{
+		ControlPlaneFirewall: &KubernetesControlPlaneFirewall{
 			Enabled: &enabled,
 			AllowedAddresses: []string{
 				"1.2.3.4/32",

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -851,7 +851,7 @@ func TestKubernetesClusters_Update(t *testing.T) {
 			"start_time": "00:00",
 			"day": "monday"
 		},
-		"control_plane_permission": {
+		"control_plane_firewall": {
              "enabled": true,
              "allowed_addresses": [
                  "1.2.3.4/32"
@@ -860,7 +860,7 @@ func TestKubernetesClusters_Update(t *testing.T) {
 	}
 }`
 
-	expectedReqJSON := `{"name":"antoine-test-cluster","tags":["cluster-tag-1","cluster-tag-2"],"maintenance_policy":{"start_time":"00:00","duration":"","day":"monday"},"surge_upgrade":true,"control_plane_permission":{"enabled":true,"allowed_addresses":["1.2.3.4/32"]}}
+	expectedReqJSON := `{"name":"antoine-test-cluster","tags":["cluster-tag-1","cluster-tag-2"],"maintenance_policy":{"start_time":"00:00","duration":"","day":"monday"},"surge_upgrade":true,"control_plane_firewall":{"enabled":true,"allowed_addresses":["1.2.3.4/32"]}}
 `
 
 	mux.HandleFunc("/v2/kubernetes/clusters/8d91899c-0739-4a1a-acc5-deadbeefbb8f", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Discussed with @timoreimann and figured that we should rename this property and payload from `ControlPlanePermission` to `ControlPlaneFirewall`. 