### PR TITLE
Add field to customize the offline page during app maintenance

### DIFF
--- a/apps.gen.go
+++ b/apps.gen.go
@@ -470,6 +470,8 @@ type AppMaintenanceSpec struct {
 	Enabled bool `json:"enabled,omitempty"`
 	// Indicates whether the app should be archived. Setting this to true implies that enabled is set to true. Note that this feature is currently in closed beta.
 	Archive bool `json:"archive,omitempty"`
+	// A custom offline page to display when maintenance mode is enabled or the app is archived.
+	OfflinePageURL string `json:"offline_page_url,omitempty"`
 }
 
 // AppRouteSpec struct for AppRouteSpec

--- a/apps_accessors.go
+++ b/apps_accessors.go
@@ -1453,6 +1453,14 @@ func (a *AppMaintenanceSpec) GetEnabled() bool {
 	return a.Enabled
 }
 
+// GetOfflinePageURL returns the OfflinePageURL field.
+func (a *AppMaintenanceSpec) GetOfflinePageURL() string {
+	if a == nil {
+		return ""
+	}
+	return a.OfflinePageURL
+}
+
 // GetAppID returns the AppID field.
 func (a *AppProposeRequest) GetAppID() string {
 	if a == nil {

--- a/apps_accessors_test.go
+++ b/apps_accessors_test.go
@@ -1273,6 +1273,13 @@ func TestAppMaintenanceSpec_GetEnabled(tt *testing.T) {
 	a.GetEnabled()
 }
 
+func TestAppMaintenanceSpec_GetOfflinePageURL(tt *testing.T) {
+	a := &AppMaintenanceSpec{}
+	a.GetOfflinePageURL()
+	a = nil
+	a.GetOfflinePageURL()
+}
+
 func TestAppProposeRequest_GetAppID(tt *testing.T) {
 	a := &AppProposeRequest{}
 	a.GetAppID()


### PR DESCRIPTION
The `offline_page_url` allows users to customize the offline page when an app is in maintenance mode or when an app is archived.