### PR TITLE
Adjust delete dangerous

### DIFF
--- a/droplet_autoscale.go
+++ b/droplet_autoscale.go
@@ -249,7 +249,7 @@ func (d *DropletAutoscaleServiceOp) Delete(ctx context.Context, id string) (*Res
 
 // DeleteDangerous deletes an existing autoscale pool with all underlying resources
 func (d *DropletAutoscaleServiceOp) DeleteDangerous(ctx context.Context, id string) (*Response, error) {
-	req, err := d.client.NewRequest(ctx, http.MethodDelete, fmt.Sprintf("%s/%s", dropletAutoscaleBasePath, id), nil)
+	req, err := d.client.NewRequest(ctx, http.MethodDelete, fmt.Sprintf("%s/%s/dangerous", dropletAutoscaleBasePath, id), nil)
 	req.Header.Set("X-Dangerous", "true")
 	if err != nil {
 		return nil, err

--- a/droplet_autoscale_test.go
+++ b/droplet_autoscale_test.go
@@ -603,7 +603,7 @@ func TestDropletAutoscaler_DeleteDangerous(t *testing.T) {
 	defer teardown()
 
 	autoscalePoolID := "d50d8276-ad17-475d-8d2a-26b0acac756c"
-	mux.HandleFunc(fmt.Sprintf("%s/%s", dropletAutoscaleBasePath, autoscalePoolID), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("%s/%s/dangerous", dropletAutoscaleBasePath, autoscalePoolID), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
 		if expectedHeader, err := strconv.ParseBool(r.Header.Get("X-Dangerous")); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
This is a followup on #743 to adjust the underlying query for hard deletion of droplet autoscale pool (i.e. delete the pool as well as all underlying resources). 