### PR TITLE
GenAI Knowledgebase endpoints 

### DIFF
--- a/genai.go
+++ b/genai.go
@@ -37,7 +37,7 @@ type GenAIService interface {
 	ListKnowledgeBases(ctx context.Context, opt *ListOptions) ([]KnowledgeBase, *Response, error)
 	CreateKnowledgeBase(ctx context.Context, KnowledgeBaseCreate *KnowledgeBaseCreateRequest) (*KnowledgeBase, *Response, error)
 	ListKnowledgebaseDataSources(ctx context.Context, knowledgeBaseID string, opt *ListOptions) ([]KnowledgeBaseDataSource, *Response, error)
-	AddKnowledgebaseDataSource(ctx context.Context, knowledgeBaseID string, addDataSource *AddDataSourceRequest) (*KnowledgeBaseDataSource, *Response, error)
+	AddKnowledgebaseDataSource(ctx context.Context, knowledgeBaseID string, addDataSource *AddKnowledgebaseDataSourceRequest) (*KnowledgeBaseDataSource, *Response, error)
 	DeleteKnowledgebaseDataSource(ctx context.Context, knowledgeBaseID string, DataSourceID string) (string, string, *Response, error)
 	GetKnowledgeBase(ctx context.Context, knowledgeBaseID string) (*KnowledgeBase, string, *Response, error)
 	UpdateKnowledgeBase(ctx context.Context, knowledgeBaseID string, update *UpdateKnowledgeBaseRequest) (*KnowledgeBase, *Response, error)
@@ -419,7 +419,7 @@ type DeletedKnowledgeBaseResponse struct {
 	KnowledgeBaseUuid string `json:"knowledge_base_uuid"`
 }
 
-type AddDataSourceRequest struct {
+type AddKnowledgebaseDataSourceRequest struct {
 	KnowledgeBaseUuid    string                `json:"knowledge_base_uuid"`
 	SpacesDataSource     *SpacesDataSource     `json:"spaces_data_source"`
 	WebCrawlerDataSource *WebCrawlerDataSource `json:"web_crawler_data_source"`
@@ -763,7 +763,7 @@ func (s *GenAIServiceOp) ListKnowledgebaseDataSources(ctx context.Context, knowl
 }
 
 // Add Data Source to a Knowledge Base
-func (s *GenAIServiceOp) AddKnowledgebaseDataSource(ctx context.Context, knowledgeBaseID string, addDataSource *AddDataSourceRequest) (*KnowledgeBaseDataSource, *Response, error) {
+func (s *GenAIServiceOp) AddKnowledgebaseDataSource(ctx context.Context, knowledgeBaseID string, addDataSource *AddKnowledgebaseDataSourceRequest) (*KnowledgeBaseDataSource, *Response, error) {
 	path := fmt.Sprintf(KnowledgeBaseDataSourcesPath, knowledgeBaseID)
 	req, err := s.client.NewRequest(ctx, http.MethodPost, path, addDataSource)
 	if err != nil {

--- a/genai.go
+++ b/genai.go
@@ -14,7 +14,7 @@ const (
 	GetKnowledgeBaseByIDPath     = KnowledgeBasePath + "/%s"
 	UpdateKnowledgeBaseByIDPath  = KnowledgeBasePath + "/%s"
 	DeleteKnowledgeBaseByIDPath  = KnowledgeBasePath + "/%s"
-	AgentKnowledgBasePath        = "/v2/gen-ai/agents" + "/%s/knowledge_bases/%s"
+	AgentKnowledgeBasePath       = "/v2/gen-ai/agents" + "/%s/knowledge_bases/%s"
 	DeleteDataSourcePath         = KnowledgeBasePath + "/%s/data_sources/%s"
 )
 
@@ -349,7 +349,7 @@ type KnowledgeBaseCreateRequest struct {
 	ProjectID          string                    `json:"project_id"`
 	Region             string                    `json:"region"`
 	Tags               []string                  `json:"tags"`
-	VPCUUIUD           string                    `json:"vpc_uuid"`
+	VPCUUID            string                    `json:"vpc_uuid"`
 }
 
 // KnowledgeBaseDataSource represents a Gen AI Knowledge Base Data Source
@@ -368,23 +368,23 @@ type KnowledgeBaseDataSource struct {
 
 // WebCrawlerDataSource represents the web crawler data source information
 type WebCrawlerDataSource struct {
-	BaseUrl        string `json:"base_url"`
-	CrawlingOption string `json:"crawling_option"`
-	EmbedMedia     bool   `json:"embed_media"`
+	BaseUrl        string `json:"base_url,omitempty"`
+	CrawlingOption string `json:"crawling_option,omitempty"`
+	EmbedMedia     bool   `json:"embed_media,omitempty"`
 }
 
 // SpacesDataSource represents the spaces data source information
 type SpacesDataSource struct {
-	BucketName string `json:"bucket_name"`
-	ItemPath   string `json:"item_path"`
-	Region     string `json:"region"`
+	BucketName string `json:"bucket_name,omitempty"`
+	ItemPath   string `json:"item_path,omitempty"`
+	Region     string `json:"region,omitempty"`
 }
 
 // FileUploadDataSource represents the file upload data source information
 type FileUploadDataSource struct {
-	OriginalFileName string `json:"original_file_name"`
-	Size             string `json:"size_in_bytes"`
-	StoredObjectKey  string `json:"stored_object_key"`
+	OriginalFileName string `json:"original_file_name,omitempty"`
+	Size             string `json:"size_in_bytes,omitempty"`
+	StoredObjectKey  string `json:"stored_object_key,omitempty"`
 }
 
 type KnowledgeBaseDataSourcesRoot struct {
@@ -854,7 +854,7 @@ func (s *GenAIServiceOp) DeleteKnowledgeBase(ctx context.Context, knowledgeBaseI
 // Attach a knowledge base to an agent
 func (s *GenAIServiceOp) AttachKnowledgeBase(ctx context.Context, AgentID string, knowledgeBaseID string) (*Agent, *Response, error) {
 
-	path := fmt.Sprintf(AgentKnowledgBasePath, AgentID, knowledgeBaseID)
+	path := fmt.Sprintf(AgentKnowledgeBasePath, AgentID, knowledgeBaseID)
 	req, err := s.client.NewRequest(ctx, http.MethodPost, path, nil)
 	if err != nil {
 		return nil, nil, err
@@ -872,7 +872,7 @@ func (s *GenAIServiceOp) AttachKnowledgeBase(ctx context.Context, AgentID string
 // Detach a knowledge base from an agent
 func (s *GenAIServiceOp) DetachKnowledgeBase(ctx context.Context, AgentID string, knowledgeBaseID string) (*Agent, *Response, error) {
 
-	path := fmt.Sprintf(AgentKnowledgBasePath, AgentID, knowledgeBaseID)
+	path := fmt.Sprintf(AgentKnowledgeBasePath, AgentID, knowledgeBaseID)
 	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return nil, nil, err

--- a/genai.go
+++ b/genai.go
@@ -39,7 +39,7 @@ type GenAIService interface {
 	ListDataSources(ctx context.Context, knowledgeBaseID string, opt *ListOptions) ([]KnowledgeBaseDataSource, *Response, error)
 	AddDataSource(ctx context.Context, knowledgeBaseID string, addDataSource *AddDataSourceRequest) (*KnowledgeBaseDataSource, *Response, error)
 	DeleteDataSource(ctx context.Context, knowledgeBaseID string, DataSourceID string) (string, string, *Response, error)
-	GetKnowledgeBase(ctx context.Context, knowledgeBaseID string) (*KnowledgeBase, *Response, error)
+	GetKnowledgeBase(ctx context.Context, knowledgeBaseID string) (*KnowledgeBase, string, *Response, error)
 	UpdateKnowledgeBase(ctx context.Context, knowledgeBaseID string, update *UpdateKnowledgeBaseRequest) (*KnowledgeBase, *Response, error)
 	DeleteKnowledgeBase(ctx context.Context, knowledgeBaseID string) (string, *Response, error)
 	AttachKnowledgeBase(ctx context.Context, AgentID string, knowledgeBaseID string) (*Agent, *Response, error)
@@ -344,25 +344,22 @@ type AgentAPIKeyUpdateRequest struct {
 type KnowledgeBaseCreateRequest struct {
 	DatabaseID         string                    `json:"database_id"`
 	DataSources        []KnowledgeBaseDataSource `json:"datasources"`
-	EmbeddingModelUUID string                    `json:"embedding_model_uuid"`
+	EmbeddingModelUuid string                    `json:"embedding_model_uuid"`
 	Name               string                    `json:"name"`
 	ProjectID          string                    `json:"project_id"`
 	Region             string                    `json:"region"`
 	Tags               []string                  `json:"tags"`
-	VPCUUID            string                    `json:"vpc_uuid"`
+	VPCUuid            string                    `json:"vpc_uuid"`
 }
 
 // KnowledgeBaseDataSource represents a Gen AI Knowledge Base Data Source
 type KnowledgeBaseDataSource struct {
-	BucketName           string                `json:"bucket_name,omitempty"`
 	CreatedAt            *Timestamp            `json:"created_at,omitempty"`
 	FileUploadDataSource *FileUploadDataSource `json:"file_upload_data_source,omitempty"`
-	ItemPath             string                `json:"item_path,omitempty"`
 	LastIndexingJob      *LastIndexingJob      `json:"last_indexing_job,omitempty"`
-	Region               string                `json:"region,omitempty"`
 	SpacesDataSource     *SpacesDataSource     `json:"spaces_data_source,omitempty"`
 	UpdatedAt            *Timestamp            `json:"updated_at,omitempty"`
-	UUID                 string                `json:"uuid,omitempty"`
+	Uuid                 string                `json:"uuid,omitempty"`
 	WebCrawlerDataSource *WebCrawlerDataSource `json:"web_crawler_data_source,omitempty"`
 }
 
@@ -409,32 +406,32 @@ type knowledgebaseRoot struct {
 }
 
 type DeleteDataSourceRoot struct {
-	DataSourceUUID    string `json:"data_source_uuid"`
-	KnowledgeBaseUUID string `json:"knowledge_base_uuid"`
+	DataSourceUuid    string `json:"data_source_uuid"`
+	KnowledgeBaseUuid string `json:"knowledge_base_uuid"`
 }
 
 type DeleteKnowledgeBaseRoot struct {
-	KnowledgeBaseUUID string `json:"uuid"`
+	KnowledgeBaseUuid string `json:"uuid"`
 }
 
 type DeletedKnowledgeBaseResponse struct {
-	DataSourceUUID    string `json:"data_source_uuid"`
-	KnowledgeBaseUUID string `json:"knowledge_base_uuid"`
+	DataSourceUuid    string `json:"data_source_uuid"`
+	KnowledgeBaseUuid string `json:"knowledge_base_uuid"`
 }
 
 type AddDataSourceRequest struct {
-	KnowledgeBaseUUID    string                `json:"knowledge_base_uuid"`
+	KnowledgeBaseUuid    string                `json:"knowledge_base_uuid"`
 	SpacesDataSource     *SpacesDataSource     `json:"spaces_data_source"`
 	WebCrawlerDataSource *WebCrawlerDataSource `json:"web_crawler_data_source"`
 }
 
 type UpdateKnowledgeBaseRequest struct {
 	DatabaseID         string   `json:"database_id"`
-	EmbeddingModelUUID string   `json:"embedding_model_uuid"`
+	EmbeddingModelUuid string   `json:"embedding_model_uuid"`
 	Name               string   `json:"name"`
 	ProjectID          string   `json:"project_id"`
 	Tags               []string `json:"tags"`
-	UUID               string   `json:"uuid"`
+	Uuid               string   `json:"uuid"`
 }
 
 type genAIAgentKBRoot struct {
@@ -796,24 +793,24 @@ func (s *GenAIServiceOp) DeleteDataSource(ctx context.Context, knowledgeBaseID s
 		return "", "", resp, err
 
 	}
-	return root.KnowledgeBaseUUID, root.DataSourceUUID, resp, nil
+	return root.KnowledgeBaseUuid, root.DataSourceUuid, resp, nil
 }
 
 // Get a KnowledgeBase
-func (s *GenAIServiceOp) GetKnowledgeBase(ctx context.Context, knowledgeBaseID string) (*KnowledgeBase, *Response, error) {
+func (s *GenAIServiceOp) GetKnowledgeBase(ctx context.Context, knowledgeBaseID string) (*KnowledgeBase, string, *Response, error) {
 	path := fmt.Sprintf(GetKnowledgeBaseByIDPath, knowledgeBaseID)
 	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 
 	if err != nil {
-		return nil, nil, err
+		return nil, "", nil, err
 	}
 	root := new(knowledgebaseRoot)
 	resp, err := s.client.Do(ctx, req, root)
 
 	if err != nil {
-		return nil, resp, err
+		return nil, "", resp, err
 	}
-	return root.KnowledgeBase, resp, nil
+	return root.KnowledgeBase, root.DatabaseStatus, resp, nil
 }
 
 // Update a knowledge base
@@ -848,7 +845,7 @@ func (s *GenAIServiceOp) DeleteKnowledgeBase(ctx context.Context, knowledgeBaseI
 	if err != nil {
 		return "", resp, err
 	}
-	return root.KnowledgeBaseUUID, resp, nil
+	return root.KnowledgeBaseUuid, resp, nil
 }
 
 // Attach a knowledge base to an agent

--- a/genai.go
+++ b/genai.go
@@ -42,8 +42,8 @@ type GenAIService interface {
 	GetKnowledgeBase(ctx context.Context, knowledgeBaseID string) (*KnowledgeBase, *Response, error)
 	UpdateKnowledgeBase(ctx context.Context, knowledgeBaseID string, update *UpdateKnowledgeBaseRequest) (*KnowledgeBase, *Response, error)
 	DeleteKnowledgeBase(ctx context.Context, knowledgeBaseID string) (string, *Response, error)
-	AttachKnowledgBase(ctx context.Context, AgentID string, knowledgeBaseID string) (*Agent, *Response, error)
-	DetachKnowledgBase(ctx context.Context, AgentID string, knowledgeBaseID string) (*Agent, *Response, error)
+	AttachKnowledgeBase(ctx context.Context, AgentID string, knowledgeBaseID string) (*Agent, *Response, error)
+	DetachKnowledgeBase(ctx context.Context, AgentID string, knowledgeBaseID string) (*Agent, *Response, error)
 }
 
 var _ GenAIService = &GenAIServiceOp{}
@@ -852,7 +852,7 @@ func (s *GenAIServiceOp) DeleteKnowledgeBase(ctx context.Context, knowledgeBaseI
 }
 
 // Attach a knowledge base to an agent
-func (s *GenAIServiceOp) AttachKnowledgBase(ctx context.Context, AgentID string, knowledgeBaseID string) (*Agent, *Response, error) {
+func (s *GenAIServiceOp) AttachKnowledgeBase(ctx context.Context, AgentID string, knowledgeBaseID string) (*Agent, *Response, error) {
 
 	path := fmt.Sprintf(AgentKnowledgBasePath, AgentID, knowledgeBaseID)
 	req, err := s.client.NewRequest(ctx, http.MethodPost, path, nil)
@@ -870,7 +870,7 @@ func (s *GenAIServiceOp) AttachKnowledgBase(ctx context.Context, AgentID string,
 }
 
 // Detach a knowledge base from an agent
-func (s *GenAIServiceOp) DetachKnowledgBase(ctx context.Context, AgentID string, knowledgeBaseID string) (*Agent, *Response, error) {
+func (s *GenAIServiceOp) DetachKnowledgeBase(ctx context.Context, AgentID string, knowledgeBaseID string) (*Agent, *Response, error) {
 
 	path := fmt.Sprintf(AgentKnowledgBasePath, AgentID, knowledgeBaseID)
 	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)

--- a/genai.go
+++ b/genai.go
@@ -36,9 +36,9 @@ type GenAIService interface {
 	ListModels(context.Context, *ListOptions) ([]*Model, *Response, error)
 	ListKnowledgeBases(ctx context.Context, opt *ListOptions) ([]KnowledgeBase, *Response, error)
 	CreateKnowledgeBase(ctx context.Context, KnowledgeBaseCreate *KnowledgeBaseCreateRequest) (*KnowledgeBase, *Response, error)
-	ListDataSources(ctx context.Context, knowledgeBaseID string, opt *ListOptions) ([]KnowledgeBaseDataSource, *Response, error)
-	AddDataSource(ctx context.Context, knowledgeBaseID string, addDataSource *AddDataSourceRequest) (*KnowledgeBaseDataSource, *Response, error)
-	DeleteDataSource(ctx context.Context, knowledgeBaseID string, DataSourceID string) (string, string, *Response, error)
+	ListKnowledgebaseDataSources(ctx context.Context, knowledgeBaseID string, opt *ListOptions) ([]KnowledgeBaseDataSource, *Response, error)
+	AddKnowledgebaseDataSource(ctx context.Context, knowledgeBaseID string, addDataSource *AddDataSourceRequest) (*KnowledgeBaseDataSource, *Response, error)
+	DeleteKnowledgebaseDataSource(ctx context.Context, knowledgeBaseID string, DataSourceID string) (string, string, *Response, error)
 	GetKnowledgeBase(ctx context.Context, knowledgeBaseID string) (*KnowledgeBase, string, *Response, error)
 	UpdateKnowledgeBase(ctx context.Context, knowledgeBaseID string, update *UpdateKnowledgeBaseRequest) (*KnowledgeBase, *Response, error)
 	DeleteKnowledgeBase(ctx context.Context, knowledgeBaseID string) (string, *Response, error)
@@ -737,7 +737,7 @@ func (s *GenAIServiceOp) CreateKnowledgeBase(ctx context.Context, KnowledgeBaseC
 }
 
 // List Data Sources for a Knowledge Base
-func (s *GenAIServiceOp) ListDataSources(ctx context.Context, knowledgeBaseID string, opt *ListOptions) ([]KnowledgeBaseDataSource, *Response, error) {
+func (s *GenAIServiceOp) ListKnowledgebaseDataSources(ctx context.Context, knowledgeBaseID string, opt *ListOptions) ([]KnowledgeBaseDataSource, *Response, error) {
 
 	path := fmt.Sprintf(KnowledgeBaseDataSourcesPath, knowledgeBaseID)
 	path, err := addOptions(path, opt)
@@ -763,7 +763,7 @@ func (s *GenAIServiceOp) ListDataSources(ctx context.Context, knowledgeBaseID st
 }
 
 // Add Data Source to a Knowledge Base
-func (s *GenAIServiceOp) AddDataSource(ctx context.Context, knowledgeBaseID string, addDataSource *AddDataSourceRequest) (*KnowledgeBaseDataSource, *Response, error) {
+func (s *GenAIServiceOp) AddKnowledgebaseDataSource(ctx context.Context, knowledgeBaseID string, addDataSource *AddDataSourceRequest) (*KnowledgeBaseDataSource, *Response, error) {
 	path := fmt.Sprintf(KnowledgeBaseDataSourcesPath, knowledgeBaseID)
 	req, err := s.client.NewRequest(ctx, http.MethodPost, path, addDataSource)
 	if err != nil {
@@ -778,7 +778,7 @@ func (s *GenAIServiceOp) AddDataSource(ctx context.Context, knowledgeBaseID stri
 }
 
 // Delete data source from a knowledge base
-func (s *GenAIServiceOp) DeleteDataSource(ctx context.Context, knowledgeBaseID string, DataSourceID string) (string, string, *Response, error) {
+func (s *GenAIServiceOp) DeleteKnowledgebaseDataSource(ctx context.Context, knowledgeBaseID string, DataSourceID string) (string, string, *Response, error) {
 
 	path := fmt.Sprintf(DeleteDataSourcePath, knowledgeBaseID, DataSourceID)
 	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)

--- a/genai.go
+++ b/genai.go
@@ -44,7 +44,7 @@ type GenAIService interface {
 	UpdateKnowledgeBase(ctx context.Context, knowledgeBaseID string, update *UpdateKnowledgeBaseRequest) (*KnowledgeBase, *Response, error)
 	DeleteKnowledgeBase(ctx context.Context, knowledgeBaseID string) (string, *Response, error)
 	AttachKnowledgeBaseToAgent(ctx context.Context, agentID string, knowledgeBaseID string) (*Agent, *Response, error)
-	DetachKnowledgeBase(ctx context.Context, agentID string, knowledgeBaseID string) (*Agent, *Response, error)
+	DetachKnowledgeBaseToAgent(ctx context.Context, agentID string, knowledgeBaseID string) (*Agent, *Response, error)
 }
 
 var _ GenAIService = &GenAIServiceOp{}
@@ -892,7 +892,7 @@ func (s *GenAIServiceOp) AttachKnowledgeBaseToAgent(ctx context.Context, agentID
 }
 
 // Detach a knowledge base from an agent
-func (s *GenAIServiceOp) DetachKnowledgeBase(ctx context.Context, agentID string, knowledgeBaseID string) (*Agent, *Response, error) {
+func (s *GenAIServiceOp) DetachKnowledgeBaseToAgent(ctx context.Context, agentID string, knowledgeBaseID string) (*Agent, *Response, error) {
 
 	path := fmt.Sprintf(AgentKnowledgeBasePath, agentID, knowledgeBaseID)
 	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)

--- a/genai_test.go
+++ b/genai_test.go
@@ -178,7 +178,7 @@ var agentResponse = `
 				"MODEL_USECASE_SERVERLESS"
 			]
 		},
-		"deployment": {
+		"deploymen": {
 			"uuid": "00000000-0000-0000-0000-000000000000",
 			"status": "STATUS_WAITING_FOR_DEPLOYMENT",
 			"visibility": "VISIBILITY_PRIVATE",
@@ -792,7 +792,7 @@ func TestListKnowledgeBases(t *testing.T) {
 	assert.Equal(t, "Test Knowledge Base", knowledgeBases[0].Name)
 }
 
-func TestCreateKnowledgeBase(t *testing.T) { //works
+func TestCreateKnowledgeBase(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -818,7 +818,7 @@ func TestCreateKnowledgeBase(t *testing.T) { //works
 	assert.Equal(t, res.ProjectId, req.ProjectID)
 }
 
-func TestListDataSources(t *testing.T) { //works
+func TestListDataSources(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -846,7 +846,7 @@ func TestListDataSources(t *testing.T) { //works
 	assert.Equal(t, "test-bucket", dataSources[0].BucketName)
 }
 
-func TestAddDataSource(t *testing.T) { //works
+func TestAddDataSource(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -873,7 +873,7 @@ func TestAddDataSource(t *testing.T) { //works
 	assert.Equal(t, "/docs/test.pdf", res.ItemPath)
 }
 
-func TestDeleteDataSource(t *testing.T) { //works
+func TestDeleteDataSource(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -892,7 +892,7 @@ func TestDeleteDataSource(t *testing.T) { //works
 	assert.Equal(t, 200, resp.Response.StatusCode)
 }
 
-func TestGetKnowledgeBase(t *testing.T) { //works
+func TestGetKnowledgeBase(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -910,7 +910,7 @@ func TestGetKnowledgeBase(t *testing.T) { //works
 	assert.Equal(t, 200, resp.Response.StatusCode)
 }
 
-func TestUpdateKnowledgeBase(t *testing.T) { //works
+func TestUpdateKnowledgeBase(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -933,7 +933,7 @@ func TestUpdateKnowledgeBase(t *testing.T) { //works
 	assert.Equal(t, 200, resp.Response.StatusCode)
 }
 
-func TestDeleteKnowledgeBase(t *testing.T) { //works
+func TestDeleteKnowledgeBase(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -951,7 +951,7 @@ func TestDeleteKnowledgeBase(t *testing.T) { //works
 	assert.Equal(t, 200, resp.Response.StatusCode)
 }
 
-func TestAttachKnowledgeBase(t *testing.T) { //fail
+func TestAttachKnowledgeBase(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -973,13 +973,11 @@ func TestDetachKnowledgeBase(t *testing.T) {
 	setup()
 	defer teardown()
 
-	// Mock the expected API endpoint
 	mux.HandleFunc("/v2/gen-ai/agents/00000000-0000-0000-0000-000000000000/knowledge_bases/11111111-1111-1111-1111-111111111111", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
-		fmt.Fprint(w, agentResponse) // Mock response
+		fmt.Fprint(w, agentResponse)
 	})
 
-	// Call the method
 	res, resp, err := client.GenAI.DetachKnowledgBase(ctx, "00000000-0000-0000-0000-000000000000", "11111111-1111-1111-1111-111111111111")
 	fmt.Print(res)
 	fmt.Print(resp)
@@ -988,11 +986,10 @@ func TestDetachKnowledgeBase(t *testing.T) {
 		t.Fatalf("GenAI.DetachKnowledgBase returned error: %v", err)
 	}
 
-	// Validate the response
 	if res == nil {
 		t.Fatalf("GenAI.DetachKnowledgBase returned nil response or result")
 	}
 
-	assert.Equal(t, "testing-godo", res.Name)      // Validate the agent name
-	assert.Equal(t, 200, resp.Response.StatusCode) // Validate the HTTP status code
+	assert.Equal(t, "testing-godo", res.Name)
+	assert.Equal(t, 200, resp.Response.StatusCode)
 }

--- a/genai_test.go
+++ b/genai_test.go
@@ -410,6 +410,25 @@ var knowledgeBaseResponse = `
 }
 `
 
+var knowledgeBaseGetResponse = `
+{
+	"database_status" : "ONLINE",
+	"knowledge_base": {
+		"uuid": "11111111-1111-1111-1111-111111111111",
+		"name": "testing-kb",
+		"created_at": "2025-05-14T13:18:05Z",
+		"updated_at": "2025-05-14T13:18:05Z",
+		"region": "tor1",
+		"project_id": "11111111-1111-1111-1111-111111111111",
+		"embedding_model_uuid": "11111111-1111-1111-1111-111111111111",
+		"database_id": "11111111-1111-1111-1111-111111111111",
+		"is_public": false,
+		"tags": ["string"],
+		"user_id": "18919793"
+	}
+}
+`
+
 var knowledgeBaseUpdateResponse = `
 {
 	"knowledge_base": {
@@ -433,9 +452,6 @@ var listDataSourcesResponse = `
 	"knowledge_base_data_sources": [
 		{
 			"uuid": "22222222-2222-2222-2222-222222222222",
-			"bucket_name": "test-bucket",
-			"item_path": "/docs/test.pdf",
-			"region": "tor1",
 			"created_at": "2025-05-14T13:18:05Z",
 			"updated_at": "2025-05-14T13:18:05Z",
 			"spaces_data_source": {
@@ -453,7 +469,7 @@ var listDataSourcesResponse = `
 			"last": "https://api.digitalocean.com/v2/gen-ai/knowledge_bases/11111111-1111-1111-1111-111111111111/data_sources?page=3&per_page=1"
 		}
 	},
-	"meta": {
+	"meta": { 
 		"total": 3,
 		"page": 1,
 		"pages": 3
@@ -465,9 +481,6 @@ var addDataSourceResponse = `
 {
 	"knowledge_base_data_source": {
 		"uuid": "22222222-2222-2222-2222-222222222222",
-		"bucket_name": "test-bucket",
-		"item_path": "/docs/test.pdf",
-		"region": "tor1",
 		"created_at": "2025-05-14T13:18:05Z",
 		"updated_at": "2025-05-14T13:18:05Z",
 		"spaces_data_source": {
@@ -567,7 +580,7 @@ func TestListAPIKeys(t *testing.T) {
 
 	keys, resp, err := client.GenAI.ListAgentAPIKeys(ctx, "00000000-0000-0000-0000-000000000000", nil)
 	assert.NoError(t, err)
-	assert.Equal(t, 200, resp.Response.StatusCode)
+	assert.Equal(t, 200, resp.StatusCode)
 	assert.Equal(t, 2, len(keys))
 	assert.Equal(t, "Key One", keys[0].Name)
 	assert.Equal(t, "00000000-0000-0000-0000-000000000000", keys[0].Uuid)
@@ -805,7 +818,7 @@ func TestCreateKnowledgeBase(t *testing.T) {
 		Name:               "testing-kb",
 		ProjectID:          "11111111-1111-1111-1111-111111111111",
 		Region:             "tor1",
-		EmbeddingModelUUID: "11111111-1111-1111-1111-111111111111",
+		EmbeddingModelUuid: "11111111-1111-1111-1111-111111111111",
 		Tags:               []string{"string"},
 	}
 
@@ -843,7 +856,7 @@ func TestListDataSources(t *testing.T) {
 	}
 
 	assert.Equal(t, 3, resp.Meta.Total)
-	assert.Equal(t, "test-bucket", dataSources[0].BucketName)
+	assert.Equal(t, "22222222-2222-2222-2222-222222222222", dataSources[0].Uuid)
 }
 
 func TestAddDataSource(t *testing.T) {
@@ -856,7 +869,7 @@ func TestAddDataSource(t *testing.T) {
 	})
 
 	req := &AddDataSourceRequest{
-		KnowledgeBaseUUID: "11111111-1111-1111-1111-111111111111",
+		KnowledgeBaseUuid: "11111111-1111-1111-1111-111111111111",
 		SpacesDataSource: &SpacesDataSource{
 			BucketName: "test-bucket",
 			ItemPath:   "/docs/test.pdf",
@@ -869,8 +882,8 @@ func TestAddDataSource(t *testing.T) {
 		t.Errorf("GenAI.AddDataSource returned error: %v", err)
 	}
 
-	assert.Equal(t, "test-bucket", res.BucketName)
-	assert.Equal(t, "/docs/test.pdf", res.ItemPath)
+	assert.Equal(t, "test-bucket", res.SpacesDataSource.BucketName)
+	assert.Equal(t, "/docs/test.pdf", res.SpacesDataSource.ItemPath)
 }
 
 func TestDeleteDataSource(t *testing.T) {
@@ -898,15 +911,17 @@ func TestGetKnowledgeBase(t *testing.T) {
 
 	mux.HandleFunc("/v2/gen-ai/knowledge_bases/11111111-1111-1111-1111-111111111111", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
-		fmt.Fprint(w, knowledgeBaseResponse)
+		fmt.Fprint(w, knowledgeBaseGetResponse)
 	})
 
-	res, resp, err := client.GenAI.GetKnowledgeBase(ctx, "11111111-1111-1111-1111-111111111111")
+	res, dbStatus, resp, err := client.GenAI.GetKnowledgeBase(ctx, "11111111-1111-1111-1111-111111111111")
 	if err != nil {
 		t.Errorf("GenAI.GetKnowledgeBase returned error: %v", err)
 	}
 
 	assert.Equal(t, "testing-kb", res.Name)
+	assert.Equal(t, "ONLINE", dbStatus)
+	assert.Equal(t, "11111111-1111-1111-1111-111111111111", res.Uuid)
 	assert.Equal(t, 200, resp.Response.StatusCode)
 }
 

--- a/genai_test.go
+++ b/genai_test.go
@@ -1004,7 +1004,7 @@ func TestDetachKnowledgeBase(t *testing.T) {
 		fmt.Fprint(w, agentResponse)
 	})
 
-	res, resp, err := client.GenAI.DetachKnowledgeBase(ctx, "00000000-0000-0000-0000-000000000000", "11111111-1111-1111-1111-111111111111")
+	res, resp, err := client.GenAI.DetachKnowledgeBaseToAgent(ctx, "00000000-0000-0000-0000-000000000000", "11111111-1111-1111-1111-111111111111")
 	fmt.Print(res)
 	fmt.Print(resp)
 

--- a/genai_test.go
+++ b/genai_test.go
@@ -868,7 +868,7 @@ func TestAddDataSource(t *testing.T) {
 		fmt.Fprint(w, addDataSourceResponse)
 	})
 
-	req := &AddDataSourceRequest{
+	req := &AddKnowledgebaseDataSourceRequest{
 		KnowledgeBaseUuid: "11111111-1111-1111-1111-111111111111",
 		SpacesDataSource: &SpacesDataSource{
 			BucketName: "test-bucket",

--- a/genai_test.go
+++ b/genai_test.go
@@ -850,7 +850,7 @@ func TestListDataSources(t *testing.T) {
 		PerPage: 1,
 	}
 
-	dataSources, resp, err := client.GenAI.ListDataSources(ctx, "11111111-1111-1111-1111-111111111111", req)
+	dataSources, resp, err := client.GenAI.ListKnowledgebaseDataSources(ctx, "11111111-1111-1111-1111-111111111111", req)
 	if err != nil {
 		t.Errorf("GenAI.ListDataSources returned error: %v", err)
 	}
@@ -877,7 +877,7 @@ func TestAddDataSource(t *testing.T) {
 		},
 	}
 
-	res, _, err := client.GenAI.AddDataSource(ctx, "11111111-1111-1111-1111-111111111111", req)
+	res, _, err := client.GenAI.AddKnowledgebaseDataSource(ctx, "11111111-1111-1111-1111-111111111111", req)
 	if err != nil {
 		t.Errorf("GenAI.AddDataSource returned error: %v", err)
 	}
@@ -895,7 +895,7 @@ func TestDeleteDataSource(t *testing.T) {
 		fmt.Fprint(w, deleteDataSourceResponse)
 	})
 
-	kbUUID, dsUUID, resp, err := client.GenAI.DeleteDataSource(ctx, "11111111-1111-1111-1111-111111111111", "22222222-2222-2222-2222-222222222222")
+	kbUUID, dsUUID, resp, err := client.GenAI.DeleteKnowledgebaseDataSource(ctx, "11111111-1111-1111-1111-111111111111", "22222222-2222-2222-2222-222222222222")
 	if err != nil {
 		t.Errorf("GenAI.DeleteDataSource returned error: %v", err)
 	}

--- a/genai_test.go
+++ b/genai_test.go
@@ -850,7 +850,7 @@ func TestListDataSources(t *testing.T) {
 		PerPage: 1,
 	}
 
-	dataSources, resp, err := client.GenAI.ListKnowledgebaseDataSources(ctx, "11111111-1111-1111-1111-111111111111", req)
+	dataSources, resp, err := client.GenAI.ListKnowledgeBaseDataSources(ctx, "11111111-1111-1111-1111-111111111111", req)
 	if err != nil {
 		t.Errorf("GenAI.ListDataSources returned error: %v", err)
 	}
@@ -868,7 +868,7 @@ func TestAddDataSource(t *testing.T) {
 		fmt.Fprint(w, addDataSourceResponse)
 	})
 
-	req := &AddKnowledgebaseDataSourceRequest{
+	req := &AddKnowledgeBaseDataSourceRequest{
 		KnowledgeBaseUuid: "11111111-1111-1111-1111-111111111111",
 		SpacesDataSource: &SpacesDataSource{
 			BucketName: "test-bucket",
@@ -877,7 +877,7 @@ func TestAddDataSource(t *testing.T) {
 		},
 	}
 
-	res, _, err := client.GenAI.AddKnowledgebaseDataSource(ctx, "11111111-1111-1111-1111-111111111111", req)
+	res, _, err := client.GenAI.AddKnowledgeBaseDataSource(ctx, "11111111-1111-1111-1111-111111111111", req)
 	if err != nil {
 		t.Errorf("GenAI.AddDataSource returned error: %v", err)
 	}
@@ -895,7 +895,7 @@ func TestDeleteDataSource(t *testing.T) {
 		fmt.Fprint(w, deleteDataSourceResponse)
 	})
 
-	kbUUID, dsUUID, resp, err := client.GenAI.DeleteKnowledgebaseDataSource(ctx, "11111111-1111-1111-1111-111111111111", "22222222-2222-2222-2222-222222222222")
+	kbUUID, dsUUID, resp, err := client.GenAI.DeleteKnowledgeBaseDataSource(ctx, "11111111-1111-1111-1111-111111111111", "22222222-2222-2222-2222-222222222222")
 	if err != nil {
 		t.Errorf("GenAI.DeleteDataSource returned error: %v", err)
 	}

--- a/genai_test.go
+++ b/genai_test.go
@@ -178,7 +178,7 @@ var agentResponse = `
 				"MODEL_USECASE_SERVERLESS"
 			]
 		},
-		"deploymen": {
+		"deployment": {
 			"uuid": "00000000-0000-0000-0000-000000000000",
 			"status": "STATUS_WAITING_FOR_DEPLOYMENT",
 			"visibility": "VISIBILITY_PRIVATE",

--- a/genai_test.go
+++ b/genai_test.go
@@ -347,6 +347,150 @@ var apiKeyInfoResponse = `
 }
 `
 
+var listKnowledgeBaseResponse = `
+{
+	"knowledge_bases": [
+		{
+			"created_at": "2025-05-08T03:37:28Z",
+			"database_id": "11111111-1111-1111-1111-111111111111",
+			"embedding_model_uuid": "11111111-1111-1111-1111-111111111111",
+			"last_indexing_job": {
+				"created_at": "2025-05-08T03:37:28Z",
+				"finished_at": "2025-05-08T03:38:28Z",
+				"knowledge_base_uuid": "11111111-1111-1111-1111-111111111111",
+				"phase": "BATCH_JOB_PHASE_SUCCEEDED",
+				"started_at": "2025-05-08T03:37:28Z",
+				"updated_at": "2025-05-08T03:38:28Z",
+				"total_datasources": 1,
+				"completed_datasources": 1,
+				"tokens": 5000,
+				"uuid": "11111111-1111-1111-1111-111111111111"
+			},
+			"name": "Test Knowledge Base",
+			"project_id": "11111111-1111-1111-1111-111111111111",
+			"region": "tor1",
+			"tags": ["test"],
+			"uuid": "11111111-1111-1111-1111-111111111111",
+			"updated_at": "2025-05-09T16:02:39Z",
+			"is_public": false,
+			"user_id": "14567334"
+		}
+	],
+	"links": {
+		"pages": {
+			"first": "https://api.digitalocean.com/v2/gen-ai/knowledge_bases?page=1&per_page=1",
+			"previous": "https://api.digitalocean.com/v2/gen-ai/knowledge_bases?page=1&per_page=1",
+			"next": "https://api.digitalocean.com/v2/gen-ai/knowledge_bases?page=3&per_page=1",
+			"last": "https://api.digitalocean.com/v2/gen-ai/knowledge_bases?page=10&per_page=1"
+		}
+	},
+	"meta": {
+		"total": 10,
+		"page": 1,
+		"pages": 10
+	}
+}
+`
+
+var knowledgeBaseResponse = `
+{
+	"knowledge_base": {
+		"uuid": "11111111-1111-1111-1111-111111111111",
+		"name": "testing-kb",
+		"created_at": "2025-05-14T13:18:05Z",
+		"updated_at": "2025-05-14T13:18:05Z",
+		"region": "tor1",
+		"project_id": "11111111-1111-1111-1111-111111111111",
+		"embedding_model_uuid": "11111111-1111-1111-1111-111111111111",
+		"database_id": "11111111-1111-1111-1111-111111111111",
+		"is_public": false,
+		"tags": ["string"],
+		"user_id": "18919793"
+	}
+}
+`
+
+var knowledgeBaseUpdateResponse = `
+{
+	"knowledge_base": {
+		"uuid": "11111111-1111-1111-1111-111111111111",
+		"name": "Updated Knowledge Base",
+		"created_at": "2025-05-14T13:18:05Z",
+		"updated_at": "2025-05-14T13:46:48Z",
+		"region": "tor1",
+		"project_id": "11111111-1111-1111-1111-111111111111",
+		"embedding_model_uuid": "11111111-1111-1111-1111-111111111111",
+		"database_id": "11111111-1111-1111-1111-111111111111",
+		"is_public": true,
+		"tags": ["updated", "example"],
+		"user_id": "18919793"
+	}
+}
+`
+
+var listDataSourcesResponse = `
+{
+	"knowledge_base_data_sources": [
+		{
+			"uuid": "22222222-2222-2222-2222-222222222222",
+			"bucket_name": "test-bucket",
+			"item_path": "/docs/test.pdf",
+			"region": "tor1",
+			"created_at": "2025-05-14T13:18:05Z",
+			"updated_at": "2025-05-14T13:18:05Z",
+			"spaces_data_source": {
+				"bucket_name": "test-bucket",
+				"item_path": "/docs/test.pdf",
+				"region": "tor1"
+			}
+		}
+	],
+	"links": {
+		"pages": {
+			"first": "https://api.digitalocean.com/v2/gen-ai/knowledge_bases/11111111-1111-1111-1111-111111111111/data_sources?page=1&per_page=1",
+			"previous": "https://api.digitalocean.com/v2/gen-ai/knowledge_bases/11111111-1111-1111-1111-111111111111/data_sources?page=1&per_page=1",
+			"next": "https://api.digitalocean.com/v2/gen-ai/knowledge_bases/11111111-1111-1111-1111-111111111111/data_sources?page=2&per_page=1",
+			"last": "https://api.digitalocean.com/v2/gen-ai/knowledge_bases/11111111-1111-1111-1111-111111111111/data_sources?page=3&per_page=1"
+		}
+	},
+	"meta": {
+		"total": 3,
+		"page": 1,
+		"pages": 3
+	}
+}
+`
+
+var addDataSourceResponse = `
+{
+	"knowledge_base_data_source": {
+		"uuid": "22222222-2222-2222-2222-222222222222",
+		"bucket_name": "test-bucket",
+		"item_path": "/docs/test.pdf",
+		"region": "tor1",
+		"created_at": "2025-05-14T13:18:05Z",
+		"updated_at": "2025-05-14T13:18:05Z",
+		"spaces_data_source": {
+			"bucket_name": "test-bucket",
+			"item_path": "/docs/test.pdf",
+			"region": "tor1"
+		}
+	}
+}
+`
+
+var deleteDataSourceResponse = `
+{
+	"knowledge_base_uuid": "11111111-1111-1111-1111-111111111111",
+	"data_source_uuid": "22222222-2222-2222-2222-222222222222"
+}
+`
+
+var deleteKnowledgeBaseResponse = `
+{
+	"uuid": "11111111-1111-1111-1111-111111111111"
+}`
+
 func TestListAgents(t *testing.T) {
 	setup()
 	defer teardown()
@@ -618,4 +762,237 @@ func TestListModels(t *testing.T) {
 	expectedString := fmt.Sprintf("%v", models[0])
 	assert.Equal(t, resp.Response.StatusCode, 200)
 	assert.Equal(t, expectedString, models[0].String())
+}
+
+func TestListKnowledgeBases(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/gen-ai/knowledge_bases", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		testFormValues(t, r, values{
+			"page":     "1",
+			"per_page": "1",
+		})
+
+		fmt.Fprint(w, listKnowledgeBaseResponse)
+	})
+
+	req := &ListOptions{
+		Page:    1,
+		PerPage: 1,
+	}
+
+	knowledgeBases, resp, err := client.GenAI.ListKnowledgeBases(ctx, req)
+	if err != nil {
+		t.Errorf("GenAI.ListKnowledgeBases returned error: %v", err)
+	}
+
+	assert.Equal(t, 10, resp.Meta.Total)
+	assert.Equal(t, "Test Knowledge Base", knowledgeBases[0].Name)
+}
+
+func TestCreateKnowledgeBase(t *testing.T) { //works
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/gen-ai/knowledge_bases", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		fmt.Fprint(w, knowledgeBaseResponse)
+	})
+
+	req := &KnowledgeBaseCreateRequest{
+		Name:               "testing-kb",
+		ProjectID:          "11111111-1111-1111-1111-111111111111",
+		Region:             "tor1",
+		EmbeddingModelUUID: "11111111-1111-1111-1111-111111111111",
+		Tags:               []string{"string"},
+	}
+
+	res, _, err := client.GenAI.CreateKnowledgeBase(ctx, req)
+	if err != nil {
+		t.Errorf("GenAI.CreateKnowledgeBase returned error: %v", err)
+	}
+
+	assert.Equal(t, res.Name, req.Name)
+	assert.Equal(t, res.ProjectId, req.ProjectID)
+}
+
+func TestListDataSources(t *testing.T) { //works
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/gen-ai/knowledge_bases/11111111-1111-1111-1111-111111111111/data_sources", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		testFormValues(t, r, values{
+			"page":     "1",
+			"per_page": "1",
+		})
+
+		fmt.Fprint(w, listDataSourcesResponse)
+	})
+
+	req := &ListOptions{
+		Page:    1,
+		PerPage: 1,
+	}
+
+	dataSources, resp, err := client.GenAI.ListDataSources(ctx, "11111111-1111-1111-1111-111111111111", req)
+	if err != nil {
+		t.Errorf("GenAI.ListDataSources returned error: %v", err)
+	}
+
+	assert.Equal(t, 3, resp.Meta.Total)
+	assert.Equal(t, "test-bucket", dataSources[0].BucketName)
+}
+
+func TestAddDataSource(t *testing.T) { //works
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/gen-ai/knowledge_bases/11111111-1111-1111-1111-111111111111/data_sources", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		fmt.Fprint(w, addDataSourceResponse)
+	})
+
+	req := &AddDataSourceRequest{
+		KnowledgeBaseUUID: "11111111-1111-1111-1111-111111111111",
+		SpacesDataSource: &SpacesDataSource{
+			BucketName: "test-bucket",
+			ItemPath:   "/docs/test.pdf",
+			Region:     "tor1",
+		},
+	}
+
+	res, _, err := client.GenAI.AddDataSource(ctx, "11111111-1111-1111-1111-111111111111", req)
+	if err != nil {
+		t.Errorf("GenAI.AddDataSource returned error: %v", err)
+	}
+
+	assert.Equal(t, "test-bucket", res.BucketName)
+	assert.Equal(t, "/docs/test.pdf", res.ItemPath)
+}
+
+func TestDeleteDataSource(t *testing.T) { //works
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/gen-ai/knowledge_bases/11111111-1111-1111-1111-111111111111/data_sources/22222222-2222-2222-2222-222222222222", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+		fmt.Fprint(w, deleteDataSourceResponse)
+	})
+
+	kbUUID, dsUUID, resp, err := client.GenAI.DeleteDataSource(ctx, "11111111-1111-1111-1111-111111111111", "22222222-2222-2222-2222-222222222222")
+	if err != nil {
+		t.Errorf("GenAI.DeleteDataSource returned error: %v", err)
+	}
+
+	assert.Equal(t, "11111111-1111-1111-1111-111111111111", kbUUID)
+	assert.Equal(t, "22222222-2222-2222-2222-222222222222", dsUUID)
+	assert.Equal(t, 200, resp.Response.StatusCode)
+}
+
+func TestGetKnowledgeBase(t *testing.T) { //works
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/gen-ai/knowledge_bases/11111111-1111-1111-1111-111111111111", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, knowledgeBaseResponse)
+	})
+
+	res, resp, err := client.GenAI.GetKnowledgeBase(ctx, "11111111-1111-1111-1111-111111111111")
+	if err != nil {
+		t.Errorf("GenAI.GetKnowledgeBase returned error: %v", err)
+	}
+
+	assert.Equal(t, "testing-kb", res.Name)
+	assert.Equal(t, 200, resp.Response.StatusCode)
+}
+
+func TestUpdateKnowledgeBase(t *testing.T) { //works
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/gen-ai/knowledge_bases/11111111-1111-1111-1111-111111111111", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPut)
+		fmt.Fprint(w, knowledgeBaseUpdateResponse)
+	})
+
+	req := &UpdateKnowledgeBaseRequest{
+		Name: "Updated Knowledge Base",
+		Tags: []string{"updated", "example"},
+	}
+
+	res, resp, err := client.GenAI.UpdateKnowledgeBase(ctx, "11111111-1111-1111-1111-111111111111", req)
+	if err != nil {
+		t.Errorf("GenAI.UpdateKnowledgeBase returned error: %v", err)
+	}
+
+	assert.Equal(t, res.Tags[0], req.Tags[0])
+	assert.Equal(t, 200, resp.Response.StatusCode)
+}
+
+func TestDeleteKnowledgeBase(t *testing.T) { //works
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/gen-ai/knowledge_bases/11111111-1111-1111-1111-111111111111", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+		fmt.Fprint(w, deleteKnowledgeBaseResponse)
+	})
+
+	kbUUID, resp, err := client.GenAI.DeleteKnowledgeBase(ctx, "11111111-1111-1111-1111-111111111111")
+	if err != nil {
+		t.Errorf("GenAI.DeleteKnowledgeBase returned error: %v", err)
+	}
+
+	assert.Equal(t, "11111111-1111-1111-1111-111111111111", kbUUID)
+	assert.Equal(t, 200, resp.Response.StatusCode)
+}
+
+func TestAttachKnowledgeBase(t *testing.T) { //fail
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/gen-ai/agents/00000000-0000-0000-0000-000000000000/knowledge_bases/11111111-1111-1111-1111-111111111111", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		fmt.Fprint(w, agentResponse)
+	})
+
+	res, resp, err := client.GenAI.AttachKnowledgBase(ctx, "00000000-0000-0000-0000-000000000000", "11111111-1111-1111-1111-111111111111")
+	if err != nil {
+		t.Errorf("GenAI.AttachKnowledgBase returned error: %v", err)
+	}
+
+	assert.Equal(t, "testing-godo", res.Name)
+	assert.Equal(t, 200, resp.Response.StatusCode)
+}
+
+func TestDetachKnowledgeBase(t *testing.T) {
+	setup()
+	defer teardown()
+
+	// Mock the expected API endpoint
+	mux.HandleFunc("/v2/gen-ai/agents/00000000-0000-0000-0000-000000000000/knowledge_bases/11111111-1111-1111-1111-111111111111", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+		fmt.Fprint(w, agentResponse) // Mock response
+	})
+
+	// Call the method
+	res, resp, err := client.GenAI.DetachKnowledgBase(ctx, "00000000-0000-0000-0000-000000000000", "11111111-1111-1111-1111-111111111111")
+	fmt.Print(res)
+	fmt.Print(resp)
+
+	if err != nil {
+		t.Fatalf("GenAI.DetachKnowledgBase returned error: %v", err)
+	}
+
+	// Validate the response
+	if res == nil {
+		t.Fatalf("GenAI.DetachKnowledgBase returned nil response or result")
+	}
+
+	assert.Equal(t, "testing-godo", res.Name)      // Validate the agent name
+	assert.Equal(t, 200, resp.Response.StatusCode) // Validate the HTTP status code
 }

--- a/genai_test.go
+++ b/genai_test.go
@@ -960,7 +960,7 @@ func TestAttachKnowledgeBase(t *testing.T) {
 		fmt.Fprint(w, agentResponse)
 	})
 
-	res, resp, err := client.GenAI.AttachKnowledgBase(ctx, "00000000-0000-0000-0000-000000000000", "11111111-1111-1111-1111-111111111111")
+	res, resp, err := client.GenAI.AttachKnowledgeBase(ctx, "00000000-0000-0000-0000-000000000000", "11111111-1111-1111-1111-111111111111")
 	if err != nil {
 		t.Errorf("GenAI.AttachKnowledgBase returned error: %v", err)
 	}
@@ -978,7 +978,7 @@ func TestDetachKnowledgeBase(t *testing.T) {
 		fmt.Fprint(w, agentResponse)
 	})
 
-	res, resp, err := client.GenAI.DetachKnowledgBase(ctx, "00000000-0000-0000-0000-000000000000", "11111111-1111-1111-1111-111111111111")
+	res, resp, err := client.GenAI.DetachKnowledgeBase(ctx, "00000000-0000-0000-0000-000000000000", "11111111-1111-1111-1111-111111111111")
 	fmt.Print(res)
 	fmt.Print(resp)
 

--- a/genai_test.go
+++ b/genai_test.go
@@ -433,7 +433,7 @@ var knowledgeBaseUpdateResponse = `
 {
 	"knowledge_base": {
 		"uuid": "11111111-1111-1111-1111-111111111111",
-		"name": "Updated Knowledge Base",
+		"name": "Updated-Knowledge-Base",
 		"created_at": "2025-05-14T13:18:05Z",
 		"updated_at": "2025-05-14T13:46:48Z",
 		"region": "tor1",
@@ -820,6 +820,13 @@ func TestCreateKnowledgeBase(t *testing.T) {
 		Region:             "tor1",
 		EmbeddingModelUuid: "11111111-1111-1111-1111-111111111111",
 		Tags:               []string{"string"},
+		DataSources: []KnowledgeBaseDataSource{
+			{
+				WebCrawlerDataSource: &WebCrawlerDataSource{
+					BaseUrl: "https://www.example.com",
+				},
+			},
+		},
 	}
 
 	res, _, err := client.GenAI.CreateKnowledgeBase(ctx, req)
@@ -829,6 +836,8 @@ func TestCreateKnowledgeBase(t *testing.T) {
 
 	assert.Equal(t, res.Name, req.Name)
 	assert.Equal(t, res.ProjectId, req.ProjectID)
+	assert.Equal(t, req.EmbeddingModelUuid, res.EmbeddingModelUuid)
+	assert.Equal(t, req.Region, res.Region)
 }
 
 func TestListDataSources(t *testing.T) {
@@ -935,7 +944,7 @@ func TestUpdateKnowledgeBase(t *testing.T) {
 	})
 
 	req := &UpdateKnowledgeBaseRequest{
-		Name: "Updated Knowledge Base",
+		Name: "Updated-Knowledge-Base",
 		Tags: []string{"updated", "example"},
 	}
 
@@ -944,6 +953,8 @@ func TestUpdateKnowledgeBase(t *testing.T) {
 		t.Errorf("GenAI.UpdateKnowledgeBase returned error: %v", err)
 	}
 
+	assert.Equal(t, req.Name, res.Name)
+	assert.Equal(t, req.Tags, res.Tags)
 	assert.Equal(t, res.Tags[0], req.Tags[0])
 	assert.Equal(t, 200, resp.Response.StatusCode)
 }
@@ -975,7 +986,7 @@ func TestAttachKnowledgeBase(t *testing.T) {
 		fmt.Fprint(w, agentResponse)
 	})
 
-	res, resp, err := client.GenAI.AttachKnowledgeBase(ctx, "00000000-0000-0000-0000-000000000000", "11111111-1111-1111-1111-111111111111")
+	res, resp, err := client.GenAI.AttachKnowledgeBaseToAgent(ctx, "00000000-0000-0000-0000-000000000000", "11111111-1111-1111-1111-111111111111")
 	if err != nil {
 		t.Errorf("GenAI.AttachKnowledgBase returned error: %v", err)
 	}


### PR DESCRIPTION
Implemented methods for Knowledge base endpoints for the GenAI Service

- List Knowledge Bases
- Create a Knowledge Base
- List Data Sources for a Knowledge Base
- Add Data Source to a Knowledge Base
- Delete Data Source from a Knowledge Base
- Retrieve Information About an Existing Knowledge Base
- Update a Knowledge Base
- Delete a Knowledge Base
- Attach Knowledge Base to an Agent
- Detach Knowledge Base from an Agent