### PR TITLE
Add Missing Database Configs for Postgresql and MYSQL

### DIFF
--- a/databases.go
+++ b/databases.go
@@ -589,6 +589,9 @@ type PostgreSQLConfig struct {
 	BackupMinute                    *int                         `json:"backup_minute,omitempty"`
 	WorkMem                         *int                         `json:"work_mem,omitempty"`
 	TimeScaleDB                     *PostgreSQLTimeScaleDBConfig `json:"timescaledb,omitempty"`
+	SynchronousReplication          *string                      `json:"synchronous_replication,omitempty"`
+	StatMonitorEnable               *bool                        `json:"stat_monitor_enable,omitempty"`
+	MaxFailoverReplicationTimeLag   *uint64                      `json:"max_failover_replication_time_lag,omitempty"`
 }
 
 // PostgreSQLBouncerConfig configuration
@@ -653,6 +656,13 @@ type MySQLConfig struct {
 	BackupHour                   *int     `json:"backup_hour,omitempty"`
 	BackupMinute                 *int     `json:"backup_minute,omitempty"`
 	BinlogRetentionPeriod        *int     `json:"binlog_retention_period,omitempty"`
+	InnodbChangeBufferMaxSize    *uint32  `json:"innodb_change_buffer_max_size,omitempty"`
+	InnodbFlushNeighbors         *uint32  `json:"innodb_flush_neighbors,omitempty"`
+	InnodbReadIoThreads          *uint32  `json:"innodb_read_io_threads,omitempty"`
+	InnodbThreadConcurrency      *uint32  `json:"innodb_thread_concurrency,omitempty"`
+	InnodbWriteIoThreads         *uint32  `json:"innodb_write_io_threads,omitempty"`
+	NetBufferLength              *uint32  `json:"net_buffer_length,omitempty"`
+	LogOutput                    *string  `json:"log_output,omitempty"`
 }
 
 // MongoDBConfig holds advanced configurations for MongoDB database clusters.

--- a/databases.go
+++ b/databases.go
@@ -656,7 +656,7 @@ type MySQLConfig struct {
 	BackupHour                   *int     `json:"backup_hour,omitempty"`
 	BackupMinute                 *int     `json:"backup_minute,omitempty"`
 	BinlogRetentionPeriod        *int     `json:"binlog_retention_period,omitempty"`
-	InnodbChangeBufferMaxSize    *uint32  `json:"innodb_change_buffer_max_size,omitempty"`
+	InnodbChangeBufferMaxSize    *int  `json:"innodb_change_buffer_max_size,omitempty"`
 	InnodbFlushNeighbors         *uint32  `json:"innodb_flush_neighbors,omitempty"`
 	InnodbReadIoThreads          *uint32  `json:"innodb_read_io_threads,omitempty"`
 	InnodbThreadConcurrency      *uint32  `json:"innodb_thread_concurrency,omitempty"`

--- a/databases.go
+++ b/databases.go
@@ -591,7 +591,7 @@ type PostgreSQLConfig struct {
 	TimeScaleDB                     *PostgreSQLTimeScaleDBConfig `json:"timescaledb,omitempty"`
 	SynchronousReplication          *string                      `json:"synchronous_replication,omitempty"`
 	StatMonitorEnable               *bool                        `json:"stat_monitor_enable,omitempty"`
-	MaxFailoverReplicationTimeLag   *uint64                      `json:"max_failover_replication_time_lag,omitempty"`
+	MaxFailoverReplicationTimeLag   *int64                       `json:"max_failover_replication_time_lag,omitempty"`
 }
 
 // PostgreSQLBouncerConfig configuration
@@ -656,7 +656,7 @@ type MySQLConfig struct {
 	BackupHour                   *int     `json:"backup_hour,omitempty"`
 	BackupMinute                 *int     `json:"backup_minute,omitempty"`
 	BinlogRetentionPeriod        *int     `json:"binlog_retention_period,omitempty"`
-	InnodbChangeBufferMaxSize    *int  `json:"innodb_change_buffer_max_size,omitempty"`
+	InnodbChangeBufferMaxSize    *int     `json:"innodb_change_buffer_max_size,omitempty"`
 	InnodbFlushNeighbors         *uint32  `json:"innodb_flush_neighbors,omitempty"`
 	InnodbReadIoThreads          *uint32  `json:"innodb_read_io_threads,omitempty"`
 	InnodbThreadConcurrency      *uint32  `json:"innodb_thread_concurrency,omitempty"`

--- a/databases.go
+++ b/databases.go
@@ -657,11 +657,11 @@ type MySQLConfig struct {
 	BackupMinute                 *int     `json:"backup_minute,omitempty"`
 	BinlogRetentionPeriod        *int     `json:"binlog_retention_period,omitempty"`
 	InnodbChangeBufferMaxSize    *int     `json:"innodb_change_buffer_max_size,omitempty"`
-	InnodbFlushNeighbors         *uint32  `json:"innodb_flush_neighbors,omitempty"`
-	InnodbReadIoThreads          *uint32  `json:"innodb_read_io_threads,omitempty"`
-	InnodbThreadConcurrency      *uint32  `json:"innodb_thread_concurrency,omitempty"`
-	InnodbWriteIoThreads         *uint32  `json:"innodb_write_io_threads,omitempty"`
-	NetBufferLength              *uint32  `json:"net_buffer_length,omitempty"`
+	InnodbFlushNeighbors         *int     `json:"innodb_flush_neighbors,omitempty"`
+	InnodbReadIoThreads          *int     `json:"innodb_read_io_threads,omitempty"`
+	InnodbThreadConcurrency      *int     `json:"innodb_thread_concurrency,omitempty"`
+	InnodbWriteIoThreads         *int     `json:"innodb_write_io_threads,omitempty"`
+	NetBufferLength              *int     `json:"net_buffer_length,omitempty"`
 	LogOutput                    *string  `json:"log_output,omitempty"`
 }
 


### PR DESCRIPTION
As part of 
https://do-internal.atlassian.net/browse/DBAAS-5519
https://do-internal.atlassian.net/browse/DBAAS-5587
We need to add missing `postgresql` and `mysql` database configs to godo.