### PR TITLE
Bump Go version to v1.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [ 1.22.x, 1.23.x ]
+        go-version: [ 1.23.x, 1.24.x ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/digitalocean/godo
 
-go 1.22
+go 1.23
 
 require (
 	github.com/google/go-querystring v1.1.0


### PR DESCRIPTION
Now that Go 1.24 is out, this updates godo to Go version v1.23, following our policy:

https://github.com/digitalocean/godo/blob/2e0eaabbd1e18eb13ce8d4c2539edba820dcf18f/CONTRIBUTING.md?plain=1#L71-L77