### PR TITLE
add ID field to KubernetesClusterUser response

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -223,6 +223,7 @@ func (kc KubernetesCluster) URN() string {
 
 // KubernetesClusterUser represents a Kubernetes cluster user.
 type KubernetesClusterUser struct {
+	ID       string   `json:"id,omitempty"`
 	Username string   `json:"username,omitempty"`
 	Groups   []string `json:"groups,omitempty"`
 }

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -384,6 +384,7 @@ func TestKubernetesClusters_GetUser(t *testing.T) {
 	kubeSvc := client.Kubernetes
 	want := &KubernetesClusterUser{
 		Username: "foo@example.com",
+		ID:       "deadbeef-dead-beef-dead-deadbeef05e8",
 		Groups: []string{
 			"foo:bar",
 		},
@@ -392,6 +393,7 @@ func TestKubernetesClusters_GetUser(t *testing.T) {
 {
 	"kubernetes_cluster_user": {
 		"username": "foo@example.com",
+		"id": "deadbeef-dead-beef-dead-deadbeef05e8",
 		"groups": ["foo:bar"]
 	}
 }`


### PR DESCRIPTION
A new field is being added to the the /v2/kubernetes/clusters/{id}/user response. Adding it to the godo type as well.