### PR TITLE
APPS-9201 Add `UpdateAllSourceVersions` parameter to update app calls

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -80,6 +80,8 @@ type AppLogs struct {
 // AppUpdateRequest represents a request to update an app.
 type AppUpdateRequest struct {
 	Spec *AppSpec `json:"spec"`
+	// Whether or not to update the source versions (for example fetching a new commit or image digest) of all components. By default (when this is false) only newly added sources will be updated to avoid changes like updating the scale of a component from also updating the respective code.
+	UpdateAllSourceVersions bool `json:"update_all_source_versions"`
 }
 
 // DeploymentCreateRequest represents a request to create a deployment.

--- a/apps_test.go
+++ b/apps_test.go
@@ -345,11 +345,12 @@ func TestApps_UpdateApp(t *testing.T) {
 		err := json.NewDecoder(r.Body).Decode(&req)
 		require.NoError(t, err)
 		assert.Equal(t, &updatedSpec, req.Spec)
+		assert.True(t, req.UpdateAllSourceVersions)
 
 		json.NewEncoder(w).Encode(&appRoot{App: &testApp})
 	})
 
-	app, _, err := client.Apps.Update(ctx, testApp.ID, &AppUpdateRequest{Spec: &updatedSpec})
+	app, _, err := client.Apps.Update(ctx, testApp.ID, &AppUpdateRequest{Spec: &updatedSpec, UpdateAllSourceVersions: true})
 	require.NoError(t, err)
 	assert.Equal(t, &testApp, app)
 }


### PR DESCRIPTION
This new parameter allows the `UpdateApp` call to cause an update of all sources (similar to how a `CreateDeployment` call would work), while also updating the spec in one call.