### PR TITLE
fix partner interconnect attachment json request response

### DIFF
--- a/partner_interconnect_attachments.go
+++ b/partner_interconnect_attachments.go
@@ -2,6 +2,7 @@ package godo
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -60,7 +61,7 @@ type partnerInterconnectAttachmentRequestBody struct {
 	// VPCIDs is the IDs of the VPCs to which the Partner Interconnect Attachment is connected
 	VPCIDs []string `json:"vpc_ids,omitempty"`
 	// BGP is the BGP configuration of the Partner Interconnect Attachment
-	BGP *BGP `json:"bgp,omitempty"`
+	BGP *BGPInput `json:"bgp,omitempty"`
 }
 
 func (req *PartnerInterconnectAttachmentCreateRequest) buildReq() *partnerInterconnectAttachmentRequestBody {
@@ -73,7 +74,13 @@ func (req *PartnerInterconnectAttachmentCreateRequest) buildReq() *partnerInterc
 	}
 
 	if req.BGP != (BGP{}) {
-		request.BGP = &req.BGP
+		request.BGP = &BGPInput{
+			LocalASN:      req.BGP.LocalASN,
+			LocalRouterIP: req.BGP.LocalRouterIP,
+			PeerASN:       req.BGP.PeerASN,
+			PeerRouterIP:  req.BGP.PeerRouterIP,
+			AuthKey:       req.BGP.AuthKey,
+		}
 	}
 
 	return request
@@ -96,6 +103,49 @@ type PartnerInterconnectAttachmentSetRoutesRequest struct {
 type BGP struct {
 	// LocalASN is the local ASN
 	LocalASN int `json:"local_asn,omitempty"`
+	// LocalRouterIP is the local router IP
+	LocalRouterIP string `json:"local_router_ip,omitempty"`
+	// PeerASN is the peer ASN
+	PeerASN int `json:"peer_asn,omitempty"`
+	// PeerRouterIP is the peer router IP
+	PeerRouterIP string `json:"peer_router_ip,omitempty"`
+	// AuthKey is the authentication key
+	AuthKey string `json:"auth_key,omitempty"`
+}
+
+func (b *BGP) UnmarshalJSON(data []byte) error {
+	type Alias BGP
+	aux := &struct {
+		LocalASN       *int `json:"local_asn,omitempty"`
+		LocalRouterASN *int `json:"local_router_asn,omitempty"`
+		PeerASN        *int `json:"peer_asn,omitempty"`
+		PeerRouterASN  *int `json:"peer_router_asn,omitempty"`
+		*Alias
+	}{
+		Alias: (*Alias)(b),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	if aux.LocalASN != nil {
+		b.LocalASN = *aux.LocalASN
+	} else if aux.LocalRouterASN != nil {
+		b.LocalASN = *aux.LocalRouterASN
+	}
+
+	if aux.PeerASN != nil {
+		b.PeerASN = *aux.PeerASN
+	} else if aux.PeerRouterASN != nil {
+		b.PeerASN = *aux.PeerRouterASN
+	}
+	return nil
+}
+
+// BGPInput represents the BGP configuration of a Partner Interconnect Attachment.
+type BGPInput struct {
+	// LocalASN is the local ASN
+	LocalASN int `json:"local_router_asn,omitempty"`
 	// LocalRouterIP is the local router IP
 	LocalRouterIP string `json:"local_router_ip,omitempty"`
 	// PeerASN is the peer ASN

--- a/partner_interconnect_attachments_test.go
+++ b/partner_interconnect_attachments_test.go
@@ -52,7 +52,7 @@ var vInterconnectTestJSON = `
 		"bgp":{
 			"local_asn":64532,
 			"local_router_ip":"169.250.0.1",
-			"peer_router_asn":133937,
+			"peer_asn":133937,
 			"peer_router_ip":"169.250.0.6",
 			"auth_key":"my-auth-key"
 			},


### PR DESCRIPTION
Request is expecting BGP config input with fields as `local_router_asn` and `peer_router_asn` but response should be in the form of `local_asn` and `peer_asn` 