### PR TITLE
Add maintenance field to AppSpec to enable/disable maintenance mode

### DIFF
--- a/apps.gen.go
+++ b/apps.gen.go
@@ -462,6 +462,12 @@ type AppLogDestinationSpecPapertrail struct {
 	Endpoint string `json:"endpoint"`
 }
 
+// AppMaintenanceSpec struct for AppMaintenanceSpec
+type AppMaintenanceSpec struct {
+	// Indicates whether maintenance mode should be enabled for the app.
+	Enabled bool `json:"enabled,omitempty"`
+}
+
 // AppRouteSpec struct for AppRouteSpec
 type AppRouteSpec struct {
 	// (Deprecated) An HTTP path prefix. Paths must start with / and must be unique across all components within an app.
@@ -559,10 +565,11 @@ type AppSpec struct {
 	// A list of environment variables made available to all components in the app.
 	Envs []*AppVariableDefinition `json:"envs,omitempty"`
 	// A list of alerts which apply to the app.
-	Alerts   []*AppAlertSpec `json:"alerts,omitempty"`
-	Ingress  *AppIngressSpec `json:"ingress,omitempty"`
-	Egress   *AppEgressSpec  `json:"egress,omitempty"`
-	Features []string        `json:"features,omitempty"`
+	Alerts      []*AppAlertSpec     `json:"alerts,omitempty"`
+	Ingress     *AppIngressSpec     `json:"ingress,omitempty"`
+	Egress      *AppEgressSpec      `json:"egress,omitempty"`
+	Features    []string            `json:"features,omitempty"`
+	Maintenance *AppMaintenanceSpec `json:"maintenance,omitempty"`
 }
 
 // AppStaticSiteSpec struct for AppStaticSiteSpec

--- a/apps_accessors.go
+++ b/apps_accessors.go
@@ -1421,6 +1421,14 @@ func (a *AppLogDestinationSpecPapertrail) GetEndpoint() string {
 	return a.Endpoint
 }
 
+// GetEnabled returns the Enabled field.
+func (a *AppMaintenanceSpec) GetEnabled() bool {
+	if a == nil {
+		return false
+	}
+	return a.Enabled
+}
+
 // GetAppID returns the AppID field.
 func (a *AppProposeRequest) GetAppID() string {
 	if a == nil {
@@ -1939,6 +1947,14 @@ func (a *AppSpec) GetJobs() []*AppJobSpec {
 		return nil
 	}
 	return a.Jobs
+}
+
+// GetMaintenance returns the Maintenance field.
+func (a *AppSpec) GetMaintenance() *AppMaintenanceSpec {
+	if a == nil {
+		return nil
+	}
+	return a.Maintenance
 }
 
 // GetName returns the Name field.

--- a/apps_accessors_test.go
+++ b/apps_accessors_test.go
@@ -1245,6 +1245,13 @@ func TestAppLogDestinationSpecPapertrail_GetEndpoint(tt *testing.T) {
 	a.GetEndpoint()
 }
 
+func TestAppMaintenanceSpec_GetEnabled(tt *testing.T) {
+	a := &AppMaintenanceSpec{}
+	a.GetEnabled()
+	a = nil
+	a.GetEnabled()
+}
+
 func TestAppProposeRequest_GetAppID(tt *testing.T) {
 	a := &AppProposeRequest{}
 	a.GetAppID()
@@ -1698,6 +1705,13 @@ func TestAppSpec_GetJobs(tt *testing.T) {
 	a.GetJobs()
 	a = nil
 	a.GetJobs()
+}
+
+func TestAppSpec_GetMaintenance(tt *testing.T) {
+	a := &AppSpec{}
+	a.GetMaintenance()
+	a = nil
+	a.GetMaintenance()
 }
 
 func TestAppSpec_GetName(tt *testing.T) {


### PR DESCRIPTION
This adds a new `maintenance.enabled` field to AppSpec to be able to specify whether maintenance mode should be enabled or disabled.

**PLEASE DON'T MERGE UNTIL OCTOBER 22**