### PR TITLE
[databases]: change Opensearch ism_history_max_docs type to int64 to …

### DIFF
--- a/databases.go
+++ b/databases.go
@@ -712,7 +712,7 @@ type OpensearchConfig struct {
 	IsmEnabled                                       *bool    `json:"ism_enabled,omitempty"`
 	IsmHistoryEnabled                                *bool    `json:"ism_history_enabled,omitempty"`
 	IsmHistoryMaxAgeHours                            *int     `json:"ism_history_max_age_hours,omitempty"`
-	IsmHistoryMaxDocs                                *uint64  `json:"ism_history_max_docs,omitempty"`
+	IsmHistoryMaxDocs                                *int64   `json:"ism_history_max_docs,omitempty"`
 	IsmHistoryRolloverCheckPeriodHours               *int     `json:"ism_history_rollover_check_period_hours,omitempty"`
 	IsmHistoryRolloverRetentionPeriodDays            *int     `json:"ism_history_rollover_retention_period_days,omitempty"`
 	SearchMaxBuckets                                 *int     `json:"search_max_buckets,omitempty"`

--- a/databases_test.go
+++ b/databases_test.go
@@ -3240,7 +3240,7 @@ func TestDatabases_GetConfigOpensearch(t *testing.T) {
 			IsmEnabled:                                       PtrTo(true),
 			IsmHistoryEnabled:                                PtrTo(true),
 			IsmHistoryMaxAgeHours:                            PtrTo(24),
-			IsmHistoryMaxDocs:                                PtrTo(uint64(2500000)),
+			IsmHistoryMaxDocs:                                PtrTo(int64(2500000)),
 			IsmHistoryRolloverCheckPeriodHours:               PtrTo(8),
 			IsmHistoryRolloverRetentionPeriodDays:            PtrTo(30),
 			SearchMaxBuckets:                                 PtrTo(10000),


### PR DESCRIPTION
…align with api

This PR changes a type for Opensearch ism_history_max_docs to int64

Because DigitalOcean API doesn't accept value that exceeds int64 max limit.