### PR TITLE
hotfix: json field name

### DIFF
--- a/partner_network_connect.go
+++ b/partner_network_connect.go
@@ -201,7 +201,7 @@ func (r *partnerNetworkConnectAttachmentRoot) UnmarshalJSON(data []byte) error {
 	// auxiliary structure to capture both potential keys
 	var aux struct {
 		PartnerNetworkConnect *PartnerAttachment `json:"partner_network_connect"`
-		PartnerAttachment     *PartnerAttachment `json:"attachment"`
+		PartnerAttachment     *PartnerAttachment `json:"partner_attachment"`
 	}
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
@@ -223,7 +223,7 @@ type partnerNetworkConnectAttachmentsRoot struct {
 
 func (r *partnerNetworkConnectAttachmentsRoot) UnmarshalJSON(data []byte) error {
 	var aux struct {
-		PartnerAttachments     []*PartnerAttachment `json:"attachments"`
+		PartnerAttachments     []*PartnerAttachment `json:"partner_attachments"`
 		PartnerNetworkConnects []*PartnerAttachment `json:"partner_network_connects"`
 		Links                  *Links               `json:"links"`
 		Meta                   *Meta                `json:"meta"`

--- a/partner_network_connect_test.go
+++ b/partner_network_connect_test.go
@@ -96,7 +96,7 @@ func TestPartnerNetworkConnects_List(t *testing.T) {
 	}
 	jsonBlob := `
 {
-  "attachments": [
+  "partner_attachments": [
 ` + vPartnerNetworkConnectTestJSON + `
   ],
   "links": {
@@ -142,7 +142,7 @@ func TestPartnerNetworkConnects_Create(t *testing.T) {
 	}
 	jsonBlob := `
 {
-	"attachment":
+	"partner_attachment":
 ` + vPartnerNetworkConnectTestJSON + `
 }
 `
@@ -180,7 +180,7 @@ func TestPartnerNetworkConnects_CreateNoBGP(t *testing.T) {
 	}
 	jsonBlob := `
 {
-	"attachment":
+	"partner_attachment":
 ` + vPartnerNetworkConnectNoBGPTestJSON + `
 }
 `
@@ -220,7 +220,7 @@ func TestPartnerNetworkConnects_Get(t *testing.T) {
 	id := "880b7f98-f062-404d-b33c-458d545696f6"
 	jsonBlob := `
 {
-	"attachment":
+	"partner_attachment":
 ` + vPartnerNetworkConnectTestJSON + `
 }
 `
@@ -249,7 +249,7 @@ func TestPartnerNetworkConnects_Update(t *testing.T) {
 	}
 	jsonBlob := `
 {
-	"attachment":
+	"partner_attachment":
 ` + vPartnerNetworkConnectTestJSON + `
 }
 `
@@ -385,7 +385,7 @@ func TestPartnerNetworkConnect_Set(t *testing.T) {
 			},
 			mockResponse: `
 {
-	"attachment":
+	"partner_attachment":
 ` + vPartnerNetworkConnectTestJSON + `
 }
 			`,


### PR DESCRIPTION
By mistake, I used `"attachment"` as json tag but the actual response is `"partner_attachment"`, see the API response:
![Screenshot 2025-03-24 at 9 53 20 a m](https://github.com/user-attachments/assets/69991cfa-30a6-4d5e-b316-aa027b3597a4)
