### PR TITLE
Support Load Balancers tls-cipher-policy

### DIFF
--- a/load_balancers.go
+++ b/load_balancers.go
@@ -26,6 +26,10 @@ const (
 	// Load Balancer network_stack types
 	LoadBalancerNetworkStackIPv4      = "IPV4"
 	LoadBalancerNetworkStackDualstack = "DUALSTACK"
+
+	// Supported TLS Cipher policies
+	LoadBalancerTLSCipherPolicyDefault = "DEFAULT"
+	LoadBalancerTLSCipherPolicyStrong  = "STRONG"
 )
 
 // LoadBalancersService is an interface for managing load balancers with the DigitalOcean API.
@@ -81,6 +85,7 @@ type LoadBalancer struct {
 	TargetLoadBalancerIDs        []string         `json:"target_load_balancer_ids,omitempty"`
 	Network                      string           `json:"network,omitempty"`
 	NetworkStack                 string           `json:"network_stack,omitempty"`
+	TLSCipherPolicy              string           `json:"tls_cipher_policy,omitempty"`
 }
 
 // String creates a human-readable description of a LoadBalancer.
@@ -116,6 +121,7 @@ func (l LoadBalancer) AsRequest() *LoadBalancerRequest {
 		TargetLoadBalancerIDs:        append([]string(nil), l.TargetLoadBalancerIDs...),
 		Network:                      l.Network,
 		NetworkStack:                 l.NetworkStack,
+		TLSCipherPolicy:              l.TLSCipherPolicy,
 	}
 
 	if l.DisableLetsEncryptDNSRecords != nil {
@@ -256,6 +262,7 @@ type LoadBalancerRequest struct {
 	TargetLoadBalancerIDs        []string         `json:"target_load_balancer_ids,omitempty"`
 	Network                      string           `json:"network,omitempty"`
 	NetworkStack                 string           `json:"network_stack,omitempty"`
+	TLSCipherPolicy              string           `json:"tls_cipher_policy,omitempty"`
 }
 
 // String creates a human-readable description of a LoadBalancerRequest.

--- a/load_balancers_test.go
+++ b/load_balancers_test.go
@@ -223,7 +223,8 @@ var lbCreateJSONResponse = `
             "8268a81c-fcf6-423e-a337-bbfe95817f24"
         ],
 		"network": "INTERNAL",
-		"network_stack": "IPV4"
+		"network_stack": "IPV4",
+		"tls_cipher_policy": "DEFAULT"
     }
 }
 `
@@ -236,6 +237,7 @@ var lbGetJSONResponse = `
         "ip": "46.214.185.203",
         "ipv6": "fd53:616d:6d60::d2c:b001",
 		"network_stack": "DUALSTACK",
+		"tls_cipher_policy": "DEFAULT",
         "algorithm": "round_robin",
         "status": "active",
         "created_at": "2016-12-15T14:16:36Z",
@@ -334,6 +336,7 @@ var lbUpdateJSONResponse = `
         "status": "active",
         "size_unit": 2,
         "created_at": "2016-12-15T14:19:09Z",
+		"tls_cipher_policy": "STRONG",
         "forwarding_rules": [
             {
                 "entry_protocol": "http",
@@ -495,6 +498,7 @@ func TestLoadBalancers_Get(t *testing.T) {
 			CDN:            &CDNSettings{IsEnabled: true},
 		},
 		TargetLoadBalancerIDs: []string{"8268a81c-fcf5-423e-a337-bbfe95817f24", "8268a81c-fcf6-423e-a337-bbfe95817f24"},
+		TLSCipherPolicy:       LoadBalancerTLSCipherPolicyDefault,
 	}
 
 	disableLetsEncryptDNSRecords := false
@@ -559,6 +563,7 @@ func TestLoadBalancers_Create(t *testing.T) {
 		TargetLoadBalancerIDs: []string{"8268a81c-fcf5-423e-a337-bbfe95817f24", "8268a81c-fcf6-423e-a337-bbfe95817f24"},
 		Network:               LoadBalancerNetworkTypeInternal,
 		NetworkStack:          LoadBalancerNetworkStackIPv4,
+		TLSCipherPolicy:       LoadBalancerTLSCipherPolicyDefault,
 	}
 
 	path := "/v2/load_balancers"
@@ -648,6 +653,7 @@ func TestLoadBalancers_Create(t *testing.T) {
 		TargetLoadBalancerIDs: []string{"8268a81c-fcf5-423e-a337-bbfe95817f24", "8268a81c-fcf6-423e-a337-bbfe95817f24"},
 		Network:               LoadBalancerNetworkTypeInternal,
 		NetworkStack:          LoadBalancerNetworkStackIPv4,
+		TLSCipherPolicy:       LoadBalancerTLSCipherPolicyDefault,
 	}
 
 	disableLetsEncryptDNSRecords := true
@@ -826,6 +832,7 @@ func TestLoadBalancers_Update(t *testing.T) {
 			CDN:            &CDNSettings{IsEnabled: true},
 		},
 		TargetLoadBalancerIDs: []string{"8268a81c-fcf5-423e-a337-bbfe95817f24", "8268a81c-fcf6-423e-a337-bbfe95817f24"},
+		TLSCipherPolicy:       LoadBalancerTLSCipherPolicyStrong,
 	}
 
 	path := "/v2/load_balancers"
@@ -909,6 +916,7 @@ func TestLoadBalancers_Update(t *testing.T) {
 			CDN:            &CDNSettings{IsEnabled: true},
 		},
 		TargetLoadBalancerIDs: []string{"8268a81c-fcf5-423e-a337-bbfe95817f24", "8268a81c-fcf6-423e-a337-bbfe95817f24"},
+		TLSCipherPolicy:       LoadBalancerTLSCipherPolicyStrong,
 	}
 
 	assert.Equal(t, expected, loadBalancer)


### PR DESCRIPTION
Support  setting and retrieving TLS cipher policy for load balancers