### PR TITLE
DOKS: add custom CIDR fields

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -65,11 +65,13 @@ type KubernetesServiceOp struct {
 
 // KubernetesClusterCreateRequest represents a request to create a Kubernetes cluster.
 type KubernetesClusterCreateRequest struct {
-	Name        string   `json:"name,omitempty"`
-	RegionSlug  string   `json:"region,omitempty"`
-	VersionSlug string   `json:"version,omitempty"`
-	Tags        []string `json:"tags,omitempty"`
-	VPCUUID     string   `json:"vpc_uuid,omitempty"`
+	Name          string   `json:"name,omitempty"`
+	RegionSlug    string   `json:"region,omitempty"`
+	VersionSlug   string   `json:"version,omitempty"`
+	Tags          []string `json:"tags,omitempty"`
+	VPCUUID       string   `json:"vpc_uuid,omitempty"`
+	ClusterSubnet string   `json:"cluster_subnet,omitempty"`
+	ServiceSubnet string   `json:"service_subnet,omitempty"`
 
 	// Create cluster with highly available control plane
 	HA bool `json:"ha"`

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -549,8 +549,8 @@ func TestKubernetesClusters_Create(t *testing.T) {
 		Name:          "antoine-test-cluster",
 		RegionSlug:    "s2r1",
 		VersionSlug:   "1.10.0-gen0",
-		ClusterSubnet: "10.244.0.0/16",
-		ServiceSubnet: "10.245.0.0/16",
+		ClusterSubnet: "192.168.0.0/16",
+		ServiceSubnet: "192.169.0.0/16",
 		Tags:          []string{"cluster-tag-1", "cluster-tag-2"},
 		VPCUUID:       "880b7f98-f062-404d-b33c-458d545696f6",
 		HA:            true,
@@ -577,13 +577,15 @@ func TestKubernetesClusters_Create(t *testing.T) {
 		},
 	}
 	createRequest := &KubernetesClusterCreateRequest{
-		Name:         want.Name,
-		RegionSlug:   want.RegionSlug,
-		VersionSlug:  want.VersionSlug,
-		Tags:         want.Tags,
-		VPCUUID:      want.VPCUUID,
-		SurgeUpgrade: true,
-		HA:           true,
+		Name:          want.Name,
+		RegionSlug:    want.RegionSlug,
+		VersionSlug:   want.VersionSlug,
+		Tags:          want.Tags,
+		VPCUUID:       want.VPCUUID,
+		ClusterSubnet: want.ClusterSubnet,
+		ServiceSubnet: want.ServiceSubnet,
+		SurgeUpgrade:  true,
+		HA:            true,
 		NodePools: []*KubernetesNodePoolCreateRequest{
 			{
 				Size:      want.NodePools[0].Size,
@@ -606,8 +608,8 @@ func TestKubernetesClusters_Create(t *testing.T) {
 		"name": "antoine-test-cluster",
 		"region": "s2r1",
 		"version": "1.10.0-gen0",
-		"cluster_subnet": "10.244.0.0/16",
-		"service_subnet": "10.245.0.0/16",
+		"cluster_subnet": "192.168.0.0/16",
+		"service_subnet": "192.169.0.0/16",
 		"tags": [
 			"cluster-tag-1",
 			"cluster-tag-2"


### PR DESCRIPTION
This exposes the new create requests fields that allow to set custom CIDRs for the cluster and service subnets.