### PR TITLE
Implement GetAppInstances

### DIFF
--- a/apps.gen.go
+++ b/apps.gen.go
@@ -505,12 +505,6 @@ type AppMaintenanceSpec struct {
 	OfflinePageURL string `json:"offline_page_url,omitempty"`
 }
 
-// AppPeeredVpcSpec Configuration of the target VPC.
-type AppPeeredVpcSpec struct {
-	// The name of the VPC.
-	Name string `json:"name,omitempty"`
-}
-
 // AppRouteSpec struct for AppRouteSpec
 type AppRouteSpec struct {
 	// (Deprecated) An HTTP path prefix. Paths must start with / and must be unique across all components within an app.
@@ -572,9 +566,9 @@ type AppServiceSpecHealthCheck struct {
 	PeriodSeconds int32 `json:"period_seconds,omitempty"`
 	// The number of seconds after which the check times out. Default: 1 second, Minimum 1, Maximum 120.
 	TimeoutSeconds int32 `json:"timeout_seconds,omitempty"`
-	// The number of successful health checks before considered healthy. Default: 1, Minimum 1, Maximum 50. When used in liveness_health_check, Default: 1, Minimum 1, Maximum 1.
+	// The number of successful health checks before considered healthy. Default: 1 second, Minimum 1, Maximum 50. When used in liveness_health_check, Default: 1 second, Minimum 1, Maximum 1.
 	SuccessThreshold int32 `json:"success_threshold,omitempty"`
-	// The number of failed health checks before considered unhealthy. Default: 9, Minimum 1, Maximum 50. When used in liveness_health_check, Default: 18, Minimum 1, Maximum 50.
+	// The number of failed health checks before considered unhealthy. Default: 9 seconds, Minimum 1, Maximum 50. When used in liveness_health_check, Default: 18 seconds, Minimum 1, Maximum 50.
 	FailureThreshold int32 `json:"failure_threshold,omitempty"`
 	// The route path used for the HTTP health check ping. If not set, the HTTP health check will be disabled and a TCP health check used instead.
 	HTTPPath string `json:"http_path,omitempty"`
@@ -623,7 +617,6 @@ type AppSpec struct {
 	Egress      *AppEgressSpec      `json:"egress,omitempty"`
 	Features    []string            `json:"features,omitempty"`
 	Maintenance *AppMaintenanceSpec `json:"maintenance,omitempty"`
-	Vpc         *AppVpcSpec         `json:"vpc,omitempty"`
 	// Specification to disable edge (CDN) cache for all domains of the app. Note that this feature is in private preview.
 	DisableEdgeCache bool `json:"disable_edge_cache,omitempty"`
 	// Specification to disable email obfuscation.
@@ -670,13 +663,6 @@ type AppVariableDefinition struct {
 	Type  AppVariableType  `json:"type,omitempty"`
 }
 
-// AppVpcSpec Configuration of VPC.
-type AppVpcSpec struct {
-	// The list of target vpcs.
-	PeeredVpcs []*AppPeeredVpcSpec `json:"peered_vpcs,omitempty"`
-	// The id of the target VPC, in UUID format.
-	ID string `json:"id,omitempty"`
-}
 
 // AppWorkerSpec struct for AppWorkerSpec
 type AppWorkerSpec struct {

--- a/apps.gen.go
+++ b/apps.gen.go
@@ -572,9 +572,9 @@ type AppServiceSpecHealthCheck struct {
 	PeriodSeconds int32 `json:"period_seconds,omitempty"`
 	// The number of seconds after which the check times out. Default: 1 second, Minimum 1, Maximum 120.
 	TimeoutSeconds int32 `json:"timeout_seconds,omitempty"`
-	// The number of successful health checks before considered healthy. Default: 1 second, Minimum 1, Maximum 50. When used in liveness_health_check, Default: 1 second, Minimum 1, Maximum 1.
+	// The number of successful health checks before considered healthy. Default: 1, Minimum 1, Maximum 50. When used in liveness_health_check, Default: 1, Minimum 1, Maximum 1.
 	SuccessThreshold int32 `json:"success_threshold,omitempty"`
-	// The number of failed health checks before considered unhealthy. Default: 9 seconds, Minimum 1, Maximum 50. When used in liveness_health_check, Default: 18 seconds, Minimum 1, Maximum 50.
+	// The number of failed health checks before considered unhealthy. Default: 9, Minimum 1, Maximum 50. When used in liveness_health_check, Default: 18, Minimum 1, Maximum 50.
 	FailureThreshold int32 `json:"failure_threshold,omitempty"`
 	// The route path used for the HTTP health check ping. If not set, the HTTP health check will be disabled and a TCP health check used instead.
 	HTTPPath string `json:"http_path,omitempty"`

--- a/apps.gen.go
+++ b/apps.gen.go
@@ -409,9 +409,8 @@ type AppJobSpec struct {
 	// The instance size to use for this component.
 	InstanceSizeSlug string `json:"instance_size_slug,omitempty"`
 	// The amount of instances that this component should be scaled to. Default 1, Minimum 1, Maximum 250. Consider using a larger instance size if your application requires more than 250 instances.
-	InstanceCount int64               `json:"instance_count,omitempty"`
-	Kind          AppJobSpecKind      `json:"kind,omitempty"`
-	Schedule      *AppJobSpecSchedule `json:"schedule,omitempty"`
+	InstanceCount int64          `json:"instance_count,omitempty"`
+	Kind          AppJobSpecKind `json:"kind,omitempty"`
 	// A list of configured alerts which apply to the component.
 	Alerts []*AppAlertSpec `json:"alerts,omitempty"`
 	// A list of configured log forwarding destinations.
@@ -428,14 +427,7 @@ const (
 	AppJobSpecKind_PreDeploy    AppJobSpecKind = "PRE_DEPLOY"
 	AppJobSpecKind_PostDeploy   AppJobSpecKind = "POST_DEPLOY"
 	AppJobSpecKind_FailedDeploy AppJobSpecKind = "FAILED_DEPLOY"
-	AppJobSpecKind_Scheduled    AppJobSpecKind = "SCHEDULED"
 )
-
-// AppJobSpecSchedule struct for AppJobSpecSchedule
-type AppJobSpecSchedule struct {
-	Cron     string `json:"cron,omitempty"`
-	TimeZone string `json:"time_zone,omitempty"`
-}
 
 // AppJobSpecTermination struct for AppJobSpecTermination
 type AppJobSpecTermination struct {
@@ -550,10 +542,9 @@ type AppServiceSpec struct {
 	// A list of configured alerts which apply to the component.
 	Alerts []*AppAlertSpec `json:"alerts,omitempty"`
 	// A list of configured log forwarding destinations.
-	LogDestinations     []*AppLogDestinationSpec       `json:"log_destinations,omitempty"`
-	Termination         *AppServiceSpecTermination     `json:"termination,omitempty"`
-	InactivitySleep     *AppServiceSpecInactivitySleep `json:"inactivity_sleep,omitempty"`
-	LivenessHealthCheck *HealthCheckSpec               `json:"liveness_health_check,omitempty"`
+	LogDestinations     []*AppLogDestinationSpec   `json:"log_destinations,omitempty"`
+	Termination         *AppServiceSpecTermination `json:"termination,omitempty"`
+	LivenessHealthCheck *HealthCheckSpec           `json:"liveness_health_check,omitempty"`
 }
 
 // AppServiceSpecHealthCheck struct for AppServiceSpecHealthCheck
@@ -574,12 +565,6 @@ type AppServiceSpecHealthCheck struct {
 	HTTPPath string `json:"http_path,omitempty"`
 	// The port on which the health check will be performed. If not set, the health check will be performed on the component's http_port.
 	Port int64 `json:"port,omitempty"`
-}
-
-// AppServiceSpecInactivitySleep struct for AppServiceSpecInactivitySleep
-type AppServiceSpecInactivitySleep struct {
-	// The number of seconds to wait before putting the service to sleep after it has been inactive. Minimum 120, Maximum 3600.
-	AfterSeconds int32 `json:"after_seconds,omitempty"`
 }
 
 // AppServiceSpecTermination struct for AppServiceSpecTermination
@@ -617,10 +602,6 @@ type AppSpec struct {
 	Egress      *AppEgressSpec      `json:"egress,omitempty"`
 	Features    []string            `json:"features,omitempty"`
 	Maintenance *AppMaintenanceSpec `json:"maintenance,omitempty"`
-	// Specification to disable edge (CDN) cache for all domains of the app. Note that this feature is in private preview.
-	DisableEdgeCache bool `json:"disable_edge_cache,omitempty"`
-	// Specification to disable email obfuscation.
-	DisableEmailObfuscation bool `json:"disable_email_obfuscation,omitempty"`
 }
 
 // AppStaticSiteSpec struct for AppStaticSiteSpec
@@ -703,12 +684,6 @@ type AppWorkerSpecTermination struct {
 	GracePeriodSeconds int32 `json:"grace_period_seconds,omitempty"`
 }
 
-// AutoscalerActionScaleChange struct for AutoscalerActionScaleChange
-type AutoscalerActionScaleChange struct {
-	From int64 `json:"from,omitempty"`
-	To   int64 `json:"to,omitempty"`
-}
-
 // BitbucketSourceSpec struct for BitbucketSourceSpec
 type BitbucketSourceSpec struct {
 	Repo         string `json:"repo,omitempty"`
@@ -736,8 +711,7 @@ type Buildpack struct {
 
 // DeploymentCauseDetailsAutoscalerAction struct for DeploymentCauseDetailsAutoscalerAction
 type DeploymentCauseDetailsAutoscalerAction struct {
-	Autoscaled       bool                                   `json:"autoscaled,omitempty"`
-	ScaledComponents map[string]AutoscalerActionScaleChange `json:"scaled_components,omitempty"`
+	Autoscaled bool `json:"autoscaled,omitempty"`
 }
 
 // DeploymentCauseDetailsDigitalOceanUser struct for DeploymentCauseDetailsDigitalOceanUser
@@ -1256,8 +1230,6 @@ type AppInstanceSize struct {
 	MemoryBytes      string                 `json:"memory_bytes,omitempty"`
 	USDPerMonth      string                 `json:"usd_per_month,omitempty"`
 	USDPerSecond     string                 `json:"usd_per_second,omitempty"`
-	IDleUSDPerMonth  string                 `json:"idle_usd_per_month,omitempty"`
-	IDleUSDPerSecond string                 `json:"idle_usd_per_second,omitempty"`
 	TierSlug         string                 `json:"tier_slug,omitempty"`
 	// (Deprecated) The slug of the corresponding upgradable instance size on the higher tier.
 	TierUpgradeTo string `json:"tier_upgrade_to,omitempty"`

--- a/apps.gen.go
+++ b/apps.gen.go
@@ -1223,14 +1223,14 @@ const (
 
 // AppInstanceSize struct for AppInstanceSize
 type AppInstanceSize struct {
-	Name             string                 `json:"name,omitempty"`
-	Slug             string                 `json:"slug,omitempty"`
-	CPUType          AppInstanceSizeCPUType `json:"cpu_type,omitempty"`
-	CPUs             string                 `json:"cpus,omitempty"`
-	MemoryBytes      string                 `json:"memory_bytes,omitempty"`
-	USDPerMonth      string                 `json:"usd_per_month,omitempty"`
-	USDPerSecond     string                 `json:"usd_per_second,omitempty"`
-	TierSlug         string                 `json:"tier_slug,omitempty"`
+	Name         string                 `json:"name,omitempty"`
+	Slug         string                 `json:"slug,omitempty"`
+	CPUType      AppInstanceSizeCPUType `json:"cpu_type,omitempty"`
+	CPUs         string                 `json:"cpus,omitempty"`
+	MemoryBytes  string                 `json:"memory_bytes,omitempty"`
+	USDPerMonth  string                 `json:"usd_per_month,omitempty"`
+	USDPerSecond string                 `json:"usd_per_second,omitempty"`
+	TierSlug     string                 `json:"tier_slug,omitempty"`
 	// (Deprecated) The slug of the corresponding upgradable instance size on the higher tier.
 	TierUpgradeTo string `json:"tier_upgrade_to,omitempty"`
 	// (Deprecated) The slug of the corresponding downgradable instance size on the lower tier.

--- a/apps.gen.go
+++ b/apps.gen.go
@@ -663,7 +663,6 @@ type AppVariableDefinition struct {
 	Type  AppVariableType  `json:"type,omitempty"`
 }
 
-
 // AppWorkerSpec struct for AppWorkerSpec
 type AppWorkerSpec struct {
 	// The name. Must be unique across all components within the same app.

--- a/apps.go
+++ b/apps.go
@@ -194,7 +194,7 @@ type AppsServiceOp struct {
 }
 
 type GetAppInstancesOpts struct {
-	// Resevered for future use.
+	// reserved for future use.
 }
 
 // URN returns a URN identifier for the app

--- a/apps.go
+++ b/apps.go
@@ -74,6 +74,8 @@ type AppsService interface {
 		*Response,
 		error,
 	)
+
+	GetAppInstances(ctx context.Context, appID string) ([]*AppInstance, *Response, error)
 }
 
 // AppLogs represent app logs.
@@ -663,6 +665,22 @@ func (s *AppsServiceOp) ToggleDatabaseTrustedSource(
 		return nil, resp, err
 	}
 	return root, resp, nil
+}
+
+// GetAppInstances returns a list of emphemeral compute instances of the current deployment for an app.
+func (s *AppsServiceOp) GetAppInstances(ctx context.Context, appID string) ([]*AppInstance, *Response, error) {
+	path := fmt.Sprintf("%s/%s/instances", appsBasePath, appID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(GetAppInstancesResponse)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Instances, resp, nil
 }
 
 // AppComponentType is an app component type.

--- a/apps.go
+++ b/apps.go
@@ -75,7 +75,7 @@ type AppsService interface {
 		error,
 	)
 
-	GetAppInstances(ctx context.Context, appID string) ([]*AppInstance, *Response, error)
+	GetAppInstances(ctx context.Context, appID string, opts *GetAppInstancesOptions) ([]*AppInstance, *Response, error)
 }
 
 // AppLogs represent app logs.
@@ -191,6 +191,10 @@ type buildpacksRoot struct {
 // AppsServiceOp handles communication with Apps methods of the DigitalOcean API.
 type AppsServiceOp struct {
 	client *Client
+}
+
+type GetAppInstancesOptions struct {
+	// Resevered for future use.
 }
 
 // URN returns a URN identifier for the app
@@ -668,7 +672,8 @@ func (s *AppsServiceOp) ToggleDatabaseTrustedSource(
 }
 
 // GetAppInstances returns a list of emphemeral compute instances of the current deployment for an app.
-func (s *AppsServiceOp) GetAppInstances(ctx context.Context, appID string) ([]*AppInstance, *Response, error) {
+// opts is reserved for future use.
+func (s *AppsServiceOp) GetAppInstances(ctx context.Context, appID string, opts *GetAppInstancesOptions) ([]*AppInstance, *Response, error) {
 	path := fmt.Sprintf("%s/%s/instances", appsBasePath, appID)
 
 	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)

--- a/apps.go
+++ b/apps.go
@@ -75,7 +75,7 @@ type AppsService interface {
 		error,
 	)
 
-	GetAppInstances(ctx context.Context, appID string, opts *GetAppInstancesOptions) ([]*AppInstance, *Response, error)
+	GetAppInstances(ctx context.Context, appID string, opts *GetAppInstancesOpts) ([]*AppInstance, *Response, error)
 }
 
 // AppLogs represent app logs.
@@ -193,7 +193,7 @@ type AppsServiceOp struct {
 	client *Client
 }
 
-type GetAppInstancesOptions struct {
+type GetAppInstancesOpts struct {
 	// Resevered for future use.
 }
 
@@ -673,7 +673,7 @@ func (s *AppsServiceOp) ToggleDatabaseTrustedSource(
 
 // GetAppInstances returns a list of emphemeral compute instances of the current deployment for an app.
 // opts is reserved for future use.
-func (s *AppsServiceOp) GetAppInstances(ctx context.Context, appID string, opts *GetAppInstancesOptions) ([]*AppInstance, *Response, error) {
+func (s *AppsServiceOp) GetAppInstances(ctx context.Context, appID string, opts *GetAppInstancesOpts) ([]*AppInstance, *Response, error) {
 	path := fmt.Sprintf("%s/%s/instances", appsBasePath, appID)
 
 	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)

--- a/apps_accessors.go
+++ b/apps_accessors.go
@@ -1541,14 +1541,6 @@ func (a *AppMaintenanceSpec) GetOfflinePageURL() string {
 	return a.OfflinePageURL
 }
 
-// GetName returns the Name field.
-func (a *AppPeeredVpcSpec) GetName() string {
-	if a == nil {
-		return ""
-	}
-	return a.Name
-}
-
 // GetAppID returns the AppID field.
 func (a *AppProposeRequest) GetAppID() string {
 	if a == nil {
@@ -2165,14 +2157,6 @@ func (a *AppSpec) GetStaticSites() []*AppStaticSiteSpec {
 	return a.StaticSites
 }
 
-// GetVpc returns the Vpc field.
-func (a *AppSpec) GetVpc() *AppVpcSpec {
-	if a == nil {
-		return nil
-	}
-	return a.Vpc
-}
-
 // GetWorkers returns the Workers field.
 func (a *AppSpec) GetWorkers() []*AppWorkerSpec {
 	if a == nil {
@@ -2395,22 +2379,6 @@ func (a *AppVariableDefinition) GetValue() string {
 		return ""
 	}
 	return a.Value
-}
-
-// GetID returns the ID field.
-func (a *AppVpcSpec) GetID() string {
-	if a == nil {
-		return ""
-	}
-	return a.ID
-}
-
-// GetPeeredVpcs returns the PeeredVpcs field.
-func (a *AppVpcSpec) GetPeeredVpcs() []*AppPeeredVpcSpec {
-	if a == nil {
-		return nil
-	}
-	return a.PeeredVpcs
 }
 
 // GetAlerts returns the Alerts field.

--- a/apps_accessors.go
+++ b/apps_accessors.go
@@ -1101,22 +1101,6 @@ func (a *AppInstanceSize) GetFeaturePreview() bool {
 	return a.FeaturePreview
 }
 
-// GetIDleUSDPerMonth returns the IDleUSDPerMonth field.
-func (a *AppInstanceSize) GetIDleUSDPerMonth() string {
-	if a == nil {
-		return ""
-	}
-	return a.IDleUSDPerMonth
-}
-
-// GetIDleUSDPerSecond returns the IDleUSDPerSecond field.
-func (a *AppInstanceSize) GetIDleUSDPerSecond() string {
-	if a == nil {
-		return ""
-	}
-	return a.IDleUSDPerSecond
-}
-
 // GetMemoryBytes returns the MemoryBytes field.
 func (a *AppInstanceSize) GetMemoryBytes() string {
 	if a == nil {
@@ -1325,14 +1309,6 @@ func (a *AppJobSpec) GetRunCommand() string {
 	return a.RunCommand
 }
 
-// GetSchedule returns the Schedule field.
-func (a *AppJobSpec) GetSchedule() *AppJobSpecSchedule {
-	if a == nil {
-		return nil
-	}
-	return a.Schedule
-}
-
 // GetSourceDir returns the SourceDir field.
 func (a *AppJobSpec) GetSourceDir() string {
 	if a == nil {
@@ -1347,22 +1323,6 @@ func (a *AppJobSpec) GetTermination() *AppJobSpecTermination {
 		return nil
 	}
 	return a.Termination
-}
-
-// GetCron returns the Cron field.
-func (a *AppJobSpecSchedule) GetCron() string {
-	if a == nil {
-		return ""
-	}
-	return a.Cron
-}
-
-// GetTimeZone returns the TimeZone field.
-func (a *AppJobSpecSchedule) GetTimeZone() string {
-	if a == nil {
-		return ""
-	}
-	return a.TimeZone
 }
 
 // GetGracePeriodSeconds returns the GracePeriodSeconds field.
@@ -1845,14 +1805,6 @@ func (a *AppServiceSpec) GetImage() *ImageSourceSpec {
 	return a.Image
 }
 
-// GetInactivitySleep returns the InactivitySleep field.
-func (a *AppServiceSpec) GetInactivitySleep() *AppServiceSpecInactivitySleep {
-	if a == nil {
-		return nil
-	}
-	return a.InactivitySleep
-}
-
 // GetInstanceCount returns the InstanceCount field.
 func (a *AppServiceSpec) GetInstanceCount() int64 {
 	if a == nil {
@@ -1875,14 +1827,6 @@ func (a *AppServiceSpec) GetInternalPorts() []int64 {
 		return nil
 	}
 	return a.InternalPorts
-}
-
-// GetLivenessHealthCheck returns the LivenessHealthCheck field.
-func (a *AppServiceSpec) GetLivenessHealthCheck() *HealthCheckSpec {
-	if a == nil {
-		return nil
-	}
-	return a.LivenessHealthCheck
 }
 
 // GetLogDestinations returns the LogDestinations field.
@@ -2005,14 +1949,6 @@ func (a *AppServiceSpecHealthCheck) GetTimeoutSeconds() int32 {
 	return a.TimeoutSeconds
 }
 
-// GetAfterSeconds returns the AfterSeconds field.
-func (a *AppServiceSpecInactivitySleep) GetAfterSeconds() int32 {
-	if a == nil {
-		return 0
-	}
-	return a.AfterSeconds
-}
-
 // GetDrainSeconds returns the DrainSeconds field.
 func (a *AppServiceSpecTermination) GetDrainSeconds() int32 {
 	if a == nil {
@@ -2043,22 +1979,6 @@ func (a *AppSpec) GetDatabases() []*AppDatabaseSpec {
 		return nil
 	}
 	return a.Databases
-}
-
-// GetDisableEdgeCache returns the DisableEdgeCache field.
-func (a *AppSpec) GetDisableEdgeCache() bool {
-	if a == nil {
-		return false
-	}
-	return a.DisableEdgeCache
-}
-
-// GetDisableEmailObfuscation returns the DisableEmailObfuscation field.
-func (a *AppSpec) GetDisableEmailObfuscation() bool {
-	if a == nil {
-		return false
-	}
-	return a.DisableEmailObfuscation
 }
 
 // GetDomains returns the Domains field.
@@ -2485,14 +2405,6 @@ func (a *AppWorkerSpec) GetInstanceSizeSlug() string {
 	return a.InstanceSizeSlug
 }
 
-// GetLivenessHealthCheck returns the LivenessHealthCheck field.
-func (a *AppWorkerSpec) GetLivenessHealthCheck() *HealthCheckSpec {
-	if a == nil {
-		return nil
-	}
-	return a.LivenessHealthCheck
-}
-
 // GetLogDestinations returns the LogDestinations field.
 func (a *AppWorkerSpec) GetLogDestinations() []*AppLogDestinationSpec {
 	if a == nil {
@@ -2539,22 +2451,6 @@ func (a *AppWorkerSpecTermination) GetGracePeriodSeconds() int32 {
 		return 0
 	}
 	return a.GracePeriodSeconds
-}
-
-// GetFrom returns the From field.
-func (a *AutoscalerActionScaleChange) GetFrom() int64 {
-	if a == nil {
-		return 0
-	}
-	return a.From
-}
-
-// GetTo returns the To field.
-func (a *AutoscalerActionScaleChange) GetTo() int64 {
-	if a == nil {
-		return 0
-	}
-	return a.To
 }
 
 // GetBranch returns the Branch field.
@@ -2843,14 +2739,6 @@ func (d *DeploymentCauseDetailsAutoscalerAction) GetAutoscaled() bool {
 		return false
 	}
 	return d.Autoscaled
-}
-
-// GetScaledComponents returns the ScaledComponents map if it's non-nil, an empty map otherwise.
-func (d *DeploymentCauseDetailsAutoscalerAction) GetScaledComponents() map[string]AutoscalerActionScaleChange {
-	if d == nil || d.ScaledComponents == nil {
-		return map[string]AutoscalerActionScaleChange{}
-	}
-	return d.ScaledComponents
 }
 
 // GetEmail returns the Email field.
@@ -3573,14 +3461,6 @@ func (g *GetAppDatabaseConnectionDetailsResponse) GetConnectionDetails() []*GetD
 	return g.ConnectionDetails
 }
 
-// GetInstances returns the Instances field.
-func (g *GetAppInstancesResponse) GetInstances() []*AppInstance {
-	if g == nil {
-		return nil
-	}
-	return g.Instances
-}
-
 // GetComponentName returns the ComponentName field.
 func (g *GetDatabaseConnectionDetailsResponse) GetComponentName() string {
 	if g == nil {
@@ -3787,62 +3667,6 @@ func (g *GitSourceSpec) GetRepoCloneURL() string {
 		return ""
 	}
 	return g.RepoCloneURL
-}
-
-// GetFailureThreshold returns the FailureThreshold field.
-func (h *HealthCheckSpec) GetFailureThreshold() int32 {
-	if h == nil {
-		return 0
-	}
-	return h.FailureThreshold
-}
-
-// GetHTTPPath returns the HTTPPath field.
-func (h *HealthCheckSpec) GetHTTPPath() string {
-	if h == nil {
-		return ""
-	}
-	return h.HTTPPath
-}
-
-// GetInitialDelaySeconds returns the InitialDelaySeconds field.
-func (h *HealthCheckSpec) GetInitialDelaySeconds() int32 {
-	if h == nil {
-		return 0
-	}
-	return h.InitialDelaySeconds
-}
-
-// GetPeriodSeconds returns the PeriodSeconds field.
-func (h *HealthCheckSpec) GetPeriodSeconds() int32 {
-	if h == nil {
-		return 0
-	}
-	return h.PeriodSeconds
-}
-
-// GetPort returns the Port field.
-func (h *HealthCheckSpec) GetPort() int64 {
-	if h == nil {
-		return 0
-	}
-	return h.Port
-}
-
-// GetSuccessThreshold returns the SuccessThreshold field.
-func (h *HealthCheckSpec) GetSuccessThreshold() int32 {
-	if h == nil {
-		return 0
-	}
-	return h.SuccessThreshold
-}
-
-// GetTimeoutSeconds returns the TimeoutSeconds field.
-func (h *HealthCheckSpec) GetTimeoutSeconds() int32 {
-	if h == nil {
-		return 0
-	}
-	return h.TimeoutSeconds
 }
 
 // GetDeployOnPush returns the DeployOnPush field.

--- a/apps_accessors.go
+++ b/apps_accessors.go
@@ -1037,6 +1037,30 @@ func (a *AppIngressSpecRuleStringMatch) GetPrefix() string {
 	return a.Prefix
 }
 
+// GetComponentName returns the ComponentName field.
+func (a *AppInstance) GetComponentName() string {
+	if a == nil {
+		return ""
+	}
+	return a.ComponentName
+}
+
+// GetComponentType returns the ComponentType field.
+func (a *AppInstance) GetComponentType() AppInstanceComponentType {
+	if a == nil {
+		return ""
+	}
+	return a.ComponentType
+}
+
+// GetInstanceName returns the InstanceName field.
+func (a *AppInstance) GetInstanceName() string {
+	if a == nil {
+		return ""
+	}
+	return a.InstanceName
+}
+
 // GetBandwidthAllowanceGib returns the BandwidthAllowanceGib field.
 func (a *AppInstanceSize) GetBandwidthAllowanceGib() string {
 	if a == nil {
@@ -1075,6 +1099,22 @@ func (a *AppInstanceSize) GetFeaturePreview() bool {
 		return false
 	}
 	return a.FeaturePreview
+}
+
+// GetIDleUSDPerMonth returns the IDleUSDPerMonth field.
+func (a *AppInstanceSize) GetIDleUSDPerMonth() string {
+	if a == nil {
+		return ""
+	}
+	return a.IDleUSDPerMonth
+}
+
+// GetIDleUSDPerSecond returns the IDleUSDPerSecond field.
+func (a *AppInstanceSize) GetIDleUSDPerSecond() string {
+	if a == nil {
+		return ""
+	}
+	return a.IDleUSDPerSecond
 }
 
 // GetMemoryBytes returns the MemoryBytes field.
@@ -1285,6 +1325,14 @@ func (a *AppJobSpec) GetRunCommand() string {
 	return a.RunCommand
 }
 
+// GetSchedule returns the Schedule field.
+func (a *AppJobSpec) GetSchedule() *AppJobSpecSchedule {
+	if a == nil {
+		return nil
+	}
+	return a.Schedule
+}
+
 // GetSourceDir returns the SourceDir field.
 func (a *AppJobSpec) GetSourceDir() string {
 	if a == nil {
@@ -1299,6 +1347,22 @@ func (a *AppJobSpec) GetTermination() *AppJobSpecTermination {
 		return nil
 	}
 	return a.Termination
+}
+
+// GetCron returns the Cron field.
+func (a *AppJobSpecSchedule) GetCron() string {
+	if a == nil {
+		return ""
+	}
+	return a.Cron
+}
+
+// GetTimeZone returns the TimeZone field.
+func (a *AppJobSpecSchedule) GetTimeZone() string {
+	if a == nil {
+		return ""
+	}
+	return a.TimeZone
 }
 
 // GetGracePeriodSeconds returns the GracePeriodSeconds field.
@@ -1475,6 +1539,14 @@ func (a *AppMaintenanceSpec) GetOfflinePageURL() string {
 		return ""
 	}
 	return a.OfflinePageURL
+}
+
+// GetName returns the Name field.
+func (a *AppPeeredVpcSpec) GetName() string {
+	if a == nil {
+		return ""
+	}
+	return a.Name
 }
 
 // GetAppID returns the AppID field.
@@ -1781,6 +1853,14 @@ func (a *AppServiceSpec) GetImage() *ImageSourceSpec {
 	return a.Image
 }
 
+// GetInactivitySleep returns the InactivitySleep field.
+func (a *AppServiceSpec) GetInactivitySleep() *AppServiceSpecInactivitySleep {
+	if a == nil {
+		return nil
+	}
+	return a.InactivitySleep
+}
+
 // GetInstanceCount returns the InstanceCount field.
 func (a *AppServiceSpec) GetInstanceCount() int64 {
 	if a == nil {
@@ -1803,6 +1883,14 @@ func (a *AppServiceSpec) GetInternalPorts() []int64 {
 		return nil
 	}
 	return a.InternalPorts
+}
+
+// GetLivenessHealthCheck returns the LivenessHealthCheck field.
+func (a *AppServiceSpec) GetLivenessHealthCheck() *HealthCheckSpec {
+	if a == nil {
+		return nil
+	}
+	return a.LivenessHealthCheck
 }
 
 // GetLogDestinations returns the LogDestinations field.
@@ -1925,6 +2013,14 @@ func (a *AppServiceSpecHealthCheck) GetTimeoutSeconds() int32 {
 	return a.TimeoutSeconds
 }
 
+// GetAfterSeconds returns the AfterSeconds field.
+func (a *AppServiceSpecInactivitySleep) GetAfterSeconds() int32 {
+	if a == nil {
+		return 0
+	}
+	return a.AfterSeconds
+}
+
 // GetDrainSeconds returns the DrainSeconds field.
 func (a *AppServiceSpecTermination) GetDrainSeconds() int32 {
 	if a == nil {
@@ -1955,6 +2051,22 @@ func (a *AppSpec) GetDatabases() []*AppDatabaseSpec {
 		return nil
 	}
 	return a.Databases
+}
+
+// GetDisableEdgeCache returns the DisableEdgeCache field.
+func (a *AppSpec) GetDisableEdgeCache() bool {
+	if a == nil {
+		return false
+	}
+	return a.DisableEdgeCache
+}
+
+// GetDisableEmailObfuscation returns the DisableEmailObfuscation field.
+func (a *AppSpec) GetDisableEmailObfuscation() bool {
+	if a == nil {
+		return false
+	}
+	return a.DisableEmailObfuscation
 }
 
 // GetDomains returns the Domains field.
@@ -2051,6 +2163,14 @@ func (a *AppSpec) GetStaticSites() []*AppStaticSiteSpec {
 		return nil
 	}
 	return a.StaticSites
+}
+
+// GetVpc returns the Vpc field.
+func (a *AppSpec) GetVpc() *AppVpcSpec {
+	if a == nil {
+		return nil
+	}
+	return a.Vpc
 }
 
 // GetWorkers returns the Workers field.
@@ -2277,6 +2397,22 @@ func (a *AppVariableDefinition) GetValue() string {
 	return a.Value
 }
 
+// GetID returns the ID field.
+func (a *AppVpcSpec) GetID() string {
+	if a == nil {
+		return ""
+	}
+	return a.ID
+}
+
+// GetPeeredVpcs returns the PeeredVpcs field.
+func (a *AppVpcSpec) GetPeeredVpcs() []*AppPeeredVpcSpec {
+	if a == nil {
+		return nil
+	}
+	return a.PeeredVpcs
+}
+
 // GetAlerts returns the Alerts field.
 func (a *AppWorkerSpec) GetAlerts() []*AppAlertSpec {
 	if a == nil {
@@ -2381,6 +2517,14 @@ func (a *AppWorkerSpec) GetInstanceSizeSlug() string {
 	return a.InstanceSizeSlug
 }
 
+// GetLivenessHealthCheck returns the LivenessHealthCheck field.
+func (a *AppWorkerSpec) GetLivenessHealthCheck() *HealthCheckSpec {
+	if a == nil {
+		return nil
+	}
+	return a.LivenessHealthCheck
+}
+
 // GetLogDestinations returns the LogDestinations field.
 func (a *AppWorkerSpec) GetLogDestinations() []*AppLogDestinationSpec {
 	if a == nil {
@@ -2427,6 +2571,22 @@ func (a *AppWorkerSpecTermination) GetGracePeriodSeconds() int32 {
 		return 0
 	}
 	return a.GracePeriodSeconds
+}
+
+// GetFrom returns the From field.
+func (a *AutoscalerActionScaleChange) GetFrom() int64 {
+	if a == nil {
+		return 0
+	}
+	return a.From
+}
+
+// GetTo returns the To field.
+func (a *AutoscalerActionScaleChange) GetTo() int64 {
+	if a == nil {
+		return 0
+	}
+	return a.To
 }
 
 // GetBranch returns the Branch field.
@@ -2715,6 +2875,14 @@ func (d *DeploymentCauseDetailsAutoscalerAction) GetAutoscaled() bool {
 		return false
 	}
 	return d.Autoscaled
+}
+
+// GetScaledComponents returns the ScaledComponents map if it's non-nil, an empty map otherwise.
+func (d *DeploymentCauseDetailsAutoscalerAction) GetScaledComponents() map[string]AutoscalerActionScaleChange {
+	if d == nil || d.ScaledComponents == nil {
+		return map[string]AutoscalerActionScaleChange{}
+	}
+	return d.ScaledComponents
 }
 
 // GetEmail returns the Email field.
@@ -3437,6 +3605,14 @@ func (g *GetAppDatabaseConnectionDetailsResponse) GetConnectionDetails() []*GetD
 	return g.ConnectionDetails
 }
 
+// GetInstances returns the Instances field.
+func (g *GetAppInstancesResponse) GetInstances() []*AppInstance {
+	if g == nil {
+		return nil
+	}
+	return g.Instances
+}
+
 // GetComponentName returns the ComponentName field.
 func (g *GetDatabaseConnectionDetailsResponse) GetComponentName() string {
 	if g == nil {
@@ -3643,6 +3819,62 @@ func (g *GitSourceSpec) GetRepoCloneURL() string {
 		return ""
 	}
 	return g.RepoCloneURL
+}
+
+// GetFailureThreshold returns the FailureThreshold field.
+func (h *HealthCheckSpec) GetFailureThreshold() int32 {
+	if h == nil {
+		return 0
+	}
+	return h.FailureThreshold
+}
+
+// GetHTTPPath returns the HTTPPath field.
+func (h *HealthCheckSpec) GetHTTPPath() string {
+	if h == nil {
+		return ""
+	}
+	return h.HTTPPath
+}
+
+// GetInitialDelaySeconds returns the InitialDelaySeconds field.
+func (h *HealthCheckSpec) GetInitialDelaySeconds() int32 {
+	if h == nil {
+		return 0
+	}
+	return h.InitialDelaySeconds
+}
+
+// GetPeriodSeconds returns the PeriodSeconds field.
+func (h *HealthCheckSpec) GetPeriodSeconds() int32 {
+	if h == nil {
+		return 0
+	}
+	return h.PeriodSeconds
+}
+
+// GetPort returns the Port field.
+func (h *HealthCheckSpec) GetPort() int64 {
+	if h == nil {
+		return 0
+	}
+	return h.Port
+}
+
+// GetSuccessThreshold returns the SuccessThreshold field.
+func (h *HealthCheckSpec) GetSuccessThreshold() int32 {
+	if h == nil {
+		return 0
+	}
+	return h.SuccessThreshold
+}
+
+// GetTimeoutSeconds returns the TimeoutSeconds field.
+func (h *HealthCheckSpec) GetTimeoutSeconds() int32 {
+	if h == nil {
+		return 0
+	}
+	return h.TimeoutSeconds
 }
 
 // GetDeployOnPush returns the DeployOnPush field.

--- a/apps_accessors_test.go
+++ b/apps_accessors_test.go
@@ -1350,13 +1350,6 @@ func TestAppMaintenanceSpec_GetOfflinePageURL(tt *testing.T) {
 	a.GetOfflinePageURL()
 }
 
-func TestAppPeeredVpcSpec_GetName(tt *testing.T) {
-	a := &AppPeeredVpcSpec{}
-	a.GetName()
-	a = nil
-	a.GetName()
-}
-
 func TestAppProposeRequest_GetAppID(tt *testing.T) {
 	a := &AppProposeRequest{}
 	a.GetAppID()
@@ -1896,13 +1889,6 @@ func TestAppSpec_GetStaticSites(tt *testing.T) {
 	a.GetStaticSites()
 }
 
-func TestAppSpec_GetVpc(tt *testing.T) {
-	a := &AppSpec{}
-	a.GetVpc()
-	a = nil
-	a.GetVpc()
-}
-
 func TestAppSpec_GetWorkers(tt *testing.T) {
 	a := &AppSpec{}
 	a.GetWorkers()
@@ -2097,20 +2083,6 @@ func TestAppVariableDefinition_GetValue(tt *testing.T) {
 	a.GetValue()
 	a = nil
 	a.GetValue()
-}
-
-func TestAppVpcSpec_GetID(tt *testing.T) {
-	a := &AppVpcSpec{}
-	a.GetID()
-	a = nil
-	a.GetID()
-}
-
-func TestAppVpcSpec_GetPeeredVpcs(tt *testing.T) {
-	a := &AppVpcSpec{}
-	a.GetPeeredVpcs()
-	a = nil
-	a.GetPeeredVpcs()
 }
 
 func TestAppWorkerSpec_GetAlerts(tt *testing.T) {

--- a/apps_accessors_test.go
+++ b/apps_accessors_test.go
@@ -909,27 +909,6 @@ func TestAppIngressSpecRuleStringMatch_GetPrefix(tt *testing.T) {
 	a.GetPrefix()
 }
 
-func TestAppInstance_GetComponentName(tt *testing.T) {
-	a := &AppInstance{}
-	a.GetComponentName()
-	a = nil
-	a.GetComponentName()
-}
-
-func TestAppInstance_GetComponentType(tt *testing.T) {
-	a := &AppInstance{}
-	a.GetComponentType()
-	a = nil
-	a.GetComponentType()
-}
-
-func TestAppInstance_GetInstanceName(tt *testing.T) {
-	a := &AppInstance{}
-	a.GetInstanceName()
-	a = nil
-	a.GetInstanceName()
-}
-
 func TestAppInstanceSize_GetBandwidthAllowanceGib(tt *testing.T) {
 	a := &AppInstanceSize{}
 	a.GetBandwidthAllowanceGib()
@@ -963,20 +942,6 @@ func TestAppInstanceSize_GetFeaturePreview(tt *testing.T) {
 	a.GetFeaturePreview()
 	a = nil
 	a.GetFeaturePreview()
-}
-
-func TestAppInstanceSize_GetIDleUSDPerMonth(tt *testing.T) {
-	a := &AppInstanceSize{}
-	a.GetIDleUSDPerMonth()
-	a = nil
-	a.GetIDleUSDPerMonth()
-}
-
-func TestAppInstanceSize_GetIDleUSDPerSecond(tt *testing.T) {
-	a := &AppInstanceSize{}
-	a.GetIDleUSDPerSecond()
-	a = nil
-	a.GetIDleUSDPerSecond()
 }
 
 func TestAppInstanceSize_GetMemoryBytes(tt *testing.T) {
@@ -1161,13 +1126,6 @@ func TestAppJobSpec_GetRunCommand(tt *testing.T) {
 	a.GetRunCommand()
 }
 
-func TestAppJobSpec_GetSchedule(tt *testing.T) {
-	a := &AppJobSpec{}
-	a.GetSchedule()
-	a = nil
-	a.GetSchedule()
-}
-
 func TestAppJobSpec_GetSourceDir(tt *testing.T) {
 	a := &AppJobSpec{}
 	a.GetSourceDir()
@@ -1180,20 +1138,6 @@ func TestAppJobSpec_GetTermination(tt *testing.T) {
 	a.GetTermination()
 	a = nil
 	a.GetTermination()
-}
-
-func TestAppJobSpecSchedule_GetCron(tt *testing.T) {
-	a := &AppJobSpecSchedule{}
-	a.GetCron()
-	a = nil
-	a.GetCron()
-}
-
-func TestAppJobSpecSchedule_GetTimeZone(tt *testing.T) {
-	a := &AppJobSpecSchedule{}
-	a.GetTimeZone()
-	a = nil
-	a.GetTimeZone()
 }
 
 func TestAppJobSpecTermination_GetGracePeriodSeconds(tt *testing.T) {
@@ -1616,13 +1560,6 @@ func TestAppServiceSpec_GetImage(tt *testing.T) {
 	a.GetImage()
 }
 
-func TestAppServiceSpec_GetInactivitySleep(tt *testing.T) {
-	a := &AppServiceSpec{}
-	a.GetInactivitySleep()
-	a = nil
-	a.GetInactivitySleep()
-}
-
 func TestAppServiceSpec_GetInstanceCount(tt *testing.T) {
 	a := &AppServiceSpec{}
 	a.GetInstanceCount()
@@ -1642,13 +1579,6 @@ func TestAppServiceSpec_GetInternalPorts(tt *testing.T) {
 	a.GetInternalPorts()
 	a = nil
 	a.GetInternalPorts()
-}
-
-func TestAppServiceSpec_GetLivenessHealthCheck(tt *testing.T) {
-	a := &AppServiceSpec{}
-	a.GetLivenessHealthCheck()
-	a = nil
-	a.GetLivenessHealthCheck()
 }
 
 func TestAppServiceSpec_GetLogDestinations(tt *testing.T) {
@@ -1756,13 +1686,6 @@ func TestAppServiceSpecHealthCheck_GetTimeoutSeconds(tt *testing.T) {
 	a.GetTimeoutSeconds()
 }
 
-func TestAppServiceSpecInactivitySleep_GetAfterSeconds(tt *testing.T) {
-	a := &AppServiceSpecInactivitySleep{}
-	a.GetAfterSeconds()
-	a = nil
-	a.GetAfterSeconds()
-}
-
 func TestAppServiceSpecTermination_GetDrainSeconds(tt *testing.T) {
 	a := &AppServiceSpecTermination{}
 	a.GetDrainSeconds()
@@ -1789,20 +1712,6 @@ func TestAppSpec_GetDatabases(tt *testing.T) {
 	a.GetDatabases()
 	a = nil
 	a.GetDatabases()
-}
-
-func TestAppSpec_GetDisableEdgeCache(tt *testing.T) {
-	a := &AppSpec{}
-	a.GetDisableEdgeCache()
-	a = nil
-	a.GetDisableEdgeCache()
-}
-
-func TestAppSpec_GetDisableEmailObfuscation(tt *testing.T) {
-	a := &AppSpec{}
-	a.GetDisableEmailObfuscation()
-	a = nil
-	a.GetDisableEmailObfuscation()
 }
 
 func TestAppSpec_GetDomains(tt *testing.T) {
@@ -2176,13 +2085,6 @@ func TestAppWorkerSpec_GetInstanceSizeSlug(tt *testing.T) {
 	a.GetInstanceSizeSlug()
 }
 
-func TestAppWorkerSpec_GetLivenessHealthCheck(tt *testing.T) {
-	a := &AppWorkerSpec{}
-	a.GetLivenessHealthCheck()
-	a = nil
-	a.GetLivenessHealthCheck()
-}
-
 func TestAppWorkerSpec_GetLogDestinations(tt *testing.T) {
 	a := &AppWorkerSpec{}
 	a.GetLogDestinations()
@@ -2223,20 +2125,6 @@ func TestAppWorkerSpecTermination_GetGracePeriodSeconds(tt *testing.T) {
 	a.GetGracePeriodSeconds()
 	a = nil
 	a.GetGracePeriodSeconds()
-}
-
-func TestAutoscalerActionScaleChange_GetFrom(tt *testing.T) {
-	a := &AutoscalerActionScaleChange{}
-	a.GetFrom()
-	a = nil
-	a.GetFrom()
-}
-
-func TestAutoscalerActionScaleChange_GetTo(tt *testing.T) {
-	a := &AutoscalerActionScaleChange{}
-	a.GetTo()
-	a = nil
-	a.GetTo()
 }
 
 func TestBitbucketSourceSpec_GetBranch(tt *testing.T) {
@@ -2489,16 +2377,6 @@ func TestDeploymentCauseDetailsAutoscalerAction_GetAutoscaled(tt *testing.T) {
 	d.GetAutoscaled()
 	d = nil
 	d.GetAutoscaled()
-}
-
-func TestDeploymentCauseDetailsAutoscalerAction_GetScaledComponents(tt *testing.T) {
-	zeroValue := map[string]AutoscalerActionScaleChange{}
-	d := &DeploymentCauseDetailsAutoscalerAction{ScaledComponents: zeroValue}
-	d.GetScaledComponents()
-	d = &DeploymentCauseDetailsAutoscalerAction{}
-	d.GetScaledComponents()
-	d = nil
-	d.GetScaledComponents()
 }
 
 func TestDeploymentCauseDetailsDigitalOceanUser_GetEmail(tt *testing.T) {
@@ -3131,13 +3009,6 @@ func TestGetAppDatabaseConnectionDetailsResponse_GetConnectionDetails(tt *testin
 	g.GetConnectionDetails()
 }
 
-func TestGetAppInstancesResponse_GetInstances(tt *testing.T) {
-	g := &GetAppInstancesResponse{}
-	g.GetInstances()
-	g = nil
-	g.GetInstances()
-}
-
 func TestGetDatabaseConnectionDetailsResponse_GetComponentName(tt *testing.T) {
 	g := &GetDatabaseConnectionDetailsResponse{}
 	g.GetComponentName()
@@ -3320,55 +3191,6 @@ func TestGitSourceSpec_GetRepoCloneURL(tt *testing.T) {
 	g.GetRepoCloneURL()
 }
 
-func TestHealthCheckSpec_GetFailureThreshold(tt *testing.T) {
-	h := &HealthCheckSpec{}
-	h.GetFailureThreshold()
-	h = nil
-	h.GetFailureThreshold()
-}
-
-func TestHealthCheckSpec_GetHTTPPath(tt *testing.T) {
-	h := &HealthCheckSpec{}
-	h.GetHTTPPath()
-	h = nil
-	h.GetHTTPPath()
-}
-
-func TestHealthCheckSpec_GetInitialDelaySeconds(tt *testing.T) {
-	h := &HealthCheckSpec{}
-	h.GetInitialDelaySeconds()
-	h = nil
-	h.GetInitialDelaySeconds()
-}
-
-func TestHealthCheckSpec_GetPeriodSeconds(tt *testing.T) {
-	h := &HealthCheckSpec{}
-	h.GetPeriodSeconds()
-	h = nil
-	h.GetPeriodSeconds()
-}
-
-func TestHealthCheckSpec_GetPort(tt *testing.T) {
-	h := &HealthCheckSpec{}
-	h.GetPort()
-	h = nil
-	h.GetPort()
-}
-
-func TestHealthCheckSpec_GetSuccessThreshold(tt *testing.T) {
-	h := &HealthCheckSpec{}
-	h.GetSuccessThreshold()
-	h = nil
-	h.GetSuccessThreshold()
-}
-
-func TestHealthCheckSpec_GetTimeoutSeconds(tt *testing.T) {
-	h := &HealthCheckSpec{}
-	h.GetTimeoutSeconds()
-	h = nil
-	h.GetTimeoutSeconds()
-}
-
 func TestImageSourceSpec_GetDeployOnPush(tt *testing.T) {
 	i := &ImageSourceSpec{}
 	i.GetDeployOnPush()
@@ -3507,4 +3329,25 @@ func TestUpgradeBuildpackResponse_GetDeployment(tt *testing.T) {
 	u.GetDeployment()
 	u = nil
 	u.GetDeployment()
+}
+
+func TestAppInstance_GetComponentName(tt *testing.T) {
+	a := &AppInstance{}
+	a.GetComponentName()
+	a = nil
+	a.GetComponentName()
+}
+
+func TestAppInstance_GetComponentType(tt *testing.T) {
+	a := &AppInstance{}
+	a.GetComponentType()
+	a = nil
+	a.GetComponentType()
+}
+
+func TestAppInstance_GetInstanceName(tt *testing.T) {
+	a := &AppInstance{}
+	a.GetInstanceName()
+	a = nil
+	a.GetInstanceName()
 }

--- a/apps_accessors_test.go
+++ b/apps_accessors_test.go
@@ -909,6 +909,27 @@ func TestAppIngressSpecRuleStringMatch_GetPrefix(tt *testing.T) {
 	a.GetPrefix()
 }
 
+func TestAppInstance_GetComponentName(tt *testing.T) {
+	a := &AppInstance{}
+	a.GetComponentName()
+	a = nil
+	a.GetComponentName()
+}
+
+func TestAppInstance_GetComponentType(tt *testing.T) {
+	a := &AppInstance{}
+	a.GetComponentType()
+	a = nil
+	a.GetComponentType()
+}
+
+func TestAppInstance_GetInstanceName(tt *testing.T) {
+	a := &AppInstance{}
+	a.GetInstanceName()
+	a = nil
+	a.GetInstanceName()
+}
+
 func TestAppInstanceSize_GetBandwidthAllowanceGib(tt *testing.T) {
 	a := &AppInstanceSize{}
 	a.GetBandwidthAllowanceGib()
@@ -942,6 +963,20 @@ func TestAppInstanceSize_GetFeaturePreview(tt *testing.T) {
 	a.GetFeaturePreview()
 	a = nil
 	a.GetFeaturePreview()
+}
+
+func TestAppInstanceSize_GetIDleUSDPerMonth(tt *testing.T) {
+	a := &AppInstanceSize{}
+	a.GetIDleUSDPerMonth()
+	a = nil
+	a.GetIDleUSDPerMonth()
+}
+
+func TestAppInstanceSize_GetIDleUSDPerSecond(tt *testing.T) {
+	a := &AppInstanceSize{}
+	a.GetIDleUSDPerSecond()
+	a = nil
+	a.GetIDleUSDPerSecond()
 }
 
 func TestAppInstanceSize_GetMemoryBytes(tt *testing.T) {
@@ -1126,6 +1161,13 @@ func TestAppJobSpec_GetRunCommand(tt *testing.T) {
 	a.GetRunCommand()
 }
 
+func TestAppJobSpec_GetSchedule(tt *testing.T) {
+	a := &AppJobSpec{}
+	a.GetSchedule()
+	a = nil
+	a.GetSchedule()
+}
+
 func TestAppJobSpec_GetSourceDir(tt *testing.T) {
 	a := &AppJobSpec{}
 	a.GetSourceDir()
@@ -1138,6 +1180,20 @@ func TestAppJobSpec_GetTermination(tt *testing.T) {
 	a.GetTermination()
 	a = nil
 	a.GetTermination()
+}
+
+func TestAppJobSpecSchedule_GetCron(tt *testing.T) {
+	a := &AppJobSpecSchedule{}
+	a.GetCron()
+	a = nil
+	a.GetCron()
+}
+
+func TestAppJobSpecSchedule_GetTimeZone(tt *testing.T) {
+	a := &AppJobSpecSchedule{}
+	a.GetTimeZone()
+	a = nil
+	a.GetTimeZone()
 }
 
 func TestAppJobSpecTermination_GetGracePeriodSeconds(tt *testing.T) {
@@ -1292,6 +1348,13 @@ func TestAppMaintenanceSpec_GetOfflinePageURL(tt *testing.T) {
 	a.GetOfflinePageURL()
 	a = nil
 	a.GetOfflinePageURL()
+}
+
+func TestAppPeeredVpcSpec_GetName(tt *testing.T) {
+	a := &AppPeeredVpcSpec{}
+	a.GetName()
+	a = nil
+	a.GetName()
 }
 
 func TestAppProposeRequest_GetAppID(tt *testing.T) {
@@ -1560,6 +1623,13 @@ func TestAppServiceSpec_GetImage(tt *testing.T) {
 	a.GetImage()
 }
 
+func TestAppServiceSpec_GetInactivitySleep(tt *testing.T) {
+	a := &AppServiceSpec{}
+	a.GetInactivitySleep()
+	a = nil
+	a.GetInactivitySleep()
+}
+
 func TestAppServiceSpec_GetInstanceCount(tt *testing.T) {
 	a := &AppServiceSpec{}
 	a.GetInstanceCount()
@@ -1579,6 +1649,13 @@ func TestAppServiceSpec_GetInternalPorts(tt *testing.T) {
 	a.GetInternalPorts()
 	a = nil
 	a.GetInternalPorts()
+}
+
+func TestAppServiceSpec_GetLivenessHealthCheck(tt *testing.T) {
+	a := &AppServiceSpec{}
+	a.GetLivenessHealthCheck()
+	a = nil
+	a.GetLivenessHealthCheck()
 }
 
 func TestAppServiceSpec_GetLogDestinations(tt *testing.T) {
@@ -1686,6 +1763,13 @@ func TestAppServiceSpecHealthCheck_GetTimeoutSeconds(tt *testing.T) {
 	a.GetTimeoutSeconds()
 }
 
+func TestAppServiceSpecInactivitySleep_GetAfterSeconds(tt *testing.T) {
+	a := &AppServiceSpecInactivitySleep{}
+	a.GetAfterSeconds()
+	a = nil
+	a.GetAfterSeconds()
+}
+
 func TestAppServiceSpecTermination_GetDrainSeconds(tt *testing.T) {
 	a := &AppServiceSpecTermination{}
 	a.GetDrainSeconds()
@@ -1712,6 +1796,20 @@ func TestAppSpec_GetDatabases(tt *testing.T) {
 	a.GetDatabases()
 	a = nil
 	a.GetDatabases()
+}
+
+func TestAppSpec_GetDisableEdgeCache(tt *testing.T) {
+	a := &AppSpec{}
+	a.GetDisableEdgeCache()
+	a = nil
+	a.GetDisableEdgeCache()
+}
+
+func TestAppSpec_GetDisableEmailObfuscation(tt *testing.T) {
+	a := &AppSpec{}
+	a.GetDisableEmailObfuscation()
+	a = nil
+	a.GetDisableEmailObfuscation()
 }
 
 func TestAppSpec_GetDomains(tt *testing.T) {
@@ -1796,6 +1894,13 @@ func TestAppSpec_GetStaticSites(tt *testing.T) {
 	a.GetStaticSites()
 	a = nil
 	a.GetStaticSites()
+}
+
+func TestAppSpec_GetVpc(tt *testing.T) {
+	a := &AppSpec{}
+	a.GetVpc()
+	a = nil
+	a.GetVpc()
 }
 
 func TestAppSpec_GetWorkers(tt *testing.T) {
@@ -1994,6 +2099,20 @@ func TestAppVariableDefinition_GetValue(tt *testing.T) {
 	a.GetValue()
 }
 
+func TestAppVpcSpec_GetID(tt *testing.T) {
+	a := &AppVpcSpec{}
+	a.GetID()
+	a = nil
+	a.GetID()
+}
+
+func TestAppVpcSpec_GetPeeredVpcs(tt *testing.T) {
+	a := &AppVpcSpec{}
+	a.GetPeeredVpcs()
+	a = nil
+	a.GetPeeredVpcs()
+}
+
 func TestAppWorkerSpec_GetAlerts(tt *testing.T) {
 	a := &AppWorkerSpec{}
 	a.GetAlerts()
@@ -2085,6 +2204,13 @@ func TestAppWorkerSpec_GetInstanceSizeSlug(tt *testing.T) {
 	a.GetInstanceSizeSlug()
 }
 
+func TestAppWorkerSpec_GetLivenessHealthCheck(tt *testing.T) {
+	a := &AppWorkerSpec{}
+	a.GetLivenessHealthCheck()
+	a = nil
+	a.GetLivenessHealthCheck()
+}
+
 func TestAppWorkerSpec_GetLogDestinations(tt *testing.T) {
 	a := &AppWorkerSpec{}
 	a.GetLogDestinations()
@@ -2125,6 +2251,20 @@ func TestAppWorkerSpecTermination_GetGracePeriodSeconds(tt *testing.T) {
 	a.GetGracePeriodSeconds()
 	a = nil
 	a.GetGracePeriodSeconds()
+}
+
+func TestAutoscalerActionScaleChange_GetFrom(tt *testing.T) {
+	a := &AutoscalerActionScaleChange{}
+	a.GetFrom()
+	a = nil
+	a.GetFrom()
+}
+
+func TestAutoscalerActionScaleChange_GetTo(tt *testing.T) {
+	a := &AutoscalerActionScaleChange{}
+	a.GetTo()
+	a = nil
+	a.GetTo()
 }
 
 func TestBitbucketSourceSpec_GetBranch(tt *testing.T) {
@@ -2377,6 +2517,16 @@ func TestDeploymentCauseDetailsAutoscalerAction_GetAutoscaled(tt *testing.T) {
 	d.GetAutoscaled()
 	d = nil
 	d.GetAutoscaled()
+}
+
+func TestDeploymentCauseDetailsAutoscalerAction_GetScaledComponents(tt *testing.T) {
+	zeroValue := map[string]AutoscalerActionScaleChange{}
+	d := &DeploymentCauseDetailsAutoscalerAction{ScaledComponents: zeroValue}
+	d.GetScaledComponents()
+	d = &DeploymentCauseDetailsAutoscalerAction{}
+	d.GetScaledComponents()
+	d = nil
+	d.GetScaledComponents()
 }
 
 func TestDeploymentCauseDetailsDigitalOceanUser_GetEmail(tt *testing.T) {
@@ -3009,6 +3159,13 @@ func TestGetAppDatabaseConnectionDetailsResponse_GetConnectionDetails(tt *testin
 	g.GetConnectionDetails()
 }
 
+func TestGetAppInstancesResponse_GetInstances(tt *testing.T) {
+	g := &GetAppInstancesResponse{}
+	g.GetInstances()
+	g = nil
+	g.GetInstances()
+}
+
 func TestGetDatabaseConnectionDetailsResponse_GetComponentName(tt *testing.T) {
 	g := &GetDatabaseConnectionDetailsResponse{}
 	g.GetComponentName()
@@ -3189,6 +3346,55 @@ func TestGitSourceSpec_GetRepoCloneURL(tt *testing.T) {
 	g.GetRepoCloneURL()
 	g = nil
 	g.GetRepoCloneURL()
+}
+
+func TestHealthCheckSpec_GetFailureThreshold(tt *testing.T) {
+	h := &HealthCheckSpec{}
+	h.GetFailureThreshold()
+	h = nil
+	h.GetFailureThreshold()
+}
+
+func TestHealthCheckSpec_GetHTTPPath(tt *testing.T) {
+	h := &HealthCheckSpec{}
+	h.GetHTTPPath()
+	h = nil
+	h.GetHTTPPath()
+}
+
+func TestHealthCheckSpec_GetInitialDelaySeconds(tt *testing.T) {
+	h := &HealthCheckSpec{}
+	h.GetInitialDelaySeconds()
+	h = nil
+	h.GetInitialDelaySeconds()
+}
+
+func TestHealthCheckSpec_GetPeriodSeconds(tt *testing.T) {
+	h := &HealthCheckSpec{}
+	h.GetPeriodSeconds()
+	h = nil
+	h.GetPeriodSeconds()
+}
+
+func TestHealthCheckSpec_GetPort(tt *testing.T) {
+	h := &HealthCheckSpec{}
+	h.GetPort()
+	h = nil
+	h.GetPort()
+}
+
+func TestHealthCheckSpec_GetSuccessThreshold(tt *testing.T) {
+	h := &HealthCheckSpec{}
+	h.GetSuccessThreshold()
+	h = nil
+	h.GetSuccessThreshold()
+}
+
+func TestHealthCheckSpec_GetTimeoutSeconds(tt *testing.T) {
+	h := &HealthCheckSpec{}
+	h.GetTimeoutSeconds()
+	h = nil
+	h.GetTimeoutSeconds()
 }
 
 func TestImageSourceSpec_GetDeployOnPush(tt *testing.T) {

--- a/apps_test.go
+++ b/apps_test.go
@@ -1227,7 +1227,8 @@ func TestApps_GetAppInstances(t *testing.T) {
 		json.NewEncoder(w).Encode(&GetAppInstancesResponse{Instances: instances})
 	})
 
-	appInstances, _, err := client.Apps.GetAppInstances(ctx, testApp.ID)
+	opts := &GetAppInstancesOptions{}
+	appInstances, _, err := client.Apps.GetAppInstances(ctx, testApp.ID, opts)
 	require.NoError(t, err)
 	require.Len(t, appInstances, 3)
 

--- a/apps_test.go
+++ b/apps_test.go
@@ -1227,7 +1227,7 @@ func TestApps_GetAppInstances(t *testing.T) {
 		json.NewEncoder(w).Encode(&GetAppInstancesResponse{Instances: instances})
 	})
 
-	opts := &GetAppInstancesOptions{}
+	opts := &GetAppInstancesOpts{}
 	appInstances, _, err := client.Apps.GetAppInstances(ctx, testApp.ID, opts)
 	require.NoError(t, err)
 	require.Len(t, appInstances, 3)

--- a/apps_test.go
+++ b/apps_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -1194,4 +1195,51 @@ func TestGetAppSpecComponent(t *testing.T) {
 		require.EqualError(t, err, "component 404 not found")
 		require.Nil(t, db)
 	})
+}
+
+func TestApps_GetAppInstances(t *testing.T) {
+	setup()
+	defer teardown()
+
+	ctx := context.Background()
+
+	mux.HandleFunc(fmt.Sprintf("/v2/apps/%s/instances", testApp.ID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+
+		instances := []*AppInstance{
+			{
+				ComponentName: "service-name",
+				InstanceName:  "service-name-64fcd65687-mmmfr",
+				ComponentType: APPINSTANCECOMPONENTTYPE_Service,
+			},
+			{
+				ComponentName: "worker-name",
+				InstanceName:  "worker-name-767c6b49c4-dkgpt",
+				ComponentType: APPINSTANCECOMPONENTTYPE_Worker,
+			},
+			{
+				ComponentName: "job-name",
+				InstanceName:  "job-name-321d5c49b4-bcgqr",
+				ComponentType: APPINSTANCECOMPONENTTYPE_Job,
+			},
+		}
+
+		json.NewEncoder(w).Encode(&GetAppInstancesResponse{Instances: instances})
+	})
+
+	appInstances, _, err := client.Apps.GetAppInstances(ctx, testApp.ID)
+	require.NoError(t, err)
+	require.Len(t, appInstances, 3)
+
+	assert.Equal(t, "service-name", appInstances[0].ComponentName)
+	assert.True(t, strings.HasPrefix(appInstances[0].InstanceName, "service-name-"))
+	assert.Equal(t, APPINSTANCECOMPONENTTYPE_Service, appInstances[0].ComponentType)
+
+	assert.Equal(t, "worker-name", appInstances[1].ComponentName)
+	assert.True(t, strings.HasPrefix(appInstances[1].InstanceName, "worker-name-"))
+	assert.Equal(t, APPINSTANCECOMPONENTTYPE_Worker, appInstances[1].ComponentType)
+
+	assert.Equal(t, "job-name", appInstances[2].ComponentName)
+	assert.True(t, strings.HasPrefix(appInstances[2].InstanceName, "job-name-"))
+	assert.Equal(t, APPINSTANCECOMPONENTTYPE_Job, appInstances[2].ComponentType)
 }


### PR DESCRIPTION
This PR adds support for getting an app's currently running ephemeral compute instances from `/v2/apps/{app_id}/instances`. An optional parameter `GetAppInstancesOpts` has been added to make it future proof. 