### PR TITLE
CON-11810 Implement GetNodePoolTemplate endpoint for DOKS godo client

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -40,6 +40,7 @@ type KubernetesService interface {
 
 	CreateNodePool(ctx context.Context, clusterID string, req *KubernetesNodePoolCreateRequest) (*KubernetesNodePool, *Response, error)
 	GetNodePool(ctx context.Context, clusterID, poolID string) (*KubernetesNodePool, *Response, error)
+	GetNodePoolTemplate(ctx context.Context, clusterID string, nodePoolName string) (*KubernetesNodePoolTemplateResponse, *Response, error)
 	ListNodePools(ctx context.Context, clusterID string, opts *ListOptions) ([]*KubernetesNodePool, *Response, error)
 	UpdateNodePool(ctx context.Context, clusterID, poolID string, req *KubernetesNodePoolUpdateRequest) (*KubernetesNodePool, *Response, error)
 	// RecycleNodePoolNodes is DEPRECATED please use DeleteNode
@@ -426,6 +427,30 @@ type KubernetesNodePool struct {
 	Nodes []*KubernetesNode `json:"nodes,omitempty"`
 }
 
+// KubernetesNodePool represents a node pool template response from the node template endpoint
+type KubernetesNodePoolTemplateResponse struct {
+	ClusterUUID string                      `json:"cluster_uuid,omitempty"`
+	Name        string                      `json:"name,omitempty"`
+	Slug        string                      `json:"slug,omitempty"`
+	Template    *KubernetesNodePoolTemplate `json:"template,omitempty"`
+}
+
+// KubernetesNodePool represents the node pool template data for a given pool.
+type KubernetesNodePoolTemplate struct {
+	Labels      map[string]string            `json:"labels,omitempty"`
+	Capacity    *KubernetesNodePoolResources `json:"capacity,omitempty"`
+	Allocatable *KubernetesNodePoolResources `json:"allocatable,omitempty"`
+}
+
+// KubernetesNodePoolResources represents the resources within a given template for a node pool
+// This follows https://pkg.go.dev/k8s.io/kubernetes@v1.32.1/pkg/scheduler/framework#Resource to represent
+// node resources within the node object.
+type KubernetesNodePoolResources struct {
+	CPU    int64  `json:"cpu,omitempty"`
+	Memory string `json:"memory,omitempty"`
+	Pods   int64  `json:"pods,omitempty"`
+}
+
 // KubernetesNode represents a Node in a node pool in a Kubernetes cluster.
 type KubernetesNode struct {
 	ID        string                `json:"id,omitempty"`
@@ -802,6 +827,24 @@ func (svc *KubernetesServiceOp) GetNodePool(ctx context.Context, clusterID, pool
 		return nil, resp, err
 	}
 	return root.NodePool, resp, nil
+}
+
+// GetNodePoolTemplate retrieves the template used for a given node pool to scale up from zero.
+func (svc *KubernetesServiceOp) GetNodePoolTemplate(ctx context.Context, clusterID string, nodePoolName string) (*KubernetesNodePoolTemplateResponse, *Response, error) {
+	path, err := url.JoinPath(kubernetesClustersPath, clusterID, "node_pools_template", nodePoolName)
+	if err != nil {
+		return nil, nil, err
+	}
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(KubernetesNodePoolTemplateResponse)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root, resp, nil
 }
 
 // ListNodePools lists all the node pools found in a Kubernetes cluster.

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -1298,6 +1298,61 @@ func TestKubernetesClusters_GetNodePool(t *testing.T) {
 	require.Equal(t, want, got)
 }
 
+func TestKubernetesClusters_GetNodePoolTemplate(t *testing.T) {
+	setup()
+	defer teardown()
+	kubeSvc := client.Kubernetes
+	want := &KubernetesNodePoolTemplateResponse{
+		ClusterUUID: "8d91899c-0739-4a1a-acc5-deadbeefbb8a",
+		Name:        "pool-a",
+		Slug:        "s-1vcpu-2gb",
+		Template: &KubernetesNodePoolTemplate{
+			Labels: map[string]string{
+				"some-label": "some-value",
+			},
+			Capacity: &KubernetesNodePoolResources{
+				CPU:    1,
+				Memory: "2048Mi",
+				Pods:   110,
+			},
+			Allocatable: &KubernetesNodePoolResources{
+				CPU:    390,
+				Memory: "1024Mi",
+				Pods:   110,
+			}},
+	}
+	jBlob := `
+{
+   "cluster_uuid": "8d91899c-0739-4a1a-acc5-deadbeefbb8a",
+   "name": "pool-a",
+   "slug": "s-1vcpu-2gb",
+   "template": {
+      "labels": {
+         "some-label": "some-value"
+      },
+      "capacity": {
+         "cpu": 1,
+         "memory": "2048Mi",
+         "pods": 110
+      },
+      "allocatable": {
+         "cpu": 390,
+         "memory": "1024Mi",
+         "pods": 110
+      }
+   }
+}
+`
+	mux.HandleFunc("/v2/kubernetes/clusters/8d91899c-0739-4a1a-acc5-deadbeefbb8a/node_pools_template/pool-a", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, jBlob)
+	})
+	got, _, err := kubeSvc.GetNodePoolTemplate(ctx, "8d91899c-0739-4a1a-acc5-deadbeefbb8a", "pool-a")
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+
+}
+
 func TestKubernetesClusters_ListNodePools(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
Extends the godo public client with new method `GetNodePoolTemplate` which will be used in assisting CA to scale back up from zero. Created a test project with the following code to verify response is returned as expected

```
package main

import (
	"context"
	"encoding/json"
	"fmt"
	"github.com/digitalocean/godo"
	"log"
	"os"
)

func main() {
	t := os.Getenv("DIGITALOCEAN_ACCESS_TOKEN")
	if t == "" {
		log.Fatal("no DO token set")
	}
	client := godo.NewFromToken(t)
	tmpl, _, err := client.Kubernetes.GetNodePoolTemplate(context.TODO(), "<some-cluster-uuid>", "<some-node-pool-name>")
	if err != nil {
		log.Fatalf("failed to get template %s", err)
	}
	j, err := json.MarshalIndent(tmpl, "", "   ")
	if err != nil {
		log.Fatal(err)
	}
	fmt.Println(string(j))
}
```

Running the code results in the following response

```
{
   "cluster_uuid": "<some-cluster-uuid>",
   "name": "<some-node-pool-name>",
   "slug": "s-2vcpu-4gb",
   "template": {
      "capacity": {
         "cpu": 2,
         "memory": "4096Mi",
         "pods": 110
      },
      "allocatable": {
         "cpu": 1390,
         "memory": "2560Mi",
         "pods": 110
      }
   }
}
```