### PR TITLE
Add support to exec into a specific instance

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -41,7 +41,7 @@ type AppsService interface {
 	CreateDeployment(ctx context.Context, appID string, create ...*DeploymentCreateRequest) (*Deployment, *Response, error)
 
 	GetLogs(ctx context.Context, appID, deploymentID, component string, logType AppLogType, follow bool, tailLines int) (*AppLogs, *Response, error)
-	GetExec(ctx context.Context, appID, deploymentID, component string) (*AppExec, *Response, error)
+	GetExec(ctx context.Context, appID, deploymentID, component, instanceID string) (*AppExec, *Response, error)
 
 	ListRegions(ctx context.Context) ([]*AppRegion, *Response, error)
 
@@ -397,7 +397,7 @@ func (s *AppsServiceOp) GetLogs(ctx context.Context, appID, deploymentID, compon
 }
 
 // GetExec retrieves the websocket URL used for sending/receiving console input and output.
-func (s *AppsServiceOp) GetExec(ctx context.Context, appID, deploymentID, component string) (*AppExec, *Response, error) {
+func (s *AppsServiceOp) GetExec(ctx context.Context, appID, deploymentID, component, instanceID string) (*AppExec, *Response, error) {
 	var url string
 	if deploymentID == "" {
 		url = fmt.Sprintf("%s/%s/components/%s/exec", appsBasePath, appID, component)
@@ -405,7 +405,13 @@ func (s *AppsServiceOp) GetExec(ctx context.Context, appID, deploymentID, compon
 		url = fmt.Sprintf("%s/%s/deployments/%s/components/%s/exec", appsBasePath, appID, deploymentID, component)
 	}
 
-	req, err := s.client.NewRequest(ctx, http.MethodGet, url, nil)
+	type ExecRequestParams struct {
+		InstanceID string `json:"instance_id"`
+	}
+
+	params := ExecRequestParams{InstanceID: instanceID}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, url, params)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/apps_test.go
+++ b/apps_test.go
@@ -579,11 +579,15 @@ func TestApps_GetExec(t *testing.T) {
 		json.NewEncoder(w).Encode(&AppExec{URL: "https://exec.url2"})
 	})
 
-	exec, _, err := client.Apps.GetExec(ctx, testApp.ID, testDeployment.ID, "service-name")
+	exec, _, err := client.Apps.GetExec(ctx, testApp.ID, testDeployment.ID, "service-name", "")
 	require.NoError(t, err)
 	assert.Equal(t, "https://exec.url1", exec.URL)
 
-	exec, _, err = client.Apps.GetExec(ctx, testApp.ID, "", "service-name")
+	exec, _, err = client.Apps.GetExec(ctx, testApp.ID, "", "service-name", "")
+	require.NoError(t, err)
+	assert.Equal(t, "https://exec.url2", exec.URL)
+
+	exec, _, err = client.Apps.GetExec(ctx, testApp.ID, "", "service-name", "app-instance-12345")
 	require.NoError(t, err)
 	assert.Equal(t, "https://exec.url2", exec.URL)
 }


### PR DESCRIPTION
This PR adds support for users to exec into a specific instance ID. This PR doesn't change the default behaviour, leaving the instance ID empty would allow users to exec just like they can do now. 