### PR TITLE
[kubernetes]: make kubernetes maintenance_policy day case insensitive

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -315,7 +315,7 @@ var (
 
 // KubernetesMaintenanceToDay returns the appropriate KubernetesMaintenancePolicyDay for the given string.
 func KubernetesMaintenanceToDay(day string) (KubernetesMaintenancePolicyDay, error) {
-	d, ok := toDay[day]
+	d, ok := toDay[strings.ToLower(day)]
 	if !ok {
 		return 0, fmt.Errorf("unknown day: %q", day)
 	}

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -351,7 +351,7 @@ func TestKubernetesClusters_Get(t *testing.T) {
 		],
 		"maintenance_policy": {
 			"start_time": "00:00",
-			"day": "monday"
+			"day": "Monday"
 		},
 		"created_at": "2018-06-15T07:10:23Z",
 		"updated_at": "2018-06-15T07:11:26Z"
@@ -633,7 +633,7 @@ func TestKubernetesClusters_Create(t *testing.T) {
 		],
 		"maintenance_policy": {
 			"start_time": "00:00",
-			"day": "monday"
+			"day": "Monday"
 		},
         "control_plane_firewall": {
              "enabled": true,
@@ -743,7 +743,7 @@ func TestKubernetesClusters_Create_AutoScalePool(t *testing.T) {
 		],
 		"maintenance_policy": {
 			"start_time": "00:00",
-			"day": "monday"
+			"day": "Monday"
 		}
 	}
 }`
@@ -851,7 +851,7 @@ func TestKubernetesClusters_Update(t *testing.T) {
 		],
 		"maintenance_policy": {
 			"start_time": "00:00",
-			"day": "monday"
+			"day": "Monday"
 		},
 		"control_plane_firewall": {
              "enabled": true,
@@ -944,7 +944,7 @@ func TestKubernetesClusters_Update_FalseAutoUpgrade(t *testing.T) {
 		],
 		"maintenance_policy": {
 			"start_time": "00:00",
-			"day": "monday"
+			"day": "Monday"
 		}
 	}
 }`


### PR DESCRIPTION
I believe day should be case insensitive.

Related to https://github.com/digitalocean/terraform-provider-digitalocean/pull/1293