### PR TITLE
kubernetes: add cluster autoscaler config

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -78,20 +78,22 @@ type KubernetesClusterCreateRequest struct {
 
 	NodePools []*KubernetesNodePoolCreateRequest `json:"node_pools,omitempty"`
 
-	MaintenancePolicy    *KubernetesMaintenancePolicy    `json:"maintenance_policy"`
-	AutoUpgrade          bool                            `json:"auto_upgrade"`
-	SurgeUpgrade         bool                            `json:"surge_upgrade"`
-	ControlPlaneFirewall *KubernetesControlPlaneFirewall `json:"control_plane_firewall,omitempty"`
+	MaintenancePolicy              *KubernetesMaintenancePolicy              `json:"maintenance_policy"`
+	AutoUpgrade                    bool                                      `json:"auto_upgrade"`
+	SurgeUpgrade                   bool                                      `json:"surge_upgrade"`
+	ControlPlaneFirewall           *KubernetesControlPlaneFirewall           `json:"control_plane_firewall,omitempty"`
+	ClusterAutoscalerConfiguration *KubernetesClusterAutoscalerConfiguration `json:"cluster_autoscaler_configuration,omitempty"`
 }
 
 // KubernetesClusterUpdateRequest represents a request to update a Kubernetes cluster.
 type KubernetesClusterUpdateRequest struct {
-	Name                 string                          `json:"name,omitempty"`
-	Tags                 []string                        `json:"tags,omitempty"`
-	MaintenancePolicy    *KubernetesMaintenancePolicy    `json:"maintenance_policy,omitempty"`
-	AutoUpgrade          *bool                           `json:"auto_upgrade,omitempty"`
-	SurgeUpgrade         bool                            `json:"surge_upgrade,omitempty"`
-	ControlPlaneFirewall *KubernetesControlPlaneFirewall `json:"control_plane_firewall,omitempty"`
+	Name                           string                                    `json:"name,omitempty"`
+	Tags                           []string                                  `json:"tags,omitempty"`
+	MaintenancePolicy              *KubernetesMaintenancePolicy              `json:"maintenance_policy,omitempty"`
+	AutoUpgrade                    *bool                                     `json:"auto_upgrade,omitempty"`
+	SurgeUpgrade                   bool                                      `json:"surge_upgrade,omitempty"`
+	ControlPlaneFirewall           *KubernetesControlPlaneFirewall           `json:"control_plane_firewall,omitempty"`
+	ClusterAutoscalerConfiguration *KubernetesClusterAutoscalerConfiguration `json:"cluster_autoscaler_configuration,omitempty"`
 
 	// Convert cluster to run highly available control plane
 	HA *bool `json:"ha,omitempty"`
@@ -205,11 +207,12 @@ type KubernetesCluster struct {
 
 	NodePools []*KubernetesNodePool `json:"node_pools,omitempty"`
 
-	MaintenancePolicy    *KubernetesMaintenancePolicy    `json:"maintenance_policy,omitempty"`
-	AutoUpgrade          bool                            `json:"auto_upgrade,omitempty"`
-	SurgeUpgrade         bool                            `json:"surge_upgrade,omitempty"`
-	RegistryEnabled      bool                            `json:"registry_enabled,omitempty"`
-	ControlPlaneFirewall *KubernetesControlPlaneFirewall `json:"control_plane_firewall,omitempty"`
+	MaintenancePolicy              *KubernetesMaintenancePolicy              `json:"maintenance_policy,omitempty"`
+	AutoUpgrade                    bool                                      `json:"auto_upgrade,omitempty"`
+	SurgeUpgrade                   bool                                      `json:"surge_upgrade,omitempty"`
+	RegistryEnabled                bool                                      `json:"registry_enabled,omitempty"`
+	ControlPlaneFirewall           *KubernetesControlPlaneFirewall           `json:"control_plane_firewall,omitempty"`
+	ClusterAutoscalerConfiguration *KubernetesClusterAutoscalerConfiguration `json:"cluster_autoscaler_configuration,omitempty"`
 
 	Status    *KubernetesClusterStatus `json:"status,omitempty"`
 	CreatedAt time.Time                `json:"created_at,omitempty"`
@@ -249,6 +252,12 @@ type KubernetesMaintenancePolicy struct {
 type KubernetesControlPlaneFirewall struct {
 	Enabled          *bool    `json:"enabled"`
 	AllowedAddresses []string `json:"allowed_addresses"`
+}
+
+// KubernetesClusterAutoscalerConfiguration represents Kubernetes cluster autoscaler configuration.
+type KubernetesClusterAutoscalerConfiguration struct {
+	ScaleDownUtilizationThreshold *float64 `json:"scale_down_utilization_threshold"`
+	ScaleDownUnneededTime         *string  `json:"scale_down_unneeded_time"`
 }
 
 // KubernetesMaintenancePolicyDay represents the possible days of a maintenance

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -543,6 +543,8 @@ func TestKubernetesClusters_Create(t *testing.T) {
 
 	kubeSvc := client.Kubernetes
 	enabled := true
+	scaleDownUtilizationThreshold := 0.5
+	scaleDownUnneededTime := "1m30s"
 
 	want := &KubernetesCluster{
 		ID:            "8d91899c-0739-4a1a-acc5-deadbeefbb8f",
@@ -575,6 +577,10 @@ func TestKubernetesClusters_Create(t *testing.T) {
 				"1.2.3.4/32",
 			},
 		},
+		ClusterAutoscalerConfiguration: &KubernetesClusterAutoscalerConfiguration{
+			ScaleDownUtilizationThreshold: &scaleDownUtilizationThreshold,
+			ScaleDownUnneededTime:         &scaleDownUnneededTime,
+		},
 	}
 	createRequest := &KubernetesClusterCreateRequest{
 		Name:          want.Name,
@@ -598,7 +604,8 @@ func TestKubernetesClusters_Create(t *testing.T) {
 				MaxNodes:  want.NodePools[0].MaxNodes,
 			},
 		},
-		MaintenancePolicy: want.MaintenancePolicy,
+		MaintenancePolicy:              want.MaintenancePolicy,
+		ClusterAutoscalerConfiguration: want.ClusterAutoscalerConfiguration,
 	}
 
 	jBlob := `
@@ -635,12 +642,16 @@ func TestKubernetesClusters_Create(t *testing.T) {
 			"start_time": "00:00",
 			"day": "monday"
 		},
-        "control_plane_firewall": {
-             "enabled": true,
-             "allowed_addresses": [
-                 "1.2.3.4/32"
-             ]
-        }
+		"control_plane_firewall": {
+			"enabled": true,
+			"allowed_addresses": [
+					"1.2.3.4/32"
+			]
+		},
+		"cluster_autoscaler_configuration": {
+      "scale_down_utilization_threshold": 0.5,
+      "scale_down_unneeded_time": "1m30s"
+    }
 	}
 }`
 
@@ -771,6 +782,8 @@ func TestKubernetesClusters_Update(t *testing.T) {
 
 	kubeSvc := client.Kubernetes
 	enabled := true
+	scaleDownUtilizationThreshold := 0.2
+	scaleDownUnneededTime := "1m27s"
 
 	want := &KubernetesCluster{
 		ID:            "8d91899c-0739-4a1a-acc5-deadbeefbb8f",
@@ -805,6 +818,10 @@ func TestKubernetesClusters_Update(t *testing.T) {
 				"1.2.3.4/32",
 			},
 		},
+		ClusterAutoscalerConfiguration: &KubernetesClusterAutoscalerConfiguration{
+			ScaleDownUtilizationThreshold: &scaleDownUtilizationThreshold,
+			ScaleDownUnneededTime:         &scaleDownUnneededTime,
+		},
 	}
 	updateRequest := &KubernetesClusterUpdateRequest{
 		Name:              want.Name,
@@ -816,6 +833,10 @@ func TestKubernetesClusters_Update(t *testing.T) {
 			AllowedAddresses: []string{
 				"1.2.3.4/32",
 			},
+		},
+		ClusterAutoscalerConfiguration: &KubernetesClusterAutoscalerConfiguration{
+			ScaleDownUtilizationThreshold: &scaleDownUtilizationThreshold,
+			ScaleDownUnneededTime:         &scaleDownUnneededTime,
 		},
 	}
 
@@ -854,15 +875,19 @@ func TestKubernetesClusters_Update(t *testing.T) {
 			"day": "monday"
 		},
 		"control_plane_firewall": {
-             "enabled": true,
-             "allowed_addresses": [
-                 "1.2.3.4/32"
-             ]
-        }
+			"enabled": true,
+			"allowed_addresses": [
+					"1.2.3.4/32"
+			]
+		},	
+		"cluster_autoscaler_configuration": {
+      "scale_down_utilization_threshold": 0.2,
+      "scale_down_unneeded_time": "1m27s"
+    }
 	}
 }`
 
-	expectedReqJSON := `{"name":"antoine-test-cluster","tags":["cluster-tag-1","cluster-tag-2"],"maintenance_policy":{"start_time":"00:00","duration":"","day":"monday"},"surge_upgrade":true,"control_plane_firewall":{"enabled":true,"allowed_addresses":["1.2.3.4/32"]}}
+	expectedReqJSON := `{"name":"antoine-test-cluster","tags":["cluster-tag-1","cluster-tag-2"],"maintenance_policy":{"start_time":"00:00","duration":"","day":"monday"},"surge_upgrade":true,"control_plane_firewall":{"enabled":true,"allowed_addresses":["1.2.3.4/32"]},"cluster_autoscaler_configuration":{"scale_down_utilization_threshold":0.2,"scale_down_unneeded_time":"1m27s"}}
 `
 
 	mux.HandleFunc("/v2/kubernetes/clusters/8d91899c-0739-4a1a-acc5-deadbeefbb8f", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This PR allows users to specify cluster autoscaler configuration in godo during kubernetes create and update. We accept a JSON string as the value for cluster autoscaler configuration.