### PR TITLE
Support maps in Stringify

### DIFF
--- a/strings.go
+++ b/strings.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"sort"
 	"strings"
 )
 
@@ -46,6 +47,8 @@ func stringifyValue(w io.Writer, val reflect.Value) {
 		return
 	case reflect.Struct:
 		stringifyStruct(w, v)
+	case reflect.Map:
+		stringifyMap(w, v)
 	default:
 		if v.CanInterface() {
 			fmt.Fprint(w, v.Interface())
@@ -64,6 +67,27 @@ func stringifySlice(w io.Writer, v reflect.Value) {
 	}
 
 	_, _ = w.Write([]byte{']'})
+}
+
+func stringifyMap(w io.Writer, v reflect.Value) {
+	_, _ = w.Write([]byte("map["))
+
+	// Sort the keys so that the output is stable
+	keys := v.MapKeys()
+	sort.Slice(keys, func(i, j int) bool {
+		return fmt.Sprintf("%v", keys[i]) < fmt.Sprintf("%v", keys[j])
+	})
+
+	for i, key := range keys {
+		stringifyValue(w, key)
+		_, _ = w.Write([]byte{':'})
+		stringifyValue(w, v.MapIndex(key))
+		if i < len(keys)-1 {
+			_, _ = w.Write([]byte(", "))
+		}
+	}
+
+	_, _ = w.Write([]byte("]"))
 }
 
 func stringifyStruct(w io.Writer, v reflect.Value) {

--- a/strings_test.go
+++ b/strings_test.go
@@ -1,0 +1,18 @@
+package godo
+
+import (
+	"testing"
+)
+
+func TestStringify_Map(t *testing.T) {
+	result := Stringify(map[int]*DropletBackupPolicy{
+		1: {DropletID: 1, BackupEnabled: true},
+		2: {DropletID: 2},
+		3: {DropletID: 3, BackupEnabled: true},
+	})
+
+	expected := `map[1:godo.DropletBackupPolicy{DropletID:1, BackupEnabled:true}, 2:godo.DropletBackupPolicy{DropletID:2, BackupEnabled:false}, 3:godo.DropletBackupPolicy{DropletID:3, BackupEnabled:true}]`
+	if result != expected {
+		t.Errorf("Expected %s, got %s", expected, result)
+	}
+}


### PR DESCRIPTION
Reviewing https://github.com/digitalocean/godo/pull/749, I noticed that the `Stringify` utility does not handle maps well. For example, the test output before this change would be something like:

    map[1:0xc00007a340 2:0xc00007a360 3:0xc00007a380]

Now it is:

    map[1:godo.DropletBackupPolicy{DropletID:1, BackupEnabled:true}, 2:godo.DropletBackupPolicy{DropletID:2, BackupEnabled:false}, 3:godo.DropletBackupPolicy{DropletID:3, BackupEnabled:true}]