### PR TITLE
[WIP] docr: Update RegistriesService to add all the methods which makes it self-sufficient for all registries operations

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -14,14 +14,13 @@ const (
 	registryPath = "/v2/registry"
 	// RegistryServer is the hostname of the DigitalOcean registry service
 	RegistryServer = "registry.digitalocean.com"
-
-	// Multi-registry Open Beta API constants
-	registriesPath = "/v2/registries"
 )
 
 // RegistryService is an interface for interfacing with the Registry endpoints
 // of the DigitalOcean API.
 // See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Container-Registry
+//
+// NOTE: We are introducing a new RegistriesService and this one will be deprecated eventually.
 type RegistryService interface {
 	Create(context.Context, *RegistryCreateRequest) (*Registry, *Response, error)
 	Get(context.Context) (*Registry, *Response, error)
@@ -627,23 +626,52 @@ func (svc *RegistryServiceOp) ValidateName(ctx context.Context, request *Registr
 	return resp, nil
 }
 
-// RegistriesService is an interface for interfacing with the new multiple-registry beta endpoints
+const (
+	registriesPath = "/v2/registries"
+)
+
+// RegistriesService is an interface for interfacing with the new multiple-registry endpoints
 // of the DigitalOcean API.
-//
-// We are creating a separate Service in alignment with the new /v2/registries endpoints.
 type RegistriesService interface {
 	Get(context.Context, string) (*Registry, *Response, error)
 	List(context.Context) ([]*Registry, *Response, error)
-	Create(context.Context, *RegistriesCreateRequest) (*Registry, *Response, error)
+	Create(context.Context, *RegistryCreateRequest) (*Registry, *Response, error)
 	Delete(context.Context, string) (*Response, error)
 	DockerCredentials(context.Context, string, *RegistryDockerCredentialsRequest) (*DockerCredentials, *Response, error)
+	ListRepositories(context.Context, string, *ListOptions) ([]*Repository, *Response, error)
+	ListRepositoriesV2(context.Context, string, *TokenListOptions) ([]*RepositoryV2, *Response, error)
+	ListRepositoryTags(context.Context, string, string, *ListOptions) ([]*RepositoryTag, *Response, error)
+	DeleteTag(context.Context, string, string, string) (*Response, error)
+	ListRepositoryManifests(context.Context, string, string, *ListOptions) ([]*RepositoryManifest, *Response, error)
+	DeleteManifest(context.Context, string, string, string) (*Response, error)
+	StartGarbageCollection(context.Context, string, ...*StartGarbageCollectionRequest) (*GarbageCollection, *Response, error)
+	GetGarbageCollection(context.Context, string) (*GarbageCollection, *Response, error)
+	ListGarbageCollections(context.Context, string, *ListOptions) ([]*GarbageCollection, *Response, error)
+	UpdateGarbageCollection(context.Context, string, string, *UpdateGarbageCollectionRequest) (*GarbageCollection, *Response, error)
+	GetOptions(context.Context) (*RegistryOptions, *Response, error)
+	GetSubscription(context.Context) (*RegistrySubscription, *Response, error)
+	UpdateSubscription(context.Context, *RegistrySubscriptionUpdateRequest) (*RegistrySubscription, *Response, error)
+	ValidateName(context.Context, *RegistryValidateNameRequest) (*Response, error)
 }
 
 var _ RegistriesService = &RegistriesServiceOp{}
 
-// RegistriesServiceOp handles communication with the multiple-registry beta methods.
 type RegistriesServiceOp struct {
 	client *Client
+}
+
+// List returns a list of the named Registries.
+func (svc *RegistriesServiceOp) List(ctx context.Context) ([]*Registry, *Response, error) {
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, registriesPath, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(registriesRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Registries, resp, nil
 }
 
 // Get returns the details of a named Registry.
@@ -661,22 +689,8 @@ func (svc *RegistriesServiceOp) Get(ctx context.Context, registry string) (*Regi
 	return root.Registry, resp, nil
 }
 
-// List returns a list of the named Registries.
-func (svc *RegistriesServiceOp) List(ctx context.Context) ([]*Registry, *Response, error) {
-	req, err := svc.client.NewRequest(ctx, http.MethodGet, registriesPath, nil)
-	if err != nil {
-		return nil, nil, err
-	}
-	root := new(registriesRoot)
-	resp, err := svc.client.Do(ctx, req, root)
-	if err != nil {
-		return nil, resp, err
-	}
-	return root.Registries, resp, nil
-}
-
-// Create creates a named Registry.
-func (svc *RegistriesServiceOp) Create(ctx context.Context, create *RegistriesCreateRequest) (*Registry, *Response, error) {
+// Create creates a new registry.
+func (svc *RegistriesServiceOp) Create(ctx context.Context, create *RegistryCreateRequest) (*Registry, *Response, error) {
 	req, err := svc.client.NewRequest(ctx, http.MethodPost, registriesPath, create)
 	if err != nil {
 		return nil, nil, err
@@ -729,4 +743,288 @@ func (svc *RegistriesServiceOp) DockerCredentials(ctx context.Context, registry 
 		DockerConfigJSON: buf.Bytes(),
 	}
 	return dc, resp, nil
+}
+
+// ListRepositories returns a list of repositories
+func (svc *RegistriesServiceOp) ListRepositories(ctx context.Context, registry string, opts *ListOptions) ([]*Repository, *Response, error) {
+	path := fmt.Sprintf("%s/%s/repositories", registriesPath, registry)
+	path, err := addOptions(path, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(repositoriesRoot)
+
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
+	}
+
+	return root.Repositories, resp, nil
+}
+
+// ListRepositoriesV2 returns a list of repositories in V2 format
+func (svc *RegistriesServiceOp) ListRepositoriesV2(ctx context.Context, registry string, opts *TokenListOptions) ([]*RepositoryV2, *Response, error) {
+	path := fmt.Sprintf("%s/%s/repositoriesV2", registriesPath, registry)
+	path, err := addOptions(path, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(repositoriesV2Root)
+
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	resp.Links = root.Links
+	resp.Meta = root.Meta
+
+	return root.Repositories, resp, nil
+}
+
+// ListRepositoryTags returns a list of tags in a repository
+func (svc *RegistriesServiceOp) ListRepositoryTags(ctx context.Context, registry, repository string, opts *ListOptions) ([]*RepositoryTag, *Response, error) {
+	path := fmt.Sprintf("%s/%s/repositories/%s/tags", registriesPath, registry, url.PathEscape(repository))
+	path, err := addOptions(path, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(repositoryTagsRoot)
+
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
+	}
+
+	return root.Tags, resp, nil
+}
+
+// DeleteTag deletes a tag from a repository
+func (svc *RegistriesServiceOp) DeleteTag(ctx context.Context, registry, repository, tag string) (*Response, error) {
+	path := fmt.Sprintf("%s/%s/repositories/%s/tags/%s", registriesPath, registry, url.PathEscape(repository), tag)
+	req, err := svc.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := svc.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// ListRepositoryManifests returns a list of manifests in a repository
+func (svc *RegistriesServiceOp) ListRepositoryManifests(ctx context.Context, registry, repository string, opts *ListOptions) ([]*RepositoryManifest, *Response, error) {
+	path := fmt.Sprintf("%s/%s/repositories/%s/digests", registriesPath, registry, url.PathEscape(repository))
+	path, err := addOptions(path, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(repositoryManifestsRoot)
+
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	resp.Links = root.Links
+	resp.Meta = root.Meta
+
+	return root.Manifests, resp, nil
+}
+
+// DeleteManifest deletes a manifest from a repository
+func (svc *RegistriesServiceOp) DeleteManifest(ctx context.Context, registry, repository, digest string) (*Response, error) {
+	path := fmt.Sprintf("%s/%s/repositories/%s/digests/%s", registriesPath, registry, url.PathEscape(repository), digest)
+	req, err := svc.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := svc.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// StartGarbageCollection starts a garbage collection process
+func (svc *RegistriesServiceOp) StartGarbageCollection(ctx context.Context, registry string, request ...*StartGarbageCollectionRequest) (*GarbageCollection, *Response, error) {
+	path := fmt.Sprintf("%s/%s/garbage-collection", registriesPath, registry)
+	var requestParams interface{}
+	if len(request) < 1 {
+		// default to only garbage collecting unreferenced blobs for backwards
+		// compatibility
+		requestParams = &StartGarbageCollectionRequest{
+			Type: GCTypeUnreferencedBlobsOnly,
+		}
+	} else {
+		requestParams = request[0]
+	}
+	req, err := svc.client.NewRequest(ctx, http.MethodPost, path, requestParams)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(garbageCollectionRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.GarbageCollection, resp, err
+}
+
+// GetGarbageCollection gets the active garbage collection
+func (svc *RegistriesServiceOp) GetGarbageCollection(ctx context.Context, registry string) (*GarbageCollection, *Response, error) {
+	path := fmt.Sprintf("%s/%s/garbage-collection", registriesPath, registry)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(garbageCollectionRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.GarbageCollection, resp, nil
+}
+
+// ListGarbageCollections lists all garbage collections
+func (svc *RegistriesServiceOp) ListGarbageCollections(ctx context.Context, registry string, opts *ListOptions) ([]*GarbageCollection, *Response, error) {
+	path := fmt.Sprintf("%s/%s/garbage-collections", registriesPath, registry)
+	path, err := addOptions(path, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(garbageCollectionsRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	if root.Links != nil {
+		resp.Links = root.Links
+	}
+	if root.Meta != nil {
+		resp.Meta = root.Meta
+	}
+
+	return root.GarbageCollections, resp, nil
+}
+
+// UpdateGarbageCollection updates a garbage collection
+func (svc *RegistriesServiceOp) UpdateGarbageCollection(ctx context.Context, registry, gcUUID string, request *UpdateGarbageCollectionRequest) (*GarbageCollection, *Response, error) {
+	path := fmt.Sprintf("%s/%s/garbage-collection/%s", registriesPath, registry, gcUUID)
+	req, err := svc.client.NewRequest(ctx, http.MethodPut, path, request)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(garbageCollectionRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.GarbageCollection, resp, nil
+}
+
+// GetOptions gets registry options
+func (svc *RegistriesServiceOp) GetOptions(ctx context.Context) (*RegistryOptions, *Response, error) {
+	path := fmt.Sprintf("%s/options", registriesPath)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(registryOptionsRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Options, resp, nil
+}
+
+// GetSubscription gets subscription information
+func (svc *RegistriesServiceOp) GetSubscription(ctx context.Context) (*RegistrySubscription, *Response, error) {
+	path := fmt.Sprintf("%s/subscription", registriesPath)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(registrySubscriptionRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Subscription, resp, nil
+}
+
+// UpdateSubscription updates subscription information
+func (svc *RegistriesServiceOp) UpdateSubscription(ctx context.Context, request *RegistrySubscriptionUpdateRequest) (*RegistrySubscription, *Response, error) {
+	path := fmt.Sprintf("%s/subscription", registriesPath)
+	req, err := svc.client.NewRequest(ctx, http.MethodPost, path, request)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(registrySubscriptionRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Subscription, resp, nil
+}
+
+// ValidateName validates a registry name
+func (svc *RegistriesServiceOp) ValidateName(ctx context.Context, request *RegistryValidateNameRequest) (*Response, error) {
+	path := fmt.Sprintf("%s/validate-name", registriesPath)
+	req, err := svc.client.NewRequest(ctx, http.MethodPost, path, request)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := svc.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
 }

--- a/registry_test.go
+++ b/registry_test.go
@@ -966,7 +966,7 @@ func TestRegistry_ValidateName(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// Tests for Registries service methods
+// Tests for RegistriesService
 func TestRegistries_Get(t *testing.T) {
 	setup()
 	defer teardown()
@@ -1033,54 +1033,7 @@ func TestRegistries_List(t *testing.T) {
 	})
 	got, _, err := client.Registries.List(ctx)
 	require.NoError(t, err)
-	fmt.Printf("Expected: %+v\n", wantRegistries)
-	fmt.Printf("Got: %+v\n", got)
 	require.Equal(t, wantRegistries, got)
-}
-
-func TestRegistries_Create(t *testing.T) {
-	setup()
-	defer teardown()
-
-	want := &Registry{
-		Name:                       testRegistry,
-		StorageUsageBytes:          0,
-		StorageUsageBytesUpdatedAt: testTime,
-		CreatedAt:                  testTime,
-		Region:                     testRegion,
-	}
-
-	createRequest := &RegistriesCreateRequest{
-		Name:   want.Name,
-		Region: testRegion,
-	}
-
-	createResponseJSON := `
-{
-	"registry": {
-		"name": "` + testRegistry + `",
-		"storage_usage_bytes": 0,
-		"storage_usage_bytes_updated_at": "` + testTimeString + `",
-		"created_at": "` + testTimeString + `",
-		"region": "` + testRegion + `"
-	}
-}`
-
-	mux.HandleFunc("/v2/registries", func(w http.ResponseWriter, r *http.Request) {
-		v := new(RegistriesCreateRequest)
-		err := json.NewDecoder(r.Body).Decode(v)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		testMethod(t, r, http.MethodPost)
-		require.Equal(t, v, createRequest)
-		fmt.Fprint(w, createResponseJSON)
-	})
-
-	got, _, err := client.Registries.Create(ctx, createRequest)
-	require.NoError(t, err)
-	require.Equal(t, want, got)
 }
 
 func TestRegistries_Delete(t *testing.T) {
@@ -1140,9 +1093,824 @@ func TestRegistries_DockerCredentials(t *testing.T) {
 			})
 
 			got, _, err := client.Registries.DockerCredentials(ctx, testRegistry, test.params)
-			fmt.Println(returnedConfig)
 			require.NoError(t, err)
 			require.Equal(t, []byte(returnedConfig), got.DockerConfigJSON)
 		})
 	}
+}
+
+func TestRegistries_Create(t *testing.T) {
+	setup()
+	defer teardown()
+
+	want := &Registry{
+		Name:                       testRegistry,
+		StorageUsageBytes:          0,
+		StorageUsageBytesUpdatedAt: testTime,
+		CreatedAt:                  testTime,
+		Region:                     testRegion,
+	}
+
+	createRequest := &RegistryCreateRequest{
+		Name:                 want.Name,
+		SubscriptionTierSlug: "basic",
+		Region:               testRegion,
+	}
+
+	createResponseJSON := `
+{
+	"registry": {
+		"name": "` + testRegistry + `",
+		"storage_usage_bytes": 0,
+        "storage_usage_bytes_updated_at": "` + testTimeString + `",
+        "created_at": "` + testTimeString + `",
+		"region": "` + testRegion + `"
+	},
+    "subscription": {
+      "tier": {
+        "name": "Basic",
+        "slug": "basic",
+        "included_repositories": 5,
+        "included_storage_bytes": 5368709120,
+        "allow_storage_overage": true,
+        "included_bandwidth_bytes": 5368709120,
+        "monthly_price_in_cents": 500
+      },
+      "created_at": "` + testTimeString + `",
+      "updated_at": "` + testTimeString + `"
+    }
+}`
+
+	mux.HandleFunc("/v2/registries", func(w http.ResponseWriter, r *http.Request) {
+		v := new(RegistryCreateRequest)
+		err := json.NewDecoder(r.Body).Decode(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		testMethod(t, r, http.MethodPost)
+		require.Equal(t, v, createRequest)
+		fmt.Fprint(w, createResponseJSON)
+	})
+
+	got, _, err := client.Registries.Create(ctx, createRequest)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestRegistries_ListRepositories(t *testing.T) {
+	setup()
+	defer teardown()
+
+	wantRepositories := []*Repository{
+		{
+			RegistryName: testRegistry,
+			Name:         testRepository,
+			TagCount:     1,
+			LatestTag: &RepositoryTag{
+				RegistryName:        testRegistry,
+				Repository:          testRepository,
+				Tag:                 testTag,
+				ManifestDigest:      testDigest,
+				CompressedSizeBytes: testCompressedSize,
+				SizeBytes:           testSize,
+				UpdatedAt:           testTime,
+			},
+		},
+	}
+	getResponseJSON := `{
+	"repositories": [
+		{
+			"registry_name": "` + testRegistry + `",
+			"name": "` + testRepository + `",
+			"tag_count": 1,
+			"latest_tag": {
+				"registry_name": "` + testRegistry + `",
+				"repository": "` + testRepository + `",
+				"tag": "` + testTag + `",
+				"manifest_digest": "` + testDigest + `",
+				"compressed_size_bytes": ` + fmt.Sprintf("%d", testCompressedSize) + `,
+				"size_bytes": ` + fmt.Sprintf("%d", testSize) + `,
+				"updated_at": "` + testTimeString + `"
+			}
+		}
+	],
+	"links": {
+	    "pages": {
+			"next": "https://api.digitalocean.com/v2/registries/` + testRegistry + `/repositories?page=2",
+			"last": "https://api.digitalocean.com/v2/registries/` + testRegistry + `/repositories?page=2"
+		}
+	},
+	"meta": {
+	    "total": 2
+	}
+}`
+
+	mux.HandleFunc(fmt.Sprintf("/v2/registries/%s/repositories", testRegistry), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		testFormValues(t, r, map[string]string{"page": "1", "per_page": "1"})
+		fmt.Fprint(w, getResponseJSON)
+	})
+	got, response, err := client.Registries.ListRepositories(ctx, testRegistry, &ListOptions{Page: 1, PerPage: 1})
+	require.NoError(t, err)
+	require.Equal(t, wantRepositories, got)
+
+	gotRespLinks := response.Links
+	wantRespLinks := &Links{
+		Pages: &Pages{
+			Next: fmt.Sprintf("https://api.digitalocean.com/v2/registries/%s/repositories?page=2", testRegistry),
+			Last: fmt.Sprintf("https://api.digitalocean.com/v2/registries/%s/repositories?page=2", testRegistry),
+		},
+	}
+	assert.Equal(t, wantRespLinks, gotRespLinks)
+
+	gotRespMeta := response.Meta
+	wantRespMeta := &Meta{
+		Total: 2,
+	}
+	assert.Equal(t, wantRespMeta, gotRespMeta)
+}
+
+func TestRegistries_ListRepositoriesV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	wantRepositories := []*RepositoryV2{
+		{
+			RegistryName:  testRegistry,
+			Name:          testRepository,
+			TagCount:      2,
+			ManifestCount: 1,
+			LatestManifest: &RepositoryManifest{
+				Digest:              "sha256:abc",
+				RegistryName:        testRegistry,
+				Repository:          testRepository,
+				CompressedSizeBytes: testCompressedSize,
+				SizeBytes:           testSize,
+				UpdatedAt:           testTime,
+				Tags:                []string{"v1", "v2"},
+				Blobs: []*Blob{
+					{
+						Digest:              "sha256:blob1",
+						CompressedSizeBytes: 100,
+					},
+					{
+						Digest:              "sha256:blob2",
+						CompressedSizeBytes: 200,
+					},
+				},
+			},
+		},
+	}
+	baseLinkPage := fmt.Sprintf("https://api.digitalocean.com/v2/registries/%s/repositoriesV2", testRegistry)
+	getResponseJSON := `{
+	"repositories": [
+		{
+			"registry_name": "` + testRegistry + `",
+			"name": "` + testRepository + `",
+			"tag_count": 2,
+			"manifest_count": 1,
+			"latest_manifest": {
+				"digest": "sha256:abc",
+				"registry_name": "` + testRegistry + `",
+				"repository": "` + testRepository + `",
+				"compressed_size_bytes": ` + fmt.Sprintf("%d", testCompressedSize) + `,
+				"size_bytes": ` + fmt.Sprintf("%d", testSize) + `,
+				"updated_at": "` + testTimeString + `",
+				"tags": [
+					"v1",
+					"v2"
+				],
+				"blobs": [
+					{
+						"digest": "sha256:blob1",
+						"compressed_size_bytes": 100
+					},
+					{
+						"digest": "sha256:blob2",
+						"compressed_size_bytes": 200
+					}
+				]
+			}
+		}
+	],
+	"links": {
+	    "pages": {
+			"first":    "` + baseLinkPage + `?page=1&page_size=1",
+			"prev":     "` + baseLinkPage + `?page=2&page_size=1&page_token=aaa",
+			"next":     "` + baseLinkPage + `?page=4&page_size=1&page_token=ccc",
+			"last":     "` + baseLinkPage + `?page=5&page_size=1"
+		}
+	},
+	"meta": {
+	    "total": 5
+	}
+}`
+
+	mux.HandleFunc(fmt.Sprintf("/v2/registries/%s/repositoriesV2", testRegistry), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		testFormValues(t, r, map[string]string{"page": "3", "per_page": "1", "page_token": "bbb"})
+		fmt.Fprint(w, getResponseJSON)
+	})
+	got, response, err := client.Registries.ListRepositoriesV2(ctx, testRegistry, &TokenListOptions{Page: 3, PerPage: 1, Token: "bbb"})
+	require.NoError(t, err)
+	require.Equal(t, wantRepositories, got)
+
+	gotRespLinks := response.Links
+	wantRespLinks := &Links{
+		Pages: &Pages{
+			First: fmt.Sprintf("https://api.digitalocean.com/v2/registries/%s/repositoriesV2?page=1&page_size=1", testRegistry),
+			Prev:  fmt.Sprintf("https://api.digitalocean.com/v2/registries/%s/repositoriesV2?page=2&page_size=1&page_token=aaa", testRegistry),
+			Next:  fmt.Sprintf("https://api.digitalocean.com/v2/registries/%s/repositoriesV2?page=4&page_size=1&page_token=ccc", testRegistry),
+			Last:  fmt.Sprintf("https://api.digitalocean.com/v2/registries/%s/repositoriesV2?page=5&page_size=1", testRegistry),
+		},
+	}
+	assert.Equal(t, wantRespLinks, gotRespLinks)
+
+	gotRespMeta := response.Meta
+	wantRespMeta := &Meta{
+		Total: 5,
+	}
+	assert.Equal(t, wantRespMeta, gotRespMeta)
+}
+
+func TestRegistries_ListRepositoryTags(t *testing.T) {
+	setup()
+	defer teardown()
+
+	wantTags := []*RepositoryTag{
+		{
+			RegistryName:        testRegistry,
+			Repository:          testRepository,
+			Tag:                 testTag,
+			ManifestDigest:      testDigest,
+			CompressedSizeBytes: testCompressedSize,
+			SizeBytes:           testSize,
+			UpdatedAt:           testTime,
+		},
+	}
+	getResponseJSON := `{
+	"tags": [
+		{
+			"registry_name": "` + testRegistry + `",
+			"repository": "` + testRepository + `",
+			"tag": "` + testTag + `",
+			"manifest_digest": "` + testDigest + `",
+			"compressed_size_bytes": ` + fmt.Sprintf("%d", testCompressedSize) + `,
+			"size_bytes": ` + fmt.Sprintf("%d", testSize) + `,
+			"updated_at": "` + testTimeString + `"
+		}
+	],
+	"links": {
+	    "pages": {
+			"next": "https://api.digitalocean.com/v2/registries/` + testRegistry + `/repositories/` + testEncodedRepository + `/tags?page=2",
+			"last": "https://api.digitalocean.com/v2/registries/` + testRegistry + `/repositories/` + testEncodedRepository + `/tags?page=2"
+		}
+	},
+	"meta": {
+	    "total": 2
+	}
+}`
+
+	mux.HandleFunc(fmt.Sprintf("/v2/registries/%s/repositories/%s/tags", testRegistry, testEncodedRepository), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		testFormValues(t, r, map[string]string{"page": "1", "per_page": "1"})
+		fmt.Fprint(w, getResponseJSON)
+	})
+	got, response, err := client.Registries.ListRepositoryTags(ctx, testRegistry, testRepository, &ListOptions{Page: 1, PerPage: 1})
+	require.NoError(t, err)
+	require.Equal(t, wantTags, got)
+
+	gotRespLinks := response.Links
+	wantRespLinks := &Links{
+		Pages: &Pages{
+			Next: fmt.Sprintf("https://api.digitalocean.com/v2/registries/%s/repositories/%s/tags?page=2", testRegistry, testEncodedRepository),
+			Last: fmt.Sprintf("https://api.digitalocean.com/v2/registries/%s/repositories/%s/tags?page=2", testRegistry, testEncodedRepository),
+		},
+	}
+	assert.Equal(t, wantRespLinks, gotRespLinks)
+
+	gotRespMeta := response.Meta
+	wantRespMeta := &Meta{
+		Total: 2,
+	}
+	assert.Equal(t, wantRespMeta, gotRespMeta)
+}
+
+func TestRegistries_DeleteTag(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc(fmt.Sprintf("/v2/registries/%s/repositories/%s/tags/%s", testRegistry, testEncodedRepository, testTag), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+	})
+
+	_, err := client.Registries.DeleteTag(ctx, testRegistry, testRepository, testTag)
+	require.NoError(t, err)
+}
+
+func TestRegistries_ListRepositoryManifests(t *testing.T) {
+	setup()
+	defer teardown()
+
+	wantTags := []*RepositoryManifest{
+		{
+			RegistryName:        testRegistry,
+			Repository:          testRepository,
+			Digest:              testDigest,
+			CompressedSizeBytes: testCompressedSize,
+			SizeBytes:           testSize,
+			UpdatedAt:           testTime,
+			Tags:                []string{"latest", "v1", "v2"},
+			Blobs: []*Blob{
+				{
+					Digest:              "sha256:blob1",
+					CompressedSizeBytes: 998,
+				},
+				{
+					Digest:              "sha256:blob2",
+					CompressedSizeBytes: 1,
+				},
+			},
+		},
+	}
+	getResponseJSON := `{
+	"manifests": [
+		{
+			"registry_name": "` + testRegistry + `",
+			"repository": "` + testRepository + `",
+			"digest": "` + testDigest + `",
+			"compressed_size_bytes": ` + fmt.Sprintf("%d", testCompressedSize) + `,
+			"size_bytes": ` + fmt.Sprintf("%d", testSize) + `,
+			"updated_at": "` + testTimeString + `",
+			"tags": [ "latest", "v1", "v2" ],
+			"blobs": [
+				{
+					"digest": "sha256:blob1",
+					"compressed_size_bytes": 998
+				},
+				{
+
+					"digest": "sha256:blob2",
+					"compressed_size_bytes": 1
+				}
+			]
+		}
+	],
+	"links": {
+	    "pages": {
+			"first": "https://api.digitalocean.com/v2/registries/` + testRegistry + `/repositories/` + testEncodedRepository + `/digests?page=1&page_size=1",
+			"prev": "https://api.digitalocean.com/v2/registries/` + testRegistry + `/repositories/` + testEncodedRepository + `/digests?page=2&page_size=1",
+			"next": "https://api.digitalocean.com/v2/registries/` + testRegistry + `/repositories/` + testEncodedRepository + `/digests?page=4&page_size=1",
+			"last": "https://api.digitalocean.com/v2/registries/` + testRegistry + `/repositories/` + testEncodedRepository + `/digests?page=5&page_size=1"
+		}
+	},
+	"meta": {
+	    "total": 5
+	}
+}`
+
+	mux.HandleFunc(fmt.Sprintf("/v2/registries/%s/repositories/%s/digests", testRegistry, testEncodedRepository), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		testFormValues(t, r, map[string]string{"page": "3", "per_page": "1"})
+		fmt.Fprint(w, getResponseJSON)
+	})
+	got, response, err := client.Registries.ListRepositoryManifests(ctx, testRegistry, testRepository, &ListOptions{Page: 3, PerPage: 1})
+	require.NoError(t, err)
+	require.Equal(t, wantTags, got)
+
+	gotRespLinks := response.Links
+	wantRespLinks := &Links{
+		Pages: &Pages{
+			First: fmt.Sprintf("https://api.digitalocean.com/v2/registries/%s/repositories/%s/digests?page=1&page_size=1", testRegistry, testEncodedRepository),
+			Prev:  fmt.Sprintf("https://api.digitalocean.com/v2/registries/%s/repositories/%s/digests?page=2&page_size=1", testRegistry, testEncodedRepository),
+			Next:  fmt.Sprintf("https://api.digitalocean.com/v2/registries/%s/repositories/%s/digests?page=4&page_size=1", testRegistry, testEncodedRepository),
+			Last:  fmt.Sprintf("https://api.digitalocean.com/v2/registries/%s/repositories/%s/digests?page=5&page_size=1", testRegistry, testEncodedRepository),
+		},
+	}
+	assert.Equal(t, wantRespLinks, gotRespLinks)
+
+	gotRespMeta := response.Meta
+	wantRespMeta := &Meta{
+		Total: 5,
+	}
+	assert.Equal(t, wantRespMeta, gotRespMeta)
+}
+
+func TestRegistries_DeleteManifest(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc(fmt.Sprintf("/v2/registries/%s/repositories/%s/digests/%s", testRegistry, testEncodedRepository, testDigest), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+	})
+
+	_, err := client.Registries.DeleteManifest(ctx, testRegistry, testRepository, testDigest)
+	require.NoError(t, err)
+}
+
+func TestRegistries_StartGarbageCollection(t *testing.T) {
+	setup()
+	defer teardown()
+
+	want := testGarbageCollection
+	requestResponseJSONTmpl := `
+{
+  "garbage_collection": {
+    "uuid": "{{.UUID}}",
+    "registry_name": "{{.RegistryName}}",
+    "status": "{{.Status}}",
+    "type": "{{.Type}}",
+    "created_at": "{{.CreatedAt.Format "2006-01-02T15:04:05Z07:00"}}",
+    "updated_at": "{{.UpdatedAt.Format "2006-01-02T15:04:05Z07:00"}}",
+    "blobs_deleted": {{.BlobsDeleted}},
+    "freed_bytes": {{.FreedBytes}}
+  }
+}`
+	requestResponseJSON := reifyTemplateStr(t, requestResponseJSONTmpl, want)
+
+	createRequest := &StartGarbageCollectionRequest{
+		Type: GCTypeUnreferencedBlobsOnly,
+	}
+	mux.HandleFunc("/v2/registries/"+testRegistry+"/garbage-collection",
+		func(w http.ResponseWriter, r *http.Request) {
+			v := new(StartGarbageCollectionRequest)
+			err := json.NewDecoder(r.Body).Decode(v)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			testMethod(t, r, http.MethodPost)
+			require.Equal(t, v, createRequest)
+			fmt.Fprint(w, requestResponseJSON)
+		})
+
+	got, _, err := client.Registries.StartGarbageCollection(ctx, testRegistry)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestRegistries_GetGarbageCollection(t *testing.T) {
+	setup()
+	defer teardown()
+
+	want := testGarbageCollection
+	requestResponseJSONTmpl := `
+{
+  "garbage_collection": {
+    "uuid": "{{.UUID}}",
+    "registry_name": "{{.RegistryName}}",
+    "status": "{{.Status}}",
+    "type": "{{.Type}}",
+    "created_at": "{{.CreatedAt.Format "2006-01-02T15:04:05Z07:00"}}",
+    "updated_at": "{{.UpdatedAt.Format "2006-01-02T15:04:05Z07:00"}}",
+    "blobs_deleted": {{.BlobsDeleted}},
+    "freed_bytes": {{.FreedBytes}}
+  }
+}`
+	requestResponseJSON := reifyTemplateStr(t, requestResponseJSONTmpl, want)
+
+	mux.HandleFunc("/v2/registries/"+testRegistry+"/garbage-collection",
+		func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, http.MethodGet)
+			fmt.Fprint(w, requestResponseJSON)
+		})
+
+	got, _, err := client.Registries.GetGarbageCollection(ctx, testRegistry)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestRegistries_ListGarbageCollections(t *testing.T) {
+	setup()
+	defer teardown()
+
+	want := []*GarbageCollection{testGarbageCollection}
+	requestResponseJSONTmpl := `
+{
+  "garbage_collections": [
+    {
+      "uuid": "{{.UUID}}",
+      "registry_name": "{{.RegistryName}}",
+      "status": "{{.Status}}",
+      "type": "{{.Type}}",
+      "created_at": "{{.CreatedAt.Format "2006-01-02T15:04:05Z07:00"}}",
+      "updated_at": "{{.UpdatedAt.Format "2006-01-02T15:04:05Z07:00"}}",
+      "blobs_deleted": {{.BlobsDeleted}},
+      "freed_bytes": {{.FreedBytes}}
+    }
+  ],
+	"links": {
+	    "pages": {
+			"next": "https://api.digitalocean.com/v2/registries/` + testRegistry + `/garbage-collections?page=2",
+			"last": "https://api.digitalocean.com/v2/registries/` + testRegistry + `/garbage-collections?page=2"
+		}
+	},
+	"meta": {
+	    "total": 2
+	}
+}`
+	requestResponseJSON := reifyTemplateStr(t, requestResponseJSONTmpl, testGarbageCollection)
+
+	mux.HandleFunc("/v2/registries/"+testRegistry+"/garbage-collections",
+		func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, http.MethodGet)
+			testFormValues(t, r, map[string]string{"page": "1", "per_page": "1"})
+			fmt.Fprint(w, requestResponseJSON)
+		})
+
+	got, resp, err := client.Registries.ListGarbageCollections(ctx, testRegistry, &ListOptions{Page: 1, PerPage: 1})
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+
+	gotRespLinks := resp.Links
+	wantRespLinks := &Links{
+		Pages: &Pages{
+			Next: fmt.Sprintf("https://api.digitalocean.com/v2/registries/%s/garbage-collections?page=2", testRegistry),
+			Last: fmt.Sprintf("https://api.digitalocean.com/v2/registries/%s/garbage-collections?page=2", testRegistry),
+		},
+	}
+	assert.Equal(t, wantRespLinks, gotRespLinks)
+
+	gotRespMeta := resp.Meta
+	wantRespMeta := &Meta{
+		Total: 2,
+	}
+	assert.Equal(t, wantRespMeta, gotRespMeta)
+}
+
+func TestRegistries_UpdateGarbageCollection(t *testing.T) {
+	setup()
+	defer teardown()
+
+	updateRequest := &UpdateGarbageCollectionRequest{
+		Cancel: true,
+	}
+
+	want := testGarbageCollection
+	requestResponseJSONTmpl := `
+{
+  "garbage_collection": {
+    "uuid": "{{.UUID}}",
+    "registry_name": "{{.RegistryName}}",
+    "status": "{{.Status}}",
+    "type": "{{.Type}}",
+    "created_at": "{{.CreatedAt.Format "2006-01-02T15:04:05Z07:00"}}",
+    "updated_at": "{{.UpdatedAt.Format "2006-01-02T15:04:05Z07:00"}}",
+    "blobs_deleted": {{.BlobsDeleted}},
+    "freed_bytes": {{.FreedBytes}}
+  }
+}`
+	requestResponseJSON := reifyTemplateStr(t, requestResponseJSONTmpl, want)
+
+	mux.HandleFunc("/v2/registries/"+testRegistry+"/garbage-collection/"+testGCUUID,
+		func(w http.ResponseWriter, r *http.Request) {
+			v := new(UpdateGarbageCollectionRequest)
+			err := json.NewDecoder(r.Body).Decode(v)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			testMethod(t, r, http.MethodPut)
+			require.Equal(t, v, updateRequest)
+			fmt.Fprint(w, requestResponseJSON)
+		})
+
+	got, _, err := client.Registries.UpdateGarbageCollection(ctx, testRegistry, testGCUUID, updateRequest)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestRegistries_GetOptions(t *testing.T) {
+	responseJSON := `
+{
+  "options": {
+	"available_regions": [
+		"r1",
+		"r2"
+	],
+    "subscription_tiers": [
+      {
+        "name": "Starter",
+        "slug": "starter",
+        "included_repositories": 1,
+        "included_storage_bytes": 524288000,
+        "allow_storage_overage": false,
+        "included_bandwidth_bytes": 524288000,
+        "monthly_price_in_cents": 0,
+        "eligible": false,
+        "eligibility_reasons": [
+          "OverStorageLimit",
+          "OverRepositoryLimit"
+        ]
+      },
+      {
+        "name": "Basic",
+        "slug": "basic",
+        "included_repositories": 5,
+        "included_storage_bytes": 5368709120,
+        "allow_storage_overage": true,
+        "included_bandwidth_bytes": 5368709120,
+        "monthly_price_in_cents": 500,
+        "eligible": false,
+        "eligibility_reasons": [
+          "OverRepositoryLimit"
+        ]
+      },
+      {
+        "name": "Professional",
+        "slug": "professional",
+        "included_repositories": 0,
+        "included_storage_bytes": 107374182400,
+        "allow_storage_overage": true,
+        "included_bandwidth_bytes": 107374182400,
+        "monthly_price_in_cents": 2000,
+        "eligible": true
+      }
+    ]
+  }
+}`
+	want := &RegistryOptions{
+		AvailableRegions: []string{
+			"r1",
+			"r2",
+		},
+		SubscriptionTiers: []*RegistrySubscriptionTier{
+			{
+				Name:                   "Starter",
+				Slug:                   "starter",
+				IncludedRepositories:   1,
+				IncludedStorageBytes:   524288000,
+				AllowStorageOverage:    false,
+				IncludedBandwidthBytes: 524288000,
+				MonthlyPriceInCents:    0,
+				Eligible:               false,
+				EligibilityReasons: []string{
+					"OverStorageLimit",
+					"OverRepositoryLimit",
+				},
+			},
+			{
+				Name:                   "Basic",
+				Slug:                   "basic",
+				IncludedRepositories:   5,
+				IncludedStorageBytes:   5368709120,
+				AllowStorageOverage:    true,
+				IncludedBandwidthBytes: 5368709120,
+				MonthlyPriceInCents:    500,
+				Eligible:               false,
+				EligibilityReasons: []string{
+					"OverRepositoryLimit",
+				},
+			},
+			{
+				Name:                   "Professional",
+				Slug:                   "professional",
+				IncludedRepositories:   0,
+				IncludedStorageBytes:   107374182400,
+				AllowStorageOverage:    true,
+				IncludedBandwidthBytes: 107374182400,
+				MonthlyPriceInCents:    2000,
+				Eligible:               true,
+			},
+		},
+	}
+
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/registries/options", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, responseJSON)
+	})
+
+	got, _, err := client.Registries.GetOptions(ctx)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestRegistries_GetSubscription(t *testing.T) {
+	setup()
+	defer teardown()
+
+	want := &RegistrySubscription{
+		Tier: &RegistrySubscriptionTier{
+			Name:                   "Basic",
+			Slug:                   "basic",
+			IncludedRepositories:   5,
+			IncludedStorageBytes:   5368709120,
+			AllowStorageOverage:    true,
+			IncludedBandwidthBytes: 5368709120,
+			MonthlyPriceInCents:    500,
+		},
+		CreatedAt: testTime,
+		UpdatedAt: testTime,
+	}
+
+	getResponseJSON := `
+{
+  "subscription": {
+    "tier": {
+      "name": "Basic",
+      "slug": "basic",
+      "included_repositories": 5,
+      "included_storage_bytes": 5368709120,
+      "allow_storage_overage": true,
+      "included_bandwidth_bytes": 5368709120,
+      "monthly_price_in_cents": 500
+    },
+    "created_at": "` + testTimeString + `",
+    "updated_at": "` + testTimeString + `"
+  }
+}
+`
+
+	mux.HandleFunc("/v2/registries/subscription", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, getResponseJSON)
+	})
+	got, _, err := client.Registries.GetSubscription(ctx)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestRegistries_UpdateSubscription(t *testing.T) {
+	setup()
+	defer teardown()
+
+	updateRequest := &RegistrySubscriptionUpdateRequest{
+		TierSlug: "professional",
+	}
+
+	want := &RegistrySubscription{
+		Tier: &RegistrySubscriptionTier{
+			Name:                   "Professional",
+			Slug:                   "professional",
+			IncludedRepositories:   0,
+			IncludedStorageBytes:   107374182400,
+			AllowStorageOverage:    true,
+			IncludedBandwidthBytes: 107374182400,
+			MonthlyPriceInCents:    2000,
+			Eligible:               true,
+		},
+		CreatedAt: testTime,
+		UpdatedAt: testTime,
+	}
+
+	updateResponseJSON := `{
+  "subscription": {
+    "tier": {
+        "name": "Professional",
+        "slug": "professional",
+        "included_repositories": 0,
+        "included_storage_bytes": 107374182400,
+        "allow_storage_overage": true,
+        "included_bandwidth_bytes": 107374182400,
+        "monthly_price_in_cents": 2000,
+        "eligible": true
+      },
+    "created_at": "` + testTimeString + `",
+    "updated_at": "` + testTimeString + `"
+  }
+}`
+
+	mux.HandleFunc("/v2/registries/subscription",
+		func(w http.ResponseWriter, r *http.Request) {
+			v := new(RegistrySubscriptionUpdateRequest)
+			err := json.NewDecoder(r.Body).Decode(v)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			testMethod(t, r, http.MethodPost)
+			require.Equal(t, v, updateRequest)
+			fmt.Fprint(w, updateResponseJSON)
+		})
+
+	got, _, err := client.Registries.UpdateSubscription(ctx, updateRequest)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestRegistries_ValidateName(t *testing.T) {
+	setup()
+	defer teardown()
+
+	validateNameRequest := &RegistryValidateNameRequest{
+		Name: testRegistry,
+	}
+
+	mux.HandleFunc("/v2/registries/validate-name", func(w http.ResponseWriter, r *http.Request) {
+		v := new(RegistryValidateNameRequest)
+		err := json.NewDecoder(r.Body).Decode(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		testMethod(t, r, http.MethodPost)
+		require.Equal(t, v, validateNameRequest)
+	})
+
+	_, err := client.Registries.ValidateName(ctx, validateNameRequest)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
Besides adding the full set of methods on `RegistriesService`, I have made changes to `Registries.Create` and it now functions the same way `Registry.Create` does. 