### PR TITLE
fix partner network connect json tags

### DIFF
--- a/partner_network_connect.go
+++ b/partner_network_connect.go
@@ -14,13 +14,13 @@ const partnerNetworkConnectBasePath = "/v2/partner_network_connect/attachments"
 // DigitalOcean API.
 // See: https://docs.digitalocean.com/reference/api/api-reference/#tag/PartnerNetworkConnect
 type PartnerNetworkConnectService interface {
-	List(context.Context, *ListOptions) ([]*Attachment, *Response, error)
-	Create(context.Context, *PartnerNetworkConnectCreateRequest) (*Attachment, *Response, error)
-	Get(context.Context, string) (*Attachment, *Response, error)
-	Update(context.Context, string, *PartnerNetworkConnectUpdateRequest) (*Attachment, *Response, error)
+	List(context.Context, *ListOptions) ([]*PartnerAttachment, *Response, error)
+	Create(context.Context, *PartnerNetworkConnectCreateRequest) (*PartnerAttachment, *Response, error)
+	Get(context.Context, string) (*PartnerAttachment, *Response, error)
+	Update(context.Context, string, *PartnerNetworkConnectUpdateRequest) (*PartnerAttachment, *Response, error)
 	Delete(context.Context, string) (*Response, error)
 	GetServiceKey(context.Context, string) (*ServiceKey, *Response, error)
-	SetRoutes(context.Context, string, *PartnerNetworkConnectSetRoutesRequest) (*Attachment, *Response, error)
+	SetRoutes(context.Context, string, *PartnerNetworkConnectSetRoutesRequest) (*PartnerAttachment, *Response, error)
 	ListRoutes(context.Context, string, *ListOptions) ([]*RemoteRoute, *Response, error)
 	GetBGPAuthKey(ctx context.Context, iaID string) (*BgpAuthKey, *Response, error)
 	RegenerateServiceKey(ctx context.Context, iaID string) (*RegenerateServiceKey, *Response, error)
@@ -171,8 +171,8 @@ type RemoteRoute struct {
 	Cidr string `json:"cidr,omitempty"`
 }
 
-// Attachment represents a DigitalOcean Partner Attachment.
-type Attachment struct {
+// PartnerAttachment represents a DigitalOcean Partner PartnerAttachment.
+type PartnerAttachment struct {
 	// ID is the generated ID of the Partner Attachment
 	ID string `json:"id,omitempty"`
 	// Name is the name of the Partner Attachment
@@ -194,39 +194,39 @@ type Attachment struct {
 }
 
 type partnerNetworkConnectAttachmentRoot struct {
-	Attachment *Attachment `json:"-"`
+	PartnerAttachment *PartnerAttachment `json:"-"`
 }
 
 func (r *partnerNetworkConnectAttachmentRoot) UnmarshalJSON(data []byte) error {
 	// auxiliary structure to capture both potential keys
 	var aux struct {
-		PartnerNetworkConnect *Attachment `json:"partner_network_connect"`
-		Attachment            *Attachment `json:"attachment"`
+		PartnerNetworkConnect *PartnerAttachment `json:"partner_network_connect"`
+		PartnerAttachment     *PartnerAttachment `json:"attachment"`
 	}
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
 	}
 
 	if aux.PartnerNetworkConnect != nil {
-		r.Attachment = aux.PartnerNetworkConnect
+		r.PartnerAttachment = aux.PartnerNetworkConnect
 	} else {
-		r.Attachment = aux.Attachment
+		r.PartnerAttachment = aux.PartnerAttachment
 	}
 	return nil
 }
 
 type partnerNetworkConnectAttachmentsRoot struct {
-	Attachments []*Attachment `json:"-"`
-	Links       *Links        `json:"links"`
-	Meta        *Meta         `json:"meta"`
+	PartnerAttachments []*PartnerAttachment `json:"-"`
+	Links              *Links               `json:"links"`
+	Meta               *Meta                `json:"meta"`
 }
 
 func (r *partnerNetworkConnectAttachmentsRoot) UnmarshalJSON(data []byte) error {
 	var aux struct {
-		Attachments            []*Attachment `json:"attachments"`
-		PartnerNetworkConnects []*Attachment `json:"partner_network_connects"`
-		Links                  *Links        `json:"links"`
-		Meta                   *Meta         `json:"meta"`
+		PartnerAttachments     []*PartnerAttachment `json:"attachments"`
+		PartnerNetworkConnects []*PartnerAttachment `json:"partner_network_connects"`
+		Links                  *Links               `json:"links"`
+		Meta                   *Meta                `json:"meta"`
 	}
 
 	if err := json.Unmarshal(data, &aux); err != nil {
@@ -234,9 +234,9 @@ func (r *partnerNetworkConnectAttachmentsRoot) UnmarshalJSON(data []byte) error 
 	}
 
 	if aux.PartnerNetworkConnects != nil {
-		r.Attachments = aux.PartnerNetworkConnects
+		r.PartnerAttachments = aux.PartnerNetworkConnects
 	} else {
-		r.Attachments = aux.Attachments
+		r.PartnerAttachments = aux.PartnerAttachments
 	}
 
 	r.Links = aux.Links
@@ -271,7 +271,7 @@ type regenerateServiceKeyRoot struct {
 }
 
 // List returns a list of all Partner Attachment, with optional pagination.
-func (s *PartnerNetworkConnectsServiceOp) List(ctx context.Context, opt *ListOptions) ([]*Attachment, *Response, error) {
+func (s *PartnerNetworkConnectsServiceOp) List(ctx context.Context, opt *ListOptions) ([]*PartnerAttachment, *Response, error) {
 	path, err := addOptions(partnerNetworkConnectBasePath, opt)
 	if err != nil {
 		return nil, nil, err
@@ -292,11 +292,11 @@ func (s *PartnerNetworkConnectsServiceOp) List(ctx context.Context, opt *ListOpt
 	if m := root.Meta; m != nil {
 		resp.Meta = m
 	}
-	return root.Attachments, resp, nil
+	return root.PartnerAttachments, resp, nil
 }
 
 // Create creates a new Partner Attachment.
-func (s *PartnerNetworkConnectsServiceOp) Create(ctx context.Context, create *PartnerNetworkConnectCreateRequest) (*Attachment, *Response, error) {
+func (s *PartnerNetworkConnectsServiceOp) Create(ctx context.Context, create *PartnerNetworkConnectCreateRequest) (*PartnerAttachment, *Response, error) {
 	path := partnerNetworkConnectBasePath
 
 	req, err := s.client.NewRequest(ctx, http.MethodPost, path, create.buildReq())
@@ -310,11 +310,11 @@ func (s *PartnerNetworkConnectsServiceOp) Create(ctx context.Context, create *Pa
 		return nil, resp, err
 	}
 
-	return root.Attachment, resp, nil
+	return root.PartnerAttachment, resp, nil
 }
 
 // Get returns the details of a Partner Attachment.
-func (s *PartnerNetworkConnectsServiceOp) Get(ctx context.Context, id string) (*Attachment, *Response, error) {
+func (s *PartnerNetworkConnectsServiceOp) Get(ctx context.Context, id string) (*PartnerAttachment, *Response, error) {
 	path := fmt.Sprintf("%s/%s", partnerNetworkConnectBasePath, id)
 	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
@@ -327,11 +327,11 @@ func (s *PartnerNetworkConnectsServiceOp) Get(ctx context.Context, id string) (*
 		return nil, resp, err
 	}
 
-	return root.Attachment, resp, nil
+	return root.PartnerAttachment, resp, nil
 }
 
 // Update updates a Partner Attachment properties.
-func (s *PartnerNetworkConnectsServiceOp) Update(ctx context.Context, id string, update *PartnerNetworkConnectUpdateRequest) (*Attachment, *Response, error) {
+func (s *PartnerNetworkConnectsServiceOp) Update(ctx context.Context, id string, update *PartnerNetworkConnectUpdateRequest) (*PartnerAttachment, *Response, error) {
 	path := fmt.Sprintf("%s/%s", partnerNetworkConnectBasePath, id)
 	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, update)
 	if err != nil {
@@ -344,7 +344,7 @@ func (s *PartnerNetworkConnectsServiceOp) Update(ctx context.Context, id string,
 		return nil, resp, err
 	}
 
-	return root.Attachment, resp, nil
+	return root.PartnerAttachment, resp, nil
 }
 
 // Delete deletes a Partner Attachment.
@@ -406,7 +406,7 @@ func (s *PartnerNetworkConnectsServiceOp) ListRoutes(ctx context.Context, id str
 }
 
 // SetRoutes updates specific properties of a Partner Attachment.
-func (s *PartnerNetworkConnectsServiceOp) SetRoutes(ctx context.Context, id string, set *PartnerNetworkConnectSetRoutesRequest) (*Attachment, *Response, error) {
+func (s *PartnerNetworkConnectsServiceOp) SetRoutes(ctx context.Context, id string, set *PartnerNetworkConnectSetRoutesRequest) (*PartnerAttachment, *Response, error) {
 	path := fmt.Sprintf("%s/%s/remote_routes", partnerNetworkConnectBasePath, id)
 	req, err := s.client.NewRequest(ctx, http.MethodPut, path, set)
 	if err != nil {
@@ -419,7 +419,7 @@ func (s *PartnerNetworkConnectsServiceOp) SetRoutes(ctx context.Context, id stri
 		return nil, resp, err
 	}
 
-	return root.Attachment, resp, nil
+	return root.PartnerAttachment, resp, nil
 }
 
 // GetBGPAuthKey returns Partner Attachment bgp auth key

--- a/partner_network_connect.go
+++ b/partner_network_connect.go
@@ -14,13 +14,13 @@ const partnerNetworkConnectBasePath = "/v2/partner_network_connect/attachments"
 // DigitalOcean API.
 // See: https://docs.digitalocean.com/reference/api/api-reference/#tag/PartnerNetworkConnect
 type PartnerNetworkConnectService interface {
-	List(context.Context, *ListOptions) ([]*PartnerNetworkConnect, *Response, error)
-	Create(context.Context, *PartnerNetworkConnectCreateRequest) (*PartnerNetworkConnect, *Response, error)
-	Get(context.Context, string) (*PartnerNetworkConnect, *Response, error)
-	Update(context.Context, string, *PartnerNetworkConnectUpdateRequest) (*PartnerNetworkConnect, *Response, error)
+	List(context.Context, *ListOptions) ([]*Attachment, *Response, error)
+	Create(context.Context, *PartnerNetworkConnectCreateRequest) (*Attachment, *Response, error)
+	Get(context.Context, string) (*Attachment, *Response, error)
+	Update(context.Context, string, *PartnerNetworkConnectUpdateRequest) (*Attachment, *Response, error)
 	Delete(context.Context, string) (*Response, error)
 	GetServiceKey(context.Context, string) (*ServiceKey, *Response, error)
-	SetRoutes(context.Context, string, *PartnerNetworkConnectSetRoutesRequest) (*PartnerNetworkConnect, *Response, error)
+	SetRoutes(context.Context, string, *PartnerNetworkConnectSetRoutesRequest) (*Attachment, *Response, error)
 	ListRoutes(context.Context, string, *ListOptions) ([]*RemoteRoute, *Response, error)
 	GetBGPAuthKey(ctx context.Context, iaID string) (*BgpAuthKey, *Response, error)
 	RegenerateServiceKey(ctx context.Context, iaID string) (*RegenerateServiceKey, *Response, error)
@@ -171,8 +171,8 @@ type RemoteRoute struct {
 	Cidr string `json:"cidr,omitempty"`
 }
 
-// PartnerNetworkConnect represents a DigitalOcean Partner Connect.
-type PartnerNetworkConnect struct {
+// Attachment represents a DigitalOcean Partner Connect.
+type Attachment struct {
 	// ID is the generated ID of the Partner Connect
 	ID string `json:"id,omitempty"`
 	// Name is the name of the Partner Connect
@@ -194,39 +194,39 @@ type PartnerNetworkConnect struct {
 }
 
 type partnerNetworkConnectAttachmentRoot struct {
-	PartnerNetworkConnect *PartnerNetworkConnect `json:"-"`
+	Attachment *Attachment `json:"-"`
 }
 
 func (r *partnerNetworkConnectAttachmentRoot) UnmarshalJSON(data []byte) error {
 	// auxiliary structure to capture both potential keys
 	var aux struct {
-		PartnerNetworkConnect         *PartnerNetworkConnect `json:"partner_network_connect"`
-		PartnerInterconnectAttachment *PartnerNetworkConnect `json:"partner_interconnect_attachment"`
+		PartnerNetworkConnect *Attachment `json:"partner_network_connect"`
+		Attachment            *Attachment `json:"attachment"`
 	}
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
 	}
 
 	if aux.PartnerNetworkConnect != nil {
-		r.PartnerNetworkConnect = aux.PartnerNetworkConnect
+		r.Attachment = aux.PartnerNetworkConnect
 	} else {
-		r.PartnerNetworkConnect = aux.PartnerInterconnectAttachment
+		r.Attachment = aux.Attachment
 	}
 	return nil
 }
 
-type partnerNetworkConnectsRoot struct {
-	PartnerNetworkConnects []*PartnerNetworkConnect `json:"-"`
-	Links                  *Links                   `json:"links"`
-	Meta                   *Meta                    `json:"meta"`
+type partnerNetworkConnectAttachmentsRoot struct {
+	Attachments []*Attachment `json:"-"`
+	Links       *Links        `json:"links"`
+	Meta        *Meta         `json:"meta"`
 }
 
-func (r *partnerNetworkConnectsRoot) UnmarshalJSON(data []byte) error {
+func (r *partnerNetworkConnectAttachmentsRoot) UnmarshalJSON(data []byte) error {
 	var aux struct {
-		PartnerInterconnectAttachments []*PartnerNetworkConnect `json:"partner_interconnect_attachments"`
-		PartnerNetworkConnects         []*PartnerNetworkConnect `json:"partner_network_connects"`
-		Links                          *Links                   `json:"links"`
-		Meta                           *Meta                    `json:"meta"`
+		Attachments            []*Attachment `json:"attachments"`
+		PartnerNetworkConnects []*Attachment `json:"partner_network_connects"`
+		Links                  *Links        `json:"links"`
+		Meta                   *Meta         `json:"meta"`
 	}
 
 	if err := json.Unmarshal(data, &aux); err != nil {
@@ -234,9 +234,9 @@ func (r *partnerNetworkConnectsRoot) UnmarshalJSON(data []byte) error {
 	}
 
 	if aux.PartnerNetworkConnects != nil {
-		r.PartnerNetworkConnects = aux.PartnerNetworkConnects
+		r.Attachments = aux.PartnerNetworkConnects
 	} else {
-		r.PartnerNetworkConnects = aux.PartnerInterconnectAttachments
+		r.Attachments = aux.Attachments
 	}
 
 	r.Links = aux.Links
@@ -271,7 +271,7 @@ type regenerateServiceKeyRoot struct {
 }
 
 // List returns a list of all Partner Connect, with optional pagination.
-func (s *PartnerNetworkConnectsServiceOp) List(ctx context.Context, opt *ListOptions) ([]*PartnerNetworkConnect, *Response, error) {
+func (s *PartnerNetworkConnectsServiceOp) List(ctx context.Context, opt *ListOptions) ([]*Attachment, *Response, error) {
 	path, err := addOptions(partnerNetworkConnectBasePath, opt)
 	if err != nil {
 		return nil, nil, err
@@ -281,7 +281,7 @@ func (s *PartnerNetworkConnectsServiceOp) List(ctx context.Context, opt *ListOpt
 		return nil, nil, err
 	}
 
-	root := new(partnerNetworkConnectsRoot)
+	root := new(partnerNetworkConnectAttachmentsRoot)
 	resp, err := s.client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
@@ -292,11 +292,11 @@ func (s *PartnerNetworkConnectsServiceOp) List(ctx context.Context, opt *ListOpt
 	if m := root.Meta; m != nil {
 		resp.Meta = m
 	}
-	return root.PartnerNetworkConnects, resp, nil
+	return root.Attachments, resp, nil
 }
 
 // Create creates a new Partner Connect.
-func (s *PartnerNetworkConnectsServiceOp) Create(ctx context.Context, create *PartnerNetworkConnectCreateRequest) (*PartnerNetworkConnect, *Response, error) {
+func (s *PartnerNetworkConnectsServiceOp) Create(ctx context.Context, create *PartnerNetworkConnectCreateRequest) (*Attachment, *Response, error) {
 	path := partnerNetworkConnectBasePath
 
 	req, err := s.client.NewRequest(ctx, http.MethodPost, path, create.buildReq())
@@ -310,11 +310,11 @@ func (s *PartnerNetworkConnectsServiceOp) Create(ctx context.Context, create *Pa
 		return nil, resp, err
 	}
 
-	return root.PartnerNetworkConnect, resp, nil
+	return root.Attachment, resp, nil
 }
 
 // Get returns the details of a Partner Connect.
-func (s *PartnerNetworkConnectsServiceOp) Get(ctx context.Context, id string) (*PartnerNetworkConnect, *Response, error) {
+func (s *PartnerNetworkConnectsServiceOp) Get(ctx context.Context, id string) (*Attachment, *Response, error) {
 	path := fmt.Sprintf("%s/%s", partnerNetworkConnectBasePath, id)
 	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
@@ -327,11 +327,11 @@ func (s *PartnerNetworkConnectsServiceOp) Get(ctx context.Context, id string) (*
 		return nil, resp, err
 	}
 
-	return root.PartnerNetworkConnect, resp, nil
+	return root.Attachment, resp, nil
 }
 
 // Update updates a Partner Connect properties.
-func (s *PartnerNetworkConnectsServiceOp) Update(ctx context.Context, id string, update *PartnerNetworkConnectUpdateRequest) (*PartnerNetworkConnect, *Response, error) {
+func (s *PartnerNetworkConnectsServiceOp) Update(ctx context.Context, id string, update *PartnerNetworkConnectUpdateRequest) (*Attachment, *Response, error) {
 	path := fmt.Sprintf("%s/%s", partnerNetworkConnectBasePath, id)
 	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, update)
 	if err != nil {
@@ -344,7 +344,7 @@ func (s *PartnerNetworkConnectsServiceOp) Update(ctx context.Context, id string,
 		return nil, resp, err
 	}
 
-	return root.PartnerNetworkConnect, resp, nil
+	return root.Attachment, resp, nil
 }
 
 // Delete deletes a Partner Connect.
@@ -406,7 +406,7 @@ func (s *PartnerNetworkConnectsServiceOp) ListRoutes(ctx context.Context, id str
 }
 
 // SetRoutes updates specific properties of a Partner Connect.
-func (s *PartnerNetworkConnectsServiceOp) SetRoutes(ctx context.Context, id string, set *PartnerNetworkConnectSetRoutesRequest) (*PartnerNetworkConnect, *Response, error) {
+func (s *PartnerNetworkConnectsServiceOp) SetRoutes(ctx context.Context, id string, set *PartnerNetworkConnectSetRoutesRequest) (*Attachment, *Response, error) {
 	path := fmt.Sprintf("%s/%s/remote_routes", partnerNetworkConnectBasePath, id)
 	req, err := s.client.NewRequest(ctx, http.MethodPut, path, set)
 	if err != nil {
@@ -419,7 +419,7 @@ func (s *PartnerNetworkConnectsServiceOp) SetRoutes(ctx context.Context, id stri
 		return nil, resp, err
 	}
 
-	return root.PartnerNetworkConnect, resp, nil
+	return root.Attachment, resp, nil
 }
 
 // GetBGPAuthKey returns Partner Connect bgp auth key

--- a/partner_network_connect.go
+++ b/partner_network_connect.go
@@ -10,7 +10,7 @@ import (
 
 const partnerNetworkConnectBasePath = "/v2/partner_network_connect/attachments"
 
-// PartnerNetworkConnectService is an interface for managing Partner Attachment with the
+// PartnerNetworkConnectService is an interface for managing Partner Attachments with the
 // DigitalOcean API.
 // See: https://docs.digitalocean.com/reference/api/api-reference/#tag/PartnerNetworkConnect
 type PartnerNetworkConnectService interface {

--- a/partner_network_connect.go
+++ b/partner_network_connect.go
@@ -10,7 +10,7 @@ import (
 
 const partnerNetworkConnectBasePath = "/v2/partner_network_connect/attachments"
 
-// PartnerNetworkConnectService is an interface for managing Partner Connect with the
+// PartnerNetworkConnectService is an interface for managing Partner Attachment with the
 // DigitalOcean API.
 // See: https://docs.digitalocean.com/reference/api/api-reference/#tag/PartnerNetworkConnect
 type PartnerNetworkConnectService interface {
@@ -28,39 +28,39 @@ type PartnerNetworkConnectService interface {
 
 var _ PartnerNetworkConnectService = &PartnerNetworkConnectsServiceOp{}
 
-// PartnerNetworkConnectsServiceOp interfaces with the Partner Connect endpoints in the DigitalOcean API.
+// PartnerNetworkConnectsServiceOp interfaces with the Partner Attachment endpoints in the DigitalOcean API.
 type PartnerNetworkConnectsServiceOp struct {
 	client *Client
 }
 
-// PartnerNetworkConnectCreateRequest represents a request to create a Partner Connect.
+// PartnerNetworkConnectCreateRequest represents a request to create a Partner Attachment.
 type PartnerNetworkConnectCreateRequest struct {
-	// Name is the name of the Partner Connect
+	// Name is the name of the Partner Attachment
 	Name string `json:"name,omitempty"`
 	// ConnectionBandwidthInMbps is the bandwidth of the connection in Mbps
 	ConnectionBandwidthInMbps int `json:"connection_bandwidth_in_mbps,omitempty"`
-	// Region is the region where the Partner Connect is created
+	// Region is the region where the Partner Attachment is created
 	Region string `json:"region,omitempty"`
 	// NaaSProvider is the name of the Network as a Service provider
 	NaaSProvider string `json:"naas_provider,omitempty"`
-	// VPCIDs is the IDs of the VPCs to which the Partner Connect is connected
+	// VPCIDs is the IDs of the VPCs to which the Partner Attachment is connected
 	VPCIDs []string `json:"vpc_ids,omitempty"`
-	// BGP is the BGP configuration of the Partner Connect
+	// BGP is the BGP configuration of the Partner Attachment
 	BGP BGP `json:"bgp,omitempty"`
 }
 
 type partnerNetworkConnectRequestBody struct {
-	// Name is the name of the Partner Connect
+	// Name is the name of the Partner Attachment
 	Name string `json:"name,omitempty"`
 	// ConnectionBandwidthInMbps is the bandwidth of the connection in Mbps
 	ConnectionBandwidthInMbps int `json:"connection_bandwidth_in_mbps,omitempty"`
-	// Region is the region where the Partner Connect is created
+	// Region is the region where the Partner Attachment is created
 	Region string `json:"region,omitempty"`
 	// NaaSProvider is the name of the Network as a Service provider
 	NaaSProvider string `json:"naas_provider,omitempty"`
-	// VPCIDs is the IDs of the VPCs to which the Partner Connect is connected
+	// VPCIDs is the IDs of the VPCs to which the Partner Attachment is connected
 	VPCIDs []string `json:"vpc_ids,omitempty"`
-	// BGP is the BGP configuration of the Partner Connect
+	// BGP is the BGP configuration of the Partner Attachment
 	BGP *BGPInput `json:"bgp,omitempty"`
 }
 
@@ -86,20 +86,20 @@ func (req *PartnerNetworkConnectCreateRequest) buildReq() *partnerNetworkConnect
 	return request
 }
 
-// PartnerNetworkConnectUpdateRequest represents a request to update a Partner Connect.
+// PartnerNetworkConnectUpdateRequest represents a request to update a Partner Attachment.
 type PartnerNetworkConnectUpdateRequest struct {
-	// Name is the name of the Partner Connect
+	// Name is the name of the Partner Attachment
 	Name string `json:"name,omitempty"`
-	//VPCIDs is the IDs of the VPCs to which the Partner Connect is connected
+	//VPCIDs is the IDs of the VPCs to which the Partner Attachment is connected
 	VPCIDs []string `json:"vpc_ids,omitempty"`
 }
 
 type PartnerNetworkConnectSetRoutesRequest struct {
-	// Routes is the list of routes to be used for the Partner Connect
+	// Routes is the list of routes to be used for the Partner Attachment
 	Routes []string `json:"routes,omitempty"`
 }
 
-// BGP represents the BGP configuration of a Partner Connect.
+// BGP represents the BGP configuration of a Partner Attachment.
 type BGP struct {
 	// LocalASN is the local ASN
 	LocalASN int `json:"local_asn,omitempty"`
@@ -142,7 +142,7 @@ func (b *BGP) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// BGPInput represents the BGP configuration of a Partner Connect.
+// BGPInput represents the BGP configuration of a Partner Attachment.
 type BGPInput struct {
 	// LocalASN is the local ASN
 	LocalASN int `json:"local_router_asn,omitempty"`
@@ -156,14 +156,14 @@ type BGPInput struct {
 	AuthKey string `json:"auth_key,omitempty"`
 }
 
-// ServiceKey represents the service key of a Partner Connect.
+// ServiceKey represents the service key of a Partner Attachment.
 type ServiceKey struct {
 	Value     string    `json:"value,omitempty"`
 	State     string    `json:"state,omitempty"`
 	CreatedAt time.Time `json:"created_at,omitempty"`
 }
 
-// RemoteRoute represents a route for a Partner Connect.
+// RemoteRoute represents a route for a Partner Attachment.
 type RemoteRoute struct {
 	// ID is the generated ID of the Route
 	ID string `json:"id,omitempty"`
@@ -171,25 +171,25 @@ type RemoteRoute struct {
 	Cidr string `json:"cidr,omitempty"`
 }
 
-// Attachment represents a DigitalOcean Partner Connect.
+// Attachment represents a DigitalOcean Partner Attachment.
 type Attachment struct {
-	// ID is the generated ID of the Partner Connect
+	// ID is the generated ID of the Partner Attachment
 	ID string `json:"id,omitempty"`
-	// Name is the name of the Partner Connect
+	// Name is the name of the Partner Attachment
 	Name string `json:"name,omitempty"`
-	// State is the state of the Partner Connect
+	// State is the state of the Partner Attachment
 	State string `json:"state,omitempty"`
 	// ConnectionBandwidthInMbps is the bandwidth of the connection in Mbps
 	ConnectionBandwidthInMbps int `json:"connection_bandwidth_in_mbps,omitempty"`
-	// Region is the region where the Partner Connect is created
+	// Region is the region where the Partner Attachment is created
 	Region string `json:"region,omitempty"`
 	// NaaSProvider is the name of the Network as a Service provider
 	NaaSProvider string `json:"naas_provider,omitempty"`
-	// VPCIDs is the IDs of the VPCs to which the Partner Connect is connected
+	// VPCIDs is the IDs of the VPCs to which the Partner Attachment is connected
 	VPCIDs []string `json:"vpc_ids,omitempty"`
-	// BGP is the BGP configuration of the Partner Connect
+	// BGP is the BGP configuration of the Partner Attachment
 	BGP BGP `json:"bgp,omitempty"`
-	// CreatedAt is time when this Partner Connect was first created
+	// CreatedAt is time when this Partner Attachment was first created
 	CreatedAt time.Time `json:"created_at,omitempty"`
 }
 
@@ -270,7 +270,7 @@ type regenerateServiceKeyRoot struct {
 	RegenerateServiceKey *RegenerateServiceKey `json:"-"`
 }
 
-// List returns a list of all Partner Connect, with optional pagination.
+// List returns a list of all Partner Attachment, with optional pagination.
 func (s *PartnerNetworkConnectsServiceOp) List(ctx context.Context, opt *ListOptions) ([]*Attachment, *Response, error) {
 	path, err := addOptions(partnerNetworkConnectBasePath, opt)
 	if err != nil {
@@ -295,7 +295,7 @@ func (s *PartnerNetworkConnectsServiceOp) List(ctx context.Context, opt *ListOpt
 	return root.Attachments, resp, nil
 }
 
-// Create creates a new Partner Connect.
+// Create creates a new Partner Attachment.
 func (s *PartnerNetworkConnectsServiceOp) Create(ctx context.Context, create *PartnerNetworkConnectCreateRequest) (*Attachment, *Response, error) {
 	path := partnerNetworkConnectBasePath
 
@@ -313,7 +313,7 @@ func (s *PartnerNetworkConnectsServiceOp) Create(ctx context.Context, create *Pa
 	return root.Attachment, resp, nil
 }
 
-// Get returns the details of a Partner Connect.
+// Get returns the details of a Partner Attachment.
 func (s *PartnerNetworkConnectsServiceOp) Get(ctx context.Context, id string) (*Attachment, *Response, error) {
 	path := fmt.Sprintf("%s/%s", partnerNetworkConnectBasePath, id)
 	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
@@ -330,7 +330,7 @@ func (s *PartnerNetworkConnectsServiceOp) Get(ctx context.Context, id string) (*
 	return root.Attachment, resp, nil
 }
 
-// Update updates a Partner Connect properties.
+// Update updates a Partner Attachment properties.
 func (s *PartnerNetworkConnectsServiceOp) Update(ctx context.Context, id string, update *PartnerNetworkConnectUpdateRequest) (*Attachment, *Response, error) {
 	path := fmt.Sprintf("%s/%s", partnerNetworkConnectBasePath, id)
 	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, update)
@@ -347,7 +347,7 @@ func (s *PartnerNetworkConnectsServiceOp) Update(ctx context.Context, id string,
 	return root.Attachment, resp, nil
 }
 
-// Delete deletes a Partner Connect.
+// Delete deletes a Partner Attachment.
 func (s *PartnerNetworkConnectsServiceOp) Delete(ctx context.Context, id string) (*Response, error) {
 	path := fmt.Sprintf("%s/%s", partnerNetworkConnectBasePath, id)
 	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
@@ -379,7 +379,7 @@ func (s *PartnerNetworkConnectsServiceOp) GetServiceKey(ctx context.Context, id 
 	return root.ServiceKey, resp, nil
 }
 
-// ListRoutes lists all remote routes for a Partner Connect.
+// ListRoutes lists all remote routes for a Partner Attachment.
 func (s *PartnerNetworkConnectsServiceOp) ListRoutes(ctx context.Context, id string, opt *ListOptions) ([]*RemoteRoute, *Response, error) {
 	path, err := addOptions(fmt.Sprintf("%s/%s/remote_routes", partnerNetworkConnectBasePath, id), opt)
 	if err != nil {
@@ -405,7 +405,7 @@ func (s *PartnerNetworkConnectsServiceOp) ListRoutes(ctx context.Context, id str
 	return root.RemoteRoutes, resp, nil
 }
 
-// SetRoutes updates specific properties of a Partner Connect.
+// SetRoutes updates specific properties of a Partner Attachment.
 func (s *PartnerNetworkConnectsServiceOp) SetRoutes(ctx context.Context, id string, set *PartnerNetworkConnectSetRoutesRequest) (*Attachment, *Response, error) {
 	path := fmt.Sprintf("%s/%s/remote_routes", partnerNetworkConnectBasePath, id)
 	req, err := s.client.NewRequest(ctx, http.MethodPut, path, set)
@@ -422,7 +422,7 @@ func (s *PartnerNetworkConnectsServiceOp) SetRoutes(ctx context.Context, id stri
 	return root.Attachment, resp, nil
 }
 
-// GetBGPAuthKey returns Partner Connect bgp auth key
+// GetBGPAuthKey returns Partner Attachment bgp auth key
 func (s *PartnerNetworkConnectsServiceOp) GetBGPAuthKey(ctx context.Context, iaID string) (*BgpAuthKey, *Response, error) {
 	path := fmt.Sprintf("%s/%s/bgp_auth_key", partnerNetworkConnectBasePath, iaID)
 	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
@@ -439,7 +439,7 @@ func (s *PartnerNetworkConnectsServiceOp) GetBGPAuthKey(ctx context.Context, iaI
 	return root.BgpAuthKey, resp, nil
 }
 
-// RegenerateServiceKey regenerates the service key of a Partner Connect.
+// RegenerateServiceKey regenerates the service key of a Partner Attachment.
 func (s *PartnerNetworkConnectsServiceOp) RegenerateServiceKey(ctx context.Context, iaID string) (*RegenerateServiceKey, *Response, error) {
 	path := fmt.Sprintf("%s/%s/service_key", partnerNetworkConnectBasePath, iaID)
 	req, err := s.client.NewRequest(ctx, http.MethodPost, path, nil)

--- a/partner_network_connect.go
+++ b/partner_network_connect.go
@@ -43,7 +43,7 @@ type PartnerNetworkConnectCreateRequest struct {
 	Region string `json:"region,omitempty"`
 	// NaaSProvider is the name of the Network as a Service provider
 	NaaSProvider string `json:"naas_provider,omitempty"`
-	// VPCIDs is the IDs of the VPCs to which the Partner Attachment is connected
+	// VPCIDs is the IDs of the VPCs to which the Partner Attachment is connected to
 	VPCIDs []string `json:"vpc_ids,omitempty"`
 	// BGP is the BGP configuration of the Partner Attachment
 	BGP BGP `json:"bgp,omitempty"`

--- a/partner_network_connect.go
+++ b/partner_network_connect.go
@@ -58,7 +58,7 @@ type partnerNetworkConnectRequestBody struct {
 	Region string `json:"region,omitempty"`
 	// NaaSProvider is the name of the Network as a Service provider
 	NaaSProvider string `json:"naas_provider,omitempty"`
-	// VPCIDs is the IDs of the VPCs to which the Partner Attachment is connected
+	// VPCIDs is the IDs of the VPCs to which the Partner Attachment is connected to
 	VPCIDs []string `json:"vpc_ids,omitempty"`
 	// BGP is the BGP configuration of the Partner Attachment
 	BGP *BGPInput `json:"bgp,omitempty"`
@@ -90,7 +90,7 @@ func (req *PartnerNetworkConnectCreateRequest) buildReq() *partnerNetworkConnect
 type PartnerNetworkConnectUpdateRequest struct {
 	// Name is the name of the Partner Attachment
 	Name string `json:"name,omitempty"`
-	//VPCIDs is the IDs of the VPCs to which the Partner Attachment is connected
+	//VPCIDs is the IDs of the VPCs to which the Partner Attachment is connected to
 	VPCIDs []string `json:"vpc_ids,omitempty"`
 }
 
@@ -185,7 +185,7 @@ type Attachment struct {
 	Region string `json:"region,omitempty"`
 	// NaaSProvider is the name of the Network as a Service provider
 	NaaSProvider string `json:"naas_provider,omitempty"`
-	// VPCIDs is the IDs of the VPCs to which the Partner Attachment is connected
+	// VPCIDs is the IDs of the VPCs to which the Partner Attachment is connected to
 	VPCIDs []string `json:"vpc_ids,omitempty"`
 	// BGP is the BGP configuration of the Partner Attachment
 	BGP BGP `json:"bgp,omitempty"`

--- a/partner_network_connect_test.go
+++ b/partner_network_connect_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var vPartnerNetworkConnectTestObj = &Attachment{
+var vPartnerNetworkConnectTestObj = &PartnerAttachment{
 	ID:                        "880b7f98-f062-404d-b33c-458d545696f6",
 	Name:                      "my-new-partner-connect",
 	State:                     "ACTIVE",
@@ -29,7 +29,7 @@ var vPartnerNetworkConnectTestObj = &Attachment{
 	CreatedAt: time.Date(2024, 12, 26, 21, 48, 40, 995304079, time.UTC),
 }
 
-var vPartnerNetworkConnectNoBGPTestObj = &Attachment{
+var vPartnerNetworkConnectNoBGPTestObj = &PartnerAttachment{
 	ID:                        "880b7f98-f062-404d-b33c-458d545696f6",
 	Name:                      "my-new-partner-connect",
 	State:                     "ACTIVE",
@@ -82,7 +82,7 @@ func TestPartnerNetworkConnects_List(t *testing.T) {
 
 	svc := client.PartnerNetworkConnect
 	path := "/v2/partner_network_connect/attachments"
-	want := []*Attachment{
+	want := []*PartnerAttachment{
 		vPartnerNetworkConnectTestObj,
 	}
 	links := &Links{
@@ -375,7 +375,7 @@ func TestPartnerNetworkConnect_Set(t *testing.T) {
 		req                         *PartnerNetworkConnectSetRoutesRequest
 		mockResponse                string
 		expectedRequestBody         string
-		expectedUpdatedInterconnect *Attachment
+		expectedUpdatedInterconnect *PartnerAttachment
 	}{
 		{
 			desc: "set remote routes",

--- a/partner_network_connect_test.go
+++ b/partner_network_connect_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var vPartnerNetworkConnectTestObj = &PartnerNetworkConnect{
+var vPartnerNetworkConnectTestObj = &Attachment{
 	ID:                        "880b7f98-f062-404d-b33c-458d545696f6",
 	Name:                      "my-new-partner-connect",
 	State:                     "ACTIVE",
@@ -29,7 +29,7 @@ var vPartnerNetworkConnectTestObj = &PartnerNetworkConnect{
 	CreatedAt: time.Date(2024, 12, 26, 21, 48, 40, 995304079, time.UTC),
 }
 
-var vPartnerNetworkConnectNoBGPTestObj = &PartnerNetworkConnect{
+var vPartnerNetworkConnectNoBGPTestObj = &Attachment{
 	ID:                        "880b7f98-f062-404d-b33c-458d545696f6",
 	Name:                      "my-new-partner-connect",
 	State:                     "ACTIVE",
@@ -82,7 +82,7 @@ func TestPartnerNetworkConnects_List(t *testing.T) {
 
 	svc := client.PartnerNetworkConnect
 	path := "/v2/partner_network_connect/attachments"
-	want := []*PartnerNetworkConnect{
+	want := []*Attachment{
 		vPartnerNetworkConnectTestObj,
 	}
 	links := &Links{
@@ -96,7 +96,7 @@ func TestPartnerNetworkConnects_List(t *testing.T) {
 	}
 	jsonBlob := `
 {
-  "partner_network_connects": [
+  "attachments": [
 ` + vPartnerNetworkConnectTestJSON + `
   ],
   "links": {
@@ -142,7 +142,7 @@ func TestPartnerNetworkConnects_Create(t *testing.T) {
 	}
 	jsonBlob := `
 {
-	"partner_network_connect":
+	"attachment":
 ` + vPartnerNetworkConnectTestJSON + `
 }
 `
@@ -180,7 +180,7 @@ func TestPartnerNetworkConnects_CreateNoBGP(t *testing.T) {
 	}
 	jsonBlob := `
 {
-	"partner_network_connect":
+	"attachment":
 ` + vPartnerNetworkConnectNoBGPTestJSON + `
 }
 `
@@ -220,7 +220,7 @@ func TestPartnerNetworkConnects_Get(t *testing.T) {
 	id := "880b7f98-f062-404d-b33c-458d545696f6"
 	jsonBlob := `
 {
-	"partner_network_connect":
+	"attachment":
 ` + vPartnerNetworkConnectTestJSON + `
 }
 `
@@ -249,7 +249,7 @@ func TestPartnerNetworkConnects_Update(t *testing.T) {
 	}
 	jsonBlob := `
 {
-	"partner_network_connect":
+	"attachment":
 ` + vPartnerNetworkConnectTestJSON + `
 }
 `
@@ -375,7 +375,7 @@ func TestPartnerNetworkConnect_Set(t *testing.T) {
 		req                         *PartnerNetworkConnectSetRoutesRequest
 		mockResponse                string
 		expectedRequestBody         string
-		expectedUpdatedInterconnect *PartnerNetworkConnect
+		expectedUpdatedInterconnect *Attachment
 	}{
 		{
 			desc: "set remote routes",
@@ -385,7 +385,7 @@ func TestPartnerNetworkConnect_Set(t *testing.T) {
 			},
 			mockResponse: `
 {
-	"partner_network_connect":
+	"attachment":
 ` + vPartnerNetworkConnectTestJSON + `
 }
 			`,


### PR DESCRIPTION
Although the product name is partner network connect, the returned json object is `attachment` not `partner_network_connect`