### PR TITLE
Fix: Update godo to use simplified template response and provide consistent struct naming

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -40,7 +40,7 @@ type KubernetesService interface {
 
 	CreateNodePool(ctx context.Context, clusterID string, req *KubernetesNodePoolCreateRequest) (*KubernetesNodePool, *Response, error)
 	GetNodePool(ctx context.Context, clusterID, poolID string) (*KubernetesNodePool, *Response, error)
-	GetNodePoolTemplate(ctx context.Context, clusterID string, nodePoolName string) (*KubernetesNodePoolTemplateResponse, *Response, error)
+	GetNodePoolTemplate(ctx context.Context, clusterID string, nodePoolName string) (*KubernetesNodePoolTemplate, *Response, error)
 	ListNodePools(ctx context.Context, clusterID string, opts *ListOptions) ([]*KubernetesNodePool, *Response, error)
 	UpdateNodePool(ctx context.Context, clusterID, poolID string, req *KubernetesNodePoolUpdateRequest) (*KubernetesNodePool, *Response, error)
 	// RecycleNodePoolNodes is DEPRECATED please use DeleteNode
@@ -435,20 +435,9 @@ type KubernetesNodePool struct {
 	Nodes []*KubernetesNode `json:"nodes,omitempty"`
 }
 
-// KubernetesNodePool represents a node pool template response from the node template endpoint
-type KubernetesNodePoolTemplateResponse struct {
-	ClusterUUID string                      `json:"cluster_uuid,omitempty"`
-	Name        string                      `json:"name,omitempty"`
-	Slug        string                      `json:"slug,omitempty"`
-	Template    *KubernetesNodePoolTemplate `json:"template,omitempty"`
-}
-
 // KubernetesNodePool represents the node pool template data for a given pool.
 type KubernetesNodePoolTemplate struct {
-	Labels      map[string]string            `json:"labels,omitempty"`
-	Taints      []string                     `json:"taints,omitempty"`
-	Capacity    *KubernetesNodePoolResources `json:"capacity,omitempty"`
-	Allocatable *KubernetesNodePoolResources `json:"allocatable,omitempty"`
+	Template *KubernetesNodeTemplate
 }
 
 // KubernetesNodePoolResources represents the resources within a given template for a node pool
@@ -469,6 +458,17 @@ type KubernetesNode struct {
 
 	CreatedAt time.Time `json:"created_at,omitempty"`
 	UpdatedAt time.Time `json:"updated_at,omitempty"`
+}
+
+// KubernetesNodeTemplate represents a template in a node pool in a Kubernetes cluster.
+type KubernetesNodeTemplate struct {
+	ClusterUUID string                       `json:"cluster_uuid,omitempty"`
+	Name        string                       `json:"name,omitempty"`
+	Slug        string                       `json:"slug,omitempty"`
+	Labels      map[string]string            `json:"labels,omitempty"`
+	Taints      []string                     `json:"taints,omitempty"`
+	Capacity    *KubernetesNodePoolResources `json:"capacity,omitempty"`
+	Allocatable *KubernetesNodePoolResources `json:"allocatable,omitempty"`
 }
 
 // KubernetesNodeStatus represents the status of a particular Node in a Kubernetes cluster.
@@ -839,7 +839,7 @@ func (svc *KubernetesServiceOp) GetNodePool(ctx context.Context, clusterID, pool
 }
 
 // GetNodePoolTemplate retrieves the template used for a given node pool to scale up from zero.
-func (svc *KubernetesServiceOp) GetNodePoolTemplate(ctx context.Context, clusterID string, nodePoolName string) (*KubernetesNodePoolTemplateResponse, *Response, error) {
+func (svc *KubernetesServiceOp) GetNodePoolTemplate(ctx context.Context, clusterID string, nodePoolName string) (*KubernetesNodePoolTemplate, *Response, error) {
 	path, err := url.JoinPath(kubernetesClustersPath, clusterID, "node_pools_template", nodePoolName)
 	if err != nil {
 		return nil, nil, err
@@ -848,7 +848,7 @@ func (svc *KubernetesServiceOp) GetNodePoolTemplate(ctx context.Context, cluster
 	if err != nil {
 		return nil, nil, err
 	}
-	root := new(KubernetesNodePoolTemplateResponse)
+	root := new(KubernetesNodePoolTemplate)
 	resp, err := svc.client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -1332,12 +1332,12 @@ func TestKubernetesClusters_GetNodePoolTemplate(t *testing.T) {
 	setup()
 	defer teardown()
 	kubeSvc := client.Kubernetes
-	want := &KubernetesNodePoolTemplateResponse{
-		ClusterUUID: "8d91899c-0739-4a1a-acc5-deadbeefbb8a",
-		Name:        "pool-a",
-		Slug:        "s-1vcpu-2gb",
-		Template: &KubernetesNodePoolTemplate{
-			Taints: []string{"some-key=some-value:NoSchedule"},
+	want := &KubernetesNodePoolTemplate{
+		Template: &KubernetesNodeTemplate{
+			ClusterUUID: "8d91899c-0739-4a1a-acc5-deadbeefbb8a",
+			Name:        "pool-a",
+			Slug:        "s-1vcpu-2gb",
+			Taints:      []string{"some-key=some-value:NoSchedule"},
 			Labels: map[string]string{
 				"some-label": "some-value",
 			},
@@ -1350,29 +1350,30 @@ func TestKubernetesClusters_GetNodePoolTemplate(t *testing.T) {
 				CPU:    390,
 				Memory: "1024Mi",
 				Pods:   110,
-			}},
+			},
+		},
 	}
 	jBlob := `
 {
-   "cluster_uuid": "8d91899c-0739-4a1a-acc5-deadbeefbb8a",
-   "name": "pool-a",
-   "slug": "s-1vcpu-2gb",
-   "template": {
-      "labels": {
-         "some-label": "some-value"
-      },
-      "taints": ["some-key=some-value:NoSchedule"],
-      "capacity": {
-         "cpu": 1,
-         "memory": "2048Mi",
-         "pods": 110
-      },
-      "allocatable": {
-         "cpu": 390,
-         "memory": "1024Mi",
-         "pods": 110
-      }
-   }
+  "template": {
+    "cluster_uuid": "8d91899c-0739-4a1a-acc5-deadbeefbb8a",
+    "name": "pool-a",
+    "slug": "s-1vcpu-2gb",
+    "labels": {
+      "some-label": "some-value"
+    },
+    "taints": ["some-key=some-value:NoSchedule"],
+    "capacity": {
+      "cpu": 1,
+      "memory": "2048Mi",
+      "pods": 110
+    },
+    "allocatable": {
+      "cpu": 390,
+      "memory": "1024Mi",
+      "pods": 110
+    }
+  }
 }
 `
 	mux.HandleFunc("/v2/kubernetes/clusters/8d91899c-0739-4a1a-acc5-deadbeefbb8a/node_pools_template/pool-a", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Updates the DOKS API to correctly reflect adjustments in the node pool template response for consistent struct naming