### PR TITLE
BLOCK-4316: Adds region param in ListSnapshot for resource type volume

### DIFF
--- a/godo.go
+++ b/godo.go
@@ -144,9 +144,6 @@ type ListOptions struct {
 
 	// Whether App responses should include project_id fields. The field will be empty if false or if omitted. (ListApps)
 	WithProjects bool `url:"with_projects,omitempty"`
-
-	// Region can be used to list only snapshots from a given region
-	Region string `url:"region,omitempty"`
 }
 
 // TokenListOptions specifies the optional parameters to various List methods that support token pagination.

--- a/snapshots.go
+++ b/snapshots.go
@@ -14,6 +14,7 @@ const snapshotBasePath = "v2/snapshots"
 type SnapshotsService interface {
 	List(context.Context, *ListOptions) ([]Snapshot, *Response, error)
 	ListVolume(context.Context, *ListOptions) ([]Snapshot, *Response, error)
+	ListVolumeSnapshotByRegion(context.Context, string, *ListOptions) ([]Snapshot, *Response, error)
 	ListDroplet(context.Context, *ListOptions) ([]Snapshot, *Response, error)
 	Get(context.Context, string) (*Snapshot, *Response, error)
 	Delete(context.Context, string) (*Response, error)
@@ -52,6 +53,7 @@ type snapshotsRoot struct {
 
 type listSnapshotOptions struct {
 	ResourceType string `url:"resource_type,omitempty"`
+	Region       string `url:"region,omitempty"`
 }
 
 func (s Snapshot) String() string {
@@ -72,6 +74,12 @@ func (s *SnapshotsServiceOp) ListDroplet(ctx context.Context, opt *ListOptions) 
 // ListVolume lists all the volume snapshots.
 func (s *SnapshotsServiceOp) ListVolume(ctx context.Context, opt *ListOptions) ([]Snapshot, *Response, error) {
 	listOpt := listSnapshotOptions{ResourceType: "volume"}
+	return s.list(ctx, opt, &listOpt)
+}
+
+// ListVolumeSnapshotByRegion lists all the volume snapshot for given region
+func (s *SnapshotsServiceOp) ListVolumeSnapshotByRegion(ctx context.Context, region string, opt *ListOptions) ([]Snapshot, *Response, error) {
+	listOpt := listSnapshotOptions{ResourceType: "volume", Region: region}
 	return s.list(ctx, opt, &listOpt)
 }
 

--- a/snapshots_test.go
+++ b/snapshots_test.go
@@ -55,7 +55,7 @@ func TestSnapshots_ListVolume(t *testing.T) {
 	}
 }
 
-func TestSnapshots_ListVolume_Regional(t *testing.T) {
+func TestSnapshots_ListVolumeSnapshotByRegion(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -104,7 +104,7 @@ func TestSnapshots_ListVolume_Regional(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	snapshots, _, err := client.Snapshots.ListVolume(ctx, &ListOptions{Region: "region1"})
+	snapshots, _, err := client.Snapshots.ListVolumeSnapshotByRegion(ctx, "region1", nil)
 	if err != nil {
 		t.Errorf("Snapshots.ListVolume returned error: %v", err)
 	}
@@ -113,25 +113,13 @@ func TestSnapshots_ListVolume_Regional(t *testing.T) {
 		t.Errorf("Snapshots.ListVolume returned %+v, expected %+v", snapshots, region1Snapshots)
 	}
 
-	snapshots, _, err = client.Snapshots.ListVolume(ctx, &ListOptions{Region: "region2"})
+	snapshots, _, err = client.Snapshots.ListVolumeSnapshotByRegion(ctx, "region2", nil)
 	if err != nil {
 		t.Errorf("Snapshots.ListVolume returned error: %v", err)
 	}
 
 	if !reflect.DeepEqual(snapshots, region2Snapshots) {
 		t.Errorf("Snapshots.ListVolume returned %+v, expected %+v", snapshots, region2Snapshots)
-	}
-
-	snapshots, _, err = client.Snapshots.ListVolume(ctx, nil)
-	if err != nil {
-		t.Errorf("Snapshots.ListVolume returned error: %v", err)
-	}
-
-	// Without region all snapshots should be returned
-	allSnapshots := append([]Snapshot{}, region1Snapshots...)
-	allSnapshots = append(allSnapshots, region2Snapshots...)
-	if !reflect.DeepEqual(snapshots, allSnapshots) {
-		t.Errorf("Snapshots.ListVolume returned %+v, expected %+v", snapshots, allSnapshots)
 	}
 }
 


### PR DESCRIPTION
This PR adds a param to list `Snapshots` for given region only