### PR TITLE
APPS-8398: Retire list and get app tiers

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -43,9 +43,6 @@ type AppsService interface {
 
 	ListRegions(ctx context.Context) ([]*AppRegion, *Response, error)
 
-	ListTiers(ctx context.Context) ([]*AppTier, *Response, error)
-	GetTier(ctx context.Context, slug string) (*AppTier, *Response, error)
-
 	ListInstanceSizes(ctx context.Context) ([]*AppInstanceSize, *Response, error)
 	GetInstanceSize(ctx context.Context, slug string) (*AppInstanceSize, *Response, error)
 
@@ -129,14 +126,6 @@ type deploymentsRoot struct {
 	Deployments []*Deployment `json:"deployments"`
 	Links       *Links        `json:"links"`
 	Meta        *Meta         `json:"meta"`
-}
-
-type appTierRoot struct {
-	Tier *AppTier `json:"tier"`
-}
-
-type appTiersRoot struct {
-	Tiers []*AppTier `json:"tiers"`
 }
 
 type instanceSizeRoot struct {
@@ -381,42 +370,6 @@ func (s *AppsServiceOp) ListRegions(ctx context.Context) ([]*AppRegion, *Respons
 		return nil, resp, err
 	}
 	return root.Regions, resp, nil
-}
-
-// ListTiers lists available app tiers.
-//
-// Deprecated: The '/v2/apps/tiers' endpoint has been deprecated as app tiers
-// are no longer tied to instance sizes. The concept of tiers is being retired.
-func (s *AppsServiceOp) ListTiers(ctx context.Context) ([]*AppTier, *Response, error) {
-	path := fmt.Sprintf("%s/tiers", appsBasePath)
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return nil, nil, err
-	}
-	root := new(appTiersRoot)
-	resp, err := s.client.Do(ctx, req, root)
-	if err != nil {
-		return nil, resp, err
-	}
-	return root.Tiers, resp, nil
-}
-
-// GetTier retrieves information about a specific app tier.
-//
-// Deprecated: The '/v2/apps/tiers/{slug}' endpoints have been deprecated as app
-// tiers are no longer tied to instance sizes. The concept of tiers is being retired.
-func (s *AppsServiceOp) GetTier(ctx context.Context, slug string) (*AppTier, *Response, error) {
-	path := fmt.Sprintf("%s/tiers/%s", appsBasePath, slug)
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return nil, nil, err
-	}
-	root := new(appTierRoot)
-	resp, err := s.client.Do(ctx, req, root)
-	if err != nil {
-		return nil, resp, err
-	}
-	return root.Tier, resp, nil
 }
 
 // ListInstanceSizes lists available instance sizes for service, worker, and job components.

--- a/apps_test.go
+++ b/apps_test.go
@@ -578,40 +578,6 @@ func TestApps_ListRegions(t *testing.T) {
 	assert.Equal(t, []*AppRegion{&testAppRegion}, regions)
 }
 
-func TestApps_ListTiers(t *testing.T) {
-	setup()
-	defer teardown()
-
-	ctx := context.Background()
-
-	mux.HandleFunc("/v2/apps/tiers", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, http.MethodGet)
-
-		json.NewEncoder(w).Encode(&appTiersRoot{Tiers: []*AppTier{&testAppTier}})
-	})
-
-	tiers, _, err := client.Apps.ListTiers(ctx)
-	require.NoError(t, err)
-	assert.Equal(t, []*AppTier{&testAppTier}, tiers)
-}
-
-func TestApps_GetTier(t *testing.T) {
-	setup()
-	defer teardown()
-
-	ctx := context.Background()
-
-	mux.HandleFunc(fmt.Sprintf("/v2/apps/tiers/%s", testAppTier.Slug), func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, http.MethodGet)
-
-		json.NewEncoder(w).Encode(&appTierRoot{Tier: &testAppTier})
-	})
-
-	tier, _, err := client.Apps.GetTier(ctx, testAppTier.Slug)
-	require.NoError(t, err)
-	assert.Equal(t, &testAppTier, tier)
-}
-
 func TestApps_ListInstanceSizes(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
The endpoints retirement was announced in the [PDOCs release notes](https://docs.digitalocean.com/release-notes/app-platform/#2024-08-01). They have already been removed from the public API specs.