### PR TITLE
[databases]: add a missing field to Opensearch advanced configuration

### DIFF
--- a/databases.go
+++ b/databases.go
@@ -724,6 +724,7 @@ type OpensearchConfig struct {
 	ScriptMaxCompilationsRate                        *string  `json:"script_max_compilations_rate,omitempty"`
 	ClusterRoutingAllocationNodeConcurrentRecoveries *int     `json:"cluster_routing_allocation_node_concurrent_recoveries,omitempty"`
 	ReindexRemoteWhitelist                           []string `json:"reindex_remote_whitelist,omitempty"`
+	PluginsAlertingFilterByBackendRolesEnabled       *bool    `json:"plugins_alerting_filter_by_backend_roles_enabled,omitempty"`
 }
 
 type databaseUserRoot struct {

--- a/databases_test.go
+++ b/databases_test.go
@@ -3209,7 +3209,8 @@ func TestDatabases_GetConfigOpensearch(t *testing.T) {
     "override_main_response_version": false,
     "script_max_compilations_rate": "use-context",
     "cluster_max_shards_per_node": 0,
-    "cluster_routing_allocation_node_concurrent_recoveries": 2
+    "cluster_routing_allocation_node_concurrent_recoveries": 2,
+	"plugins_alerting_filter_by_backend_roles_enabled": true
   }
 }`
 
@@ -3251,6 +3252,7 @@ func TestDatabases_GetConfigOpensearch(t *testing.T) {
 			ScriptMaxCompilationsRate:                        PtrTo("use-context"),
 			ClusterRoutingAllocationNodeConcurrentRecoveries: PtrTo(2),
 			ReindexRemoteWhitelist:                           nil,
+			PluginsAlertingFilterByBackendRolesEnabled:       PtrTo(true),
 		}
 	)
 

--- a/databases_test.go
+++ b/databases_test.go
@@ -3210,7 +3210,7 @@ func TestDatabases_GetConfigOpensearch(t *testing.T) {
     "script_max_compilations_rate": "use-context",
     "cluster_max_shards_per_node": 0,
     "cluster_routing_allocation_node_concurrent_recoveries": 2,
-	"plugins_alerting_filter_by_backend_roles_enabled": true
+    "plugins_alerting_filter_by_backend_roles_enabled": true
   }
 }`
 


### PR DESCRIPTION
This PR is adding a field to the Opensearch advanced configuration. 
The field was overlooked in a previous PR.