### PR TITLE
Bump go version to 1.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [ 1.20.x, 1.21.x ]
+        go-version: [ 1.22.x, 1.23.x ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/digitalocean/godo
 
-go 1.21
+go 1.22
 
 require (
 	github.com/google/go-querystring v1.1.0

--- a/registry_test.go
+++ b/registry_test.go
@@ -412,7 +412,7 @@ func TestRepository_ListTags(t *testing.T) {
 	}
 }`
 
-	mux.HandleFunc(fmt.Sprintf("/v2/registry/%s/repositories/%s/tags", testRegistry, testRepository), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/v2/registry/%s/repositories/%s/tags", testRegistry, testEncodedRepository), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		testFormValues(t, r, map[string]string{"page": "1", "per_page": "1"})
 		fmt.Fprint(w, getResponseJSON)
@@ -441,7 +441,7 @@ func TestRegistry_DeleteTag(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mux.HandleFunc(fmt.Sprintf("/v2/registry/%s/repositories/%s/tags/%s", testRegistry, testRepository, testTag), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/v2/registry/%s/repositories/%s/tags/%s", testRegistry, testEncodedRepository, testTag), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
 	})
 
@@ -510,7 +510,7 @@ func TestRegistry_ListManifests(t *testing.T) {
 	}
 }`
 
-	mux.HandleFunc(fmt.Sprintf("/v2/registry/%s/repositories/%s/digests", testRegistry, testRepository), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/v2/registry/%s/repositories/%s/digests", testRegistry, testEncodedRepository), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		testFormValues(t, r, map[string]string{"page": "3", "per_page": "1"})
 		fmt.Fprint(w, getResponseJSON)
@@ -541,7 +541,7 @@ func TestRegistry_DeleteManifest(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mux.HandleFunc(fmt.Sprintf("/v2/registry/%s/repositories/%s/digests/%s", testRegistry, testRepository, testDigest), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/v2/registry/%s/repositories/%s/digests/%s", testRegistry, testEncodedRepository, testDigest), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
 	})
 


### PR DESCRIPTION
This updates to Go 1.22 following our stated Go support policy:

https://github.com/digitalocean/godo/blob/2e0eaabbd1e18eb13ce8d4c2539edba820dcf18f/CONTRIBUTING.md?plain=1#L71-L77

The test changes are due to new `net/http.ServeMux` behavior in Go 1.22. 