### PR TITLE
APPS-11076: Add support for VALKEY as a database engine option

### DIFF
--- a/apps.gen.go
+++ b/apps.gen.go
@@ -223,6 +223,7 @@ const (
 	AppDatabaseSpecEngine_MongoDB    AppDatabaseSpecEngine = "MONGODB"
 	AppDatabaseSpecEngine_Kafka      AppDatabaseSpecEngine = "KAFKA"
 	AppDatabaseSpecEngine_Opensearch AppDatabaseSpecEngine = "OPENSEARCH"
+	AppDatabaseSpecEngine_Valkey     AppDatabaseSpecEngine = "VALKEY"
 )
 
 // AppDedicatedIp Represents a dedicated egress ip.


### PR DESCRIPTION
Add support in App Platform for VALKEY as a new database option. 
GA on 04/30.