### PR TITLE
Add archive field to AppSpec to archive/restore apps

### DIFF
--- a/apps.gen.go
+++ b/apps.gen.go
@@ -467,6 +467,7 @@ type AppMaintenanceSpec struct {
 	// Indicates whether maintenance mode should be enabled for the app.
 	Enabled bool `json:"enabled,omitempty"`
 	// Indicates whether the app should be archived. Setting this to true implies that enabled is set to true.
+	// Note that this feature is currently in closed beta.
 	Archive bool `json:"archive,omitempty"`
 }
 

--- a/apps.gen.go
+++ b/apps.gen.go
@@ -466,6 +466,8 @@ type AppLogDestinationSpecPapertrail struct {
 type AppMaintenanceSpec struct {
 	// Indicates whether maintenance mode should be enabled for the app.
 	Enabled bool `json:"enabled,omitempty"`
+	// Indicates whether the app should be archived. Setting this to true implies that enabled is set to true.
+	Archive bool `json:"archive,omitempty"`
 }
 
 // AppRouteSpec struct for AppRouteSpec

--- a/apps_accessors.go
+++ b/apps_accessors.go
@@ -1421,6 +1421,14 @@ func (a *AppLogDestinationSpecPapertrail) GetEndpoint() string {
 	return a.Endpoint
 }
 
+// GetArchive returns the Archive field.
+func (a *AppMaintenanceSpec) GetArchive() bool {
+	if a == nil {
+		return false
+	}
+	return a.Archive
+}
+
 // GetEnabled returns the Enabled field.
 func (a *AppMaintenanceSpec) GetEnabled() bool {
 	if a == nil {

--- a/apps_accessors_test.go
+++ b/apps_accessors_test.go
@@ -1245,6 +1245,13 @@ func TestAppLogDestinationSpecPapertrail_GetEndpoint(tt *testing.T) {
 	a.GetEndpoint()
 }
 
+func TestAppMaintenanceSpec_GetArchive(tt *testing.T) {
+	a := &AppMaintenanceSpec{}
+	a.GetArchive()
+	a = nil
+	a.GetArchive()
+}
+
 func TestAppMaintenanceSpec_GetEnabled(tt *testing.T) {
 	a := &AppMaintenanceSpec{}
 	a.GetEnabled()


### PR DESCRIPTION
This adds a new `maintenance.archive` field to AppSpec to allow users to archive/restore apps.