### PR TITLE
fix partner interconnect json tag

### DIFF
--- a/partner_interconnect_attachments.go
+++ b/partner_interconnect_attachments.go
@@ -97,7 +97,7 @@ type BGP struct {
 	// LocalRouterIP is the local router IP
 	LocalRouterIP string `json:"local_router_ip,omitempty"`
 	// PeerASN is the peer ASN
-	PeerASN int `json:"peer_asn,omitempty"`
+	PeerASN int `json:"peer_router_asn,omitempty"`
 	// PeerRouterIP is the peer router IP
 	PeerRouterIP string `json:"peer_router_ip,omitempty"`
 }

--- a/partner_interconnect_attachments_test.go
+++ b/partner_interconnect_attachments_test.go
@@ -51,7 +51,7 @@ var vInterconnectTestJSON = `
 		"bgp":{
 			"local_asn":64532,
 			"local_router_ip":"169.250.0.1",
-			"peer_asn":133937,
+			"peer_router_asn":133937,
 			"peer_router_ip":"169.250.0.6"
 			},
 		"created_at":"2024-12-26T21:48:40.995304079Z"


### PR DESCRIPTION
The json tag for `PeerASN` is incorrect causing it to return an error when trying to create a partner interconnect attachment.