### PR TITLE
APPS-8398: Remove ListTiers and GetTier APIs

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -43,9 +43,6 @@ type AppsService interface {
 
 	ListRegions(ctx context.Context) ([]*AppRegion, *Response, error)
 
-	ListTiers(ctx context.Context) ([]*AppTier, *Response, error)
-	GetTier(ctx context.Context, slug string) (*AppTier, *Response, error)
-
 	ListInstanceSizes(ctx context.Context) ([]*AppInstanceSize, *Response, error)
 	GetInstanceSize(ctx context.Context, slug string) (*AppInstanceSize, *Response, error)
 
@@ -379,36 +376,6 @@ func (s *AppsServiceOp) ListRegions(ctx context.Context) ([]*AppRegion, *Respons
 		return nil, resp, err
 	}
 	return root.Regions, resp, nil
-}
-
-// ListTiers lists available app tiers.
-func (s *AppsServiceOp) ListTiers(ctx context.Context) ([]*AppTier, *Response, error) {
-	path := fmt.Sprintf("%s/tiers", appsBasePath)
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return nil, nil, err
-	}
-	root := new(appTiersRoot)
-	resp, err := s.client.Do(ctx, req, root)
-	if err != nil {
-		return nil, resp, err
-	}
-	return root.Tiers, resp, nil
-}
-
-// GetTier retrieves information about a specific app tier.
-func (s *AppsServiceOp) GetTier(ctx context.Context, slug string) (*AppTier, *Response, error) {
-	path := fmt.Sprintf("%s/tiers/%s", appsBasePath, slug)
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return nil, nil, err
-	}
-	root := new(appTierRoot)
-	resp, err := s.client.Do(ctx, req, root)
-	if err != nil {
-		return nil, resp, err
-	}
-	return root.Tier, resp, nil
 }
 
 // ListInstanceSizes lists available instance sizes for service, worker, and job components.

--- a/apps_test.go
+++ b/apps_test.go
@@ -577,40 +577,6 @@ func TestApps_ListRegions(t *testing.T) {
 	assert.Equal(t, []*AppRegion{&testAppRegion}, regions)
 }
 
-func TestApps_ListTiers(t *testing.T) {
-	setup()
-	defer teardown()
-
-	ctx := context.Background()
-
-	mux.HandleFunc("/v2/apps/tiers", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, http.MethodGet)
-
-		json.NewEncoder(w).Encode(&appTiersRoot{Tiers: []*AppTier{&testAppTier}})
-	})
-
-	tiers, _, err := client.Apps.ListTiers(ctx)
-	require.NoError(t, err)
-	assert.Equal(t, []*AppTier{&testAppTier}, tiers)
-}
-
-func TestApps_GetTier(t *testing.T) {
-	setup()
-	defer teardown()
-
-	ctx := context.Background()
-
-	mux.HandleFunc(fmt.Sprintf("/v2/apps/tiers/%s", testAppTier.Slug), func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, http.MethodGet)
-
-		json.NewEncoder(w).Encode(&appTierRoot{Tier: &testAppTier})
-	})
-
-	tier, _, err := client.Apps.GetTier(ctx, testAppTier.Slug)
-	require.NoError(t, err)
-	assert.Equal(t, &testAppTier, tier)
-}
-
 func TestApps_ListInstanceSizes(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
Customer comms have already been sent out with a deadline of July 17th. [Remaining usage](https://logs.internal.digitalocean.com/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-2w,to:now))&_a=(columns:!(msg,request_method,request_path,response_status,request_user_agent,user_id,X-Org-Id),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:edge,key:msg,negate:!f,params:(query:'outgoing%20response'),type:phrase),query:(match_phrase:(msg:'outgoing%20response'))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:edge,key:response_status,negate:!f,params:(query:200),type:phrase),query:(match_phrase:(response_status:200)))),index:edge,interval:auto,query:(language:kuery,query:'request_path:%22%2Fv2%2Fapps%2Ftiers%22%20AND%20NOT%20(request_path:%22%2Fv2%2Fapps%2Ftiers%2Finstance_sizes%22)'),sort:!(!('@timestamp',desc))))  has also declined.