### PR TITLE
Add protocol to AppSpec and pending to detect responses

### DIFF
--- a/apps.gen.go
+++ b/apps.gen.go
@@ -495,7 +495,8 @@ type AppServiceSpec struct {
 	InstanceCount int64               `json:"instance_count,omitempty"`
 	Autoscaling   *AppAutoscalingSpec `json:"autoscaling,omitempty"`
 	// The internal port on which this service's run command will listen. Default: 8080 If there is not an environment variable with the name `PORT`, one will be automatically added with its value set to the value of this field.
-	HTTPPort int64 `json:"http_port,omitempty"`
+	HTTPPort int64           `json:"http_port,omitempty"`
+	Protocol ServingProtocol `json:"protocol,omitempty"`
 	// (Deprecated) A list of HTTP routes that should be routed to this component.
 	Routes      []*AppRouteSpec            `json:"routes,omitempty"`
 	HealthCheck *AppServiceSpecHealthCheck `json:"health_check,omitempty"`
@@ -917,6 +918,8 @@ type DetectResponse struct {
 	TemplateFound bool                       `json:"template_found,omitempty"`
 	TemplateValid bool                       `json:"template_valid,omitempty"`
 	TemplateError string                     `json:"template_error,omitempty"`
+	// Whether or not the underlying detection is still pending. If true, the request can be retried as-is until this field is false and the response contains the detection result.
+	Pending bool `json:"pending,omitempty"`
 }
 
 // DetectResponseComponent struct for DetectResponseComponent
@@ -1251,6 +1254,15 @@ type ResetDatabasePasswordRequest struct {
 type ResetDatabasePasswordResponse struct {
 	Deployment *Deployment `json:"deployment,omitempty"`
 }
+
+// ServingProtocol  - HTTP: The app is serving the HTTP protocol. Default.  - HTTP2: The app is serving the HTTP/2 protocol. Currently, this needs to be implemented in the service by serving HTTP/2 with prior knowledge.
+type ServingProtocol string
+
+// List of ServingProtocol
+const (
+	SERVINGPROTOCOL_HTTP  ServingProtocol = "HTTP"
+	SERVINGPROTOCOL_HTTP2 ServingProtocol = "HTTP2"
+)
 
 // AppStringMatch struct for AppStringMatch
 type AppStringMatch struct {

--- a/apps_accessors.go
+++ b/apps_accessors.go
@@ -1757,6 +1757,14 @@ func (a *AppServiceSpec) GetName() string {
 	return a.Name
 }
 
+// GetProtocol returns the Protocol field.
+func (a *AppServiceSpec) GetProtocol() ServingProtocol {
+	if a == nil {
+		return ""
+	}
+	return a.Protocol
+}
+
 // GetRoutes returns the Routes field.
 func (a *AppServiceSpec) GetRoutes() []*AppRouteSpec {
 	if a == nil {
@@ -3091,6 +3099,14 @@ func (d *DetectResponse) GetComponents() []*DetectResponseComponent {
 		return nil
 	}
 	return d.Components
+}
+
+// GetPending returns the Pending field.
+func (d *DetectResponse) GetPending() bool {
+	if d == nil {
+		return false
+	}
+	return d.Pending
 }
 
 // GetTemplate returns the Template field.

--- a/apps_accessors_test.go
+++ b/apps_accessors_test.go
@@ -1539,6 +1539,13 @@ func TestAppServiceSpec_GetName(tt *testing.T) {
 	a.GetName()
 }
 
+func TestAppServiceSpec_GetProtocol(tt *testing.T) {
+	a := &AppServiceSpec{}
+	a.GetProtocol()
+	a = nil
+	a.GetProtocol()
+}
+
 func TestAppServiceSpec_GetRoutes(tt *testing.T) {
 	a := &AppServiceSpec{}
 	a.GetRoutes()
@@ -2706,6 +2713,13 @@ func TestDetectResponse_GetComponents(tt *testing.T) {
 	d.GetComponents()
 	d = nil
 	d.GetComponents()
+}
+
+func TestDetectResponse_GetPending(tt *testing.T) {
+	d := &DetectResponse{}
+	d.GetPending()
+	d = nil
+	d.GetPending()
 }
 
 func TestDetectResponse_GetTemplate(tt *testing.T) {


### PR DESCRIPTION
This adds the new protocol field to AppSpecs to be able to specify either HTTP or HTTP2 traffic. It also adds the pending field to detect responses which reflects whether a request is still in-flight in the background.