### PR TITLE
CON-11904 Ensure taints are correctly returned via node template endpoint

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -446,6 +446,7 @@ type KubernetesNodePoolTemplateResponse struct {
 // KubernetesNodePool represents the node pool template data for a given pool.
 type KubernetesNodePoolTemplate struct {
 	Labels      map[string]string            `json:"labels,omitempty"`
+	Taints      []string                     `json:"taints,omitempty"`
 	Capacity    *KubernetesNodePoolResources `json:"capacity,omitempty"`
 	Allocatable *KubernetesNodePoolResources `json:"allocatable,omitempty"`
 }

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -1337,6 +1337,7 @@ func TestKubernetesClusters_GetNodePoolTemplate(t *testing.T) {
 		Name:        "pool-a",
 		Slug:        "s-1vcpu-2gb",
 		Template: &KubernetesNodePoolTemplate{
+			Taints: []string{"some-key=some-value:NoSchedule"},
 			Labels: map[string]string{
 				"some-label": "some-value",
 			},
@@ -1360,6 +1361,7 @@ func TestKubernetesClusters_GetNodePoolTemplate(t *testing.T) {
       "labels": {
          "some-label": "some-value"
       },
+      "taints": ["some-key=some-value:NoSchedule"],
       "capacity": {
          "cpu": 1,
          "memory": "2048Mi",


### PR DESCRIPTION
Continuation of PR https://github.com/digitalocean/godo/pull/781 to ensure taints are also returned from the new template endpoint