### PR TITLE
add auth_key field

### DIFF
--- a/partner_interconnect_attachments.go
+++ b/partner_interconnect_attachments.go
@@ -93,13 +93,15 @@ type PartnerInterconnectAttachmentSetRoutesRequest struct {
 // BGP represents the BGP configuration of a Partner Interconnect Attachment.
 type BGP struct {
 	// LocalASN is the local ASN
-	LocalASN int `json:"local_asn,omitempty"`
+	LocalASN int `json:"local_router_asn,omitempty"`
 	// LocalRouterIP is the local router IP
 	LocalRouterIP string `json:"local_router_ip,omitempty"`
 	// PeerASN is the peer ASN
-	PeerASN int `json:"peer_asn,omitempty"`
+	PeerASN int `json:"peer_router_asn,omitempty"`
 	// PeerRouterIP is the peer router IP
 	PeerRouterIP string `json:"peer_router_ip,omitempty"`
+	// AuthKey is the authentication key
+	AuthKey string `json:"auth_key,omitempty"`
 }
 
 // ServiceKey represents the service key of a Partner Interconnect Attachment.

--- a/partner_interconnect_attachments.go
+++ b/partner_interconnect_attachments.go
@@ -95,7 +95,7 @@ type PartnerInterconnectAttachmentSetRoutesRequest struct {
 // BGP represents the BGP configuration of a Partner Interconnect Attachment.
 type BGP struct {
 	// LocalASN is the local ASN
-	LocalASN int `json:"local_router_asn,omitempty"`
+	LocalASN int `json:"local_asn,omitempty"`
 	// LocalRouterIP is the local router IP
 	LocalRouterIP string `json:"local_router_ip,omitempty"`
 	// PeerASN is the peer ASN

--- a/partner_interconnect_attachments_test.go
+++ b/partner_interconnect_attachments_test.go
@@ -50,7 +50,7 @@ var vInterconnectTestJSON = `
 		"naas_provider":"MEGAPORT",
 		"vpc_ids":["f5a0c5e4-7537-47de-bb8d-46c766f89ffb"],
 		"bgp":{
-			"local_router_asn":64532,
+			"local_asn":64532,
 			"local_router_ip":"169.250.0.1",
 			"peer_router_asn":133937,
 			"peer_router_ip":"169.250.0.6",

--- a/partner_interconnect_attachments_test.go
+++ b/partner_interconnect_attachments_test.go
@@ -24,6 +24,7 @@ var vInterconnectTestObj = &PartnerInterconnectAttachment{
 		LocalRouterIP: "169.250.0.1",
 		PeerASN:       133937,
 		PeerRouterIP:  "169.250.0.6",
+		AuthKey:       "my-auth-key",
 	},
 	CreatedAt: time.Date(2024, 12, 26, 21, 48, 40, 995304079, time.UTC),
 }
@@ -49,10 +50,11 @@ var vInterconnectTestJSON = `
 		"naas_provider":"MEGAPORT",
 		"vpc_ids":["f5a0c5e4-7537-47de-bb8d-46c766f89ffb"],
 		"bgp":{
-			"local_asn":64532,
+			"local_router_asn":64532,
 			"local_router_ip":"169.250.0.1",
-			"peer_asn":133937,
-			"peer_router_ip":"169.250.0.6"
+			"peer_router_asn":133937,
+			"peer_router_ip":"169.250.0.6",
+			"auth_key":"my-auth-key"
 			},
 		"created_at":"2024-12-26T21:48:40.995304079Z"
 	}


### PR DESCRIPTION
When the BGP configuration is provided it is also expecting an auth_key for the BGP session.
Also, json tags are expected with a bit different name without this change creating a partner interconnect attachment with a specific BGP configuration can't be done.