### PR TITLE
Apps add instance alias

### DIFF
--- a/apps.gen.go
+++ b/apps.gen.go
@@ -413,8 +413,8 @@ type AppJobSpec struct {
 	// The instance size to use for this component.
 	InstanceSizeSlug string `json:"instance_size_slug,omitempty"`
 	// The amount of instances that this component should be scaled to. Default 1, Minimum 1, Maximum 250. Consider using a larger instance size if your application requires more than 250 instances.
-	InstanceCount int64               `json:"instance_count,omitempty"`
-	Kind          AppJobSpecKind      `json:"kind,omitempty"`
+	InstanceCount int64          `json:"instance_count,omitempty"`
+	Kind          AppJobSpecKind `json:"kind,omitempty"`
 	// A list of configured alerts which apply to the component.
 	Alerts []*AppAlertSpec `json:"alerts,omitempty"`
 	// A list of configured log forwarding destinations.
@@ -546,9 +546,9 @@ type AppServiceSpec struct {
 	// A list of configured alerts which apply to the component.
 	Alerts []*AppAlertSpec `json:"alerts,omitempty"`
 	// A list of configured log forwarding destinations.
-	LogDestinations     []*AppLogDestinationSpec       `json:"log_destinations,omitempty"`
-	Termination         *AppServiceSpecTermination     `json:"termination,omitempty"`
-	LivenessHealthCheck *HealthCheckSpec               `json:"liveness_health_check,omitempty"`
+	LogDestinations     []*AppLogDestinationSpec   `json:"log_destinations,omitempty"`
+	Termination         *AppServiceSpecTermination `json:"termination,omitempty"`
+	LivenessHealthCheck *HealthCheckSpec           `json:"liveness_health_check,omitempty"`
 }
 
 // AppServiceSpecHealthCheck struct for AppServiceSpecHealthCheck
@@ -559,9 +559,9 @@ type AppServiceSpecHealthCheck struct {
 	InitialDelaySeconds int32 `json:"initial_delay_seconds,omitempty"`
 	// The number of seconds to wait between health checks. Default: 10 seconds, Minimum 1, Maximum 300. When used in liveness_health_check, Default: 10 seconds, Minimum 1, Maximum 300.
 	PeriodSeconds int32 `json:"period_seconds,omitempty"`
-	// The number of seconds after which the check times out. Default: 1 second, Minimum 1, Maximum 120.
+	// The number of seconds after which the check times out. Default: 1, Minimum 1, Maximum 120.
 	TimeoutSeconds int32 `json:"timeout_seconds,omitempty"`
-	// The number of successful health checks before considered healthy. Default: 1 second, Minimum 1, Maximum 50. When used in liveness_health_check, Default: 1 second, Minimum 1, Maximum 1.
+	// The number of successful health checks before considered healthy. Default: 1, Minimum 1, Maximum 50. When used in liveness_health_check, Default: 1, Minimum 1, Maximum 1.
 	SuccessThreshold int32 `json:"success_threshold,omitempty"`
 	// The number of failed health checks before considered unhealthy. Default: 9 seconds, Minimum 1, Maximum 50. When used in liveness_health_check, Default: 18 seconds, Minimum 1, Maximum 50.
 	FailureThreshold int32 `json:"failure_threshold,omitempty"`
@@ -721,7 +721,7 @@ type Buildpack struct {
 
 // DeploymentCauseDetailsAutoscalerAction struct for DeploymentCauseDetailsAutoscalerAction
 type DeploymentCauseDetailsAutoscalerAction struct {
-	Autoscaled       bool                                   `json:"autoscaled,omitempty"`
+	Autoscaled bool `json:"autoscaled,omitempty"`
 }
 
 // DeploymentCauseDetailsDigitalOceanUser struct for DeploymentCauseDetailsDigitalOceanUser
@@ -1233,14 +1233,14 @@ const (
 
 // AppInstanceSize struct for AppInstanceSize
 type AppInstanceSize struct {
-	Name             string                 `json:"name,omitempty"`
-	Slug             string                 `json:"slug,omitempty"`
-	CPUType          AppInstanceSizeCPUType `json:"cpu_type,omitempty"`
-	CPUs             string                 `json:"cpus,omitempty"`
-	MemoryBytes      string                 `json:"memory_bytes,omitempty"`
-	USDPerMonth      string                 `json:"usd_per_month,omitempty"`
-	USDPerSecond     string                 `json:"usd_per_second,omitempty"`
-	TierSlug         string                 `json:"tier_slug,omitempty"`
+	Name         string                 `json:"name,omitempty"`
+	Slug         string                 `json:"slug,omitempty"`
+	CPUType      AppInstanceSizeCPUType `json:"cpu_type,omitempty"`
+	CPUs         string                 `json:"cpus,omitempty"`
+	MemoryBytes  string                 `json:"memory_bytes,omitempty"`
+	USDPerMonth  string                 `json:"usd_per_month,omitempty"`
+	USDPerSecond string                 `json:"usd_per_second,omitempty"`
+	TierSlug     string                 `json:"tier_slug,omitempty"`
 	// (Deprecated) The slug of the corresponding upgradable instance size on the higher tier.
 	TierUpgradeTo string `json:"tier_upgrade_to,omitempty"`
 	// (Deprecated) The slug of the corresponding downgradable instance size on the lower tier.

--- a/apps.gen.go
+++ b/apps.gen.go
@@ -100,7 +100,6 @@ type App struct {
 	ProjectID string `json:"project_id,omitempty"`
 	// The dedicated egress ip addresses associated with the app.
 	DedicatedIps []*AppDedicatedIp `json:"dedicated_ips,omitempty"`
-	VPC          *AppVPC           `json:"vpc,omitempty"`
 }
 
 // AppAlertSpec Configuration of an alert for the app or a individual component.
@@ -416,7 +415,6 @@ type AppJobSpec struct {
 	// The amount of instances that this component should be scaled to. Default 1, Minimum 1, Maximum 250. Consider using a larger instance size if your application requires more than 250 instances.
 	InstanceCount int64               `json:"instance_count,omitempty"`
 	Kind          AppJobSpecKind      `json:"kind,omitempty"`
-	Schedule      *AppJobSpecSchedule `json:"schedule,omitempty"`
 	// A list of configured alerts which apply to the component.
 	Alerts []*AppAlertSpec `json:"alerts,omitempty"`
 	// A list of configured log forwarding destinations.
@@ -433,14 +431,7 @@ const (
 	AppJobSpecKind_PreDeploy    AppJobSpecKind = "PRE_DEPLOY"
 	AppJobSpecKind_PostDeploy   AppJobSpecKind = "POST_DEPLOY"
 	AppJobSpecKind_FailedDeploy AppJobSpecKind = "FAILED_DEPLOY"
-	AppJobSpecKind_Scheduled    AppJobSpecKind = "SCHEDULED"
 )
-
-// AppJobSpecSchedule struct for AppJobSpecSchedule
-type AppJobSpecSchedule struct {
-	Cron     string `json:"cron,omitempty"`
-	TimeZone string `json:"time_zone,omitempty"`
-}
 
 // AppJobSpecTermination struct for AppJobSpecTermination
 type AppJobSpecTermination struct {
@@ -510,12 +501,6 @@ type AppMaintenanceSpec struct {
 	OfflinePageURL string `json:"offline_page_url,omitempty"`
 }
 
-// AppPeeredVpcSpec Configuration of the target VPC.
-type AppPeeredVpcSpec struct {
-	// The name of the VPC.
-	Name string `json:"name,omitempty"`
-}
-
 // AppRouteSpec struct for AppRouteSpec
 type AppRouteSpec struct {
 	// (Deprecated) An HTTP path prefix. Paths must start with / and must be unique across all components within an app.
@@ -563,7 +548,6 @@ type AppServiceSpec struct {
 	// A list of configured log forwarding destinations.
 	LogDestinations     []*AppLogDestinationSpec       `json:"log_destinations,omitempty"`
 	Termination         *AppServiceSpecTermination     `json:"termination,omitempty"`
-	InactivitySleep     *AppServiceSpecInactivitySleep `json:"inactivity_sleep,omitempty"`
 	LivenessHealthCheck *HealthCheckSpec               `json:"liveness_health_check,omitempty"`
 }
 
@@ -585,12 +569,6 @@ type AppServiceSpecHealthCheck struct {
 	HTTPPath string `json:"http_path,omitempty"`
 	// The port on which the health check will be performed. If not set, the health check will be performed on the component's http_port.
 	Port int64 `json:"port,omitempty"`
-}
-
-// AppServiceSpecInactivitySleep struct for AppServiceSpecInactivitySleep
-type AppServiceSpecInactivitySleep struct {
-	// The number of seconds to wait before putting the service to sleep after it has been inactive. Minimum 120, Maximum 3600.
-	AfterSeconds int32 `json:"after_seconds,omitempty"`
 }
 
 // AppServiceSpecTermination struct for AppServiceSpecTermination
@@ -628,7 +606,6 @@ type AppSpec struct {
 	Egress      *AppEgressSpec      `json:"egress,omitempty"`
 	Features    []string            `json:"features,omitempty"`
 	Maintenance *AppMaintenanceSpec `json:"maintenance,omitempty"`
-	Vpc         *AppVpcSpec         `json:"vpc,omitempty"`
 	// Specification to disable edge (CDN) cache for all domains of the app. Note that this feature is in private preview.
 	DisableEdgeCache bool `json:"disable_edge_cache,omitempty"`
 	// Specification to disable email obfuscation.
@@ -677,27 +654,6 @@ type AppVariableDefinition struct {
 	Type  AppVariableType  `json:"type,omitempty"`
 }
 
-// AppVPC The VPC configuration for the app.
-type AppVPC struct {
-	// The ID of the VPC (derived from the app spec).
-	ID string `json:"id,omitempty"`
-	// The private IP addresses allocated for the app in the customer's VPC.
-	EgressIPs []*AppVPCEgressIP `json:"egress_ips,omitempty"`
-}
-
-// AppVPCEgressIP struct for AppVPCEgressIP
-type AppVPCEgressIP struct {
-	IP string `json:"ip,omitempty"`
-}
-
-// AppVpcSpec Configuration of VPC.
-type AppVpcSpec struct {
-	// The list of target vpcs.
-	PeeredVpcs []*AppPeeredVpcSpec `json:"peered_vpcs,omitempty"`
-	// The id of the target VPC, in UUID format.
-	ID string `json:"id,omitempty"`
-}
-
 // AppWorkerSpec struct for AppWorkerSpec
 type AppWorkerSpec struct {
 	// The name. Must be unique across all components within the same app.
@@ -738,12 +694,6 @@ type AppWorkerSpecTermination struct {
 	GracePeriodSeconds int32 `json:"grace_period_seconds,omitempty"`
 }
 
-// AutoscalerActionScaleChange struct for AutoscalerActionScaleChange
-type AutoscalerActionScaleChange struct {
-	From int64 `json:"from,omitempty"`
-	To   int64 `json:"to,omitempty"`
-}
-
 // BitbucketSourceSpec struct for BitbucketSourceSpec
 type BitbucketSourceSpec struct {
 	Repo         string `json:"repo,omitempty"`
@@ -772,7 +722,6 @@ type Buildpack struct {
 // DeploymentCauseDetailsAutoscalerAction struct for DeploymentCauseDetailsAutoscalerAction
 type DeploymentCauseDetailsAutoscalerAction struct {
 	Autoscaled       bool                                   `json:"autoscaled,omitempty"`
-	ScaledComponents map[string]AutoscalerActionScaleChange `json:"scaled_components,omitempty"`
 }
 
 // DeploymentCauseDetailsDigitalOceanUser struct for DeploymentCauseDetailsDigitalOceanUser
@@ -1291,8 +1240,6 @@ type AppInstanceSize struct {
 	MemoryBytes      string                 `json:"memory_bytes,omitempty"`
 	USDPerMonth      string                 `json:"usd_per_month,omitempty"`
 	USDPerSecond     string                 `json:"usd_per_second,omitempty"`
-	IDleUSDPerMonth  string                 `json:"idle_usd_per_month,omitempty"`
-	IDleUSDPerSecond string                 `json:"idle_usd_per_second,omitempty"`
 	TierSlug         string                 `json:"tier_slug,omitempty"`
 	// (Deprecated) The slug of the corresponding upgradable instance size on the higher tier.
 	TierUpgradeTo string `json:"tier_upgrade_to,omitempty"`

--- a/apps.gen.go
+++ b/apps.gen.go
@@ -559,11 +559,11 @@ type AppServiceSpecHealthCheck struct {
 	InitialDelaySeconds int32 `json:"initial_delay_seconds,omitempty"`
 	// The number of seconds to wait between health checks. Default: 10 seconds, Minimum 1, Maximum 300. When used in liveness_health_check, Default: 10 seconds, Minimum 1, Maximum 300.
 	PeriodSeconds int32 `json:"period_seconds,omitempty"`
-	// The number of seconds after which the check times out. Default: 1, Minimum 1, Maximum 120.
+	// The number of seconds after which the check times out. Default: 1 second, Minimum 1, Maximum 120.
 	TimeoutSeconds int32 `json:"timeout_seconds,omitempty"`
 	// The number of successful health checks before considered healthy. Default: 1, Minimum 1, Maximum 50. When used in liveness_health_check, Default: 1, Minimum 1, Maximum 1.
 	SuccessThreshold int32 `json:"success_threshold,omitempty"`
-	// The number of failed health checks before considered unhealthy. Default: 9 seconds, Minimum 1, Maximum 50. When used in liveness_health_check, Default: 18 seconds, Minimum 1, Maximum 50.
+	// The number of failed health checks before considered unhealthy. Default: 9, Minimum 1, Maximum 50. When used in liveness_health_check, Default: 18, Minimum 1, Maximum 50.
 	FailureThreshold int32 `json:"failure_threshold,omitempty"`
 	// The route path used for the HTTP health check ping. If not set, the HTTP health check will be disabled and a TCP health check used instead.
 	HTTPPath string `json:"http_path,omitempty"`

--- a/apps_accessors.go
+++ b/apps_accessors.go
@@ -181,14 +181,6 @@ func (a *App) GetUpdatedAt() time.Time {
 	return a.UpdatedAt
 }
 
-// GetVPC returns the VPC field.
-func (a *App) GetVPC() *AppVPC {
-	if a == nil {
-		return nil
-	}
-	return a.VPC
-}
-
 // GetComponentName returns the ComponentName field.
 func (a *AppAlert) GetComponentName() string {
 	if a == nil {
@@ -1117,22 +1109,6 @@ func (a *AppInstanceSize) GetFeaturePreview() bool {
 	return a.FeaturePreview
 }
 
-// GetIDleUSDPerMonth returns the IDleUSDPerMonth field.
-func (a *AppInstanceSize) GetIDleUSDPerMonth() string {
-	if a == nil {
-		return ""
-	}
-	return a.IDleUSDPerMonth
-}
-
-// GetIDleUSDPerSecond returns the IDleUSDPerSecond field.
-func (a *AppInstanceSize) GetIDleUSDPerSecond() string {
-	if a == nil {
-		return ""
-	}
-	return a.IDleUSDPerSecond
-}
-
 // GetMemoryBytes returns the MemoryBytes field.
 func (a *AppInstanceSize) GetMemoryBytes() string {
 	if a == nil {
@@ -1341,14 +1317,6 @@ func (a *AppJobSpec) GetRunCommand() string {
 	return a.RunCommand
 }
 
-// GetSchedule returns the Schedule field.
-func (a *AppJobSpec) GetSchedule() *AppJobSpecSchedule {
-	if a == nil {
-		return nil
-	}
-	return a.Schedule
-}
-
 // GetSourceDir returns the SourceDir field.
 func (a *AppJobSpec) GetSourceDir() string {
 	if a == nil {
@@ -1363,22 +1331,6 @@ func (a *AppJobSpec) GetTermination() *AppJobSpecTermination {
 		return nil
 	}
 	return a.Termination
-}
-
-// GetCron returns the Cron field.
-func (a *AppJobSpecSchedule) GetCron() string {
-	if a == nil {
-		return ""
-	}
-	return a.Cron
-}
-
-// GetTimeZone returns the TimeZone field.
-func (a *AppJobSpecSchedule) GetTimeZone() string {
-	if a == nil {
-		return ""
-	}
-	return a.TimeZone
 }
 
 // GetGracePeriodSeconds returns the GracePeriodSeconds field.
@@ -1555,30 +1507,6 @@ func (a *AppMaintenanceSpec) GetOfflinePageURL() string {
 		return ""
 	}
 	return a.OfflinePageURL
-}
-
-// GetName returns the Name field.
-func (a *AppPeeredVpcSpec) GetName() string {
-	if a == nil {
-		return ""
-	}
-	return a.Name
-}
-
-// GetAppID returns the AppID field.
-func (a *AppProposeRequest) GetAppID() string {
-	if a == nil {
-		return ""
-	}
-	return a.AppID
-}
-
-// GetSpec returns the Spec field.
-func (a *AppProposeRequest) GetSpec() *AppSpec {
-	if a == nil {
-		return nil
-	}
-	return a.Spec
 }
 
 // GetAppCost returns the AppCost field.
@@ -1869,14 +1797,6 @@ func (a *AppServiceSpec) GetImage() *ImageSourceSpec {
 	return a.Image
 }
 
-// GetInactivitySleep returns the InactivitySleep field.
-func (a *AppServiceSpec) GetInactivitySleep() *AppServiceSpecInactivitySleep {
-	if a == nil {
-		return nil
-	}
-	return a.InactivitySleep
-}
-
 // GetInstanceCount returns the InstanceCount field.
 func (a *AppServiceSpec) GetInstanceCount() int64 {
 	if a == nil {
@@ -2029,14 +1949,6 @@ func (a *AppServiceSpecHealthCheck) GetTimeoutSeconds() int32 {
 	return a.TimeoutSeconds
 }
 
-// GetAfterSeconds returns the AfterSeconds field.
-func (a *AppServiceSpecInactivitySleep) GetAfterSeconds() int32 {
-	if a == nil {
-		return 0
-	}
-	return a.AfterSeconds
-}
-
 // GetDrainSeconds returns the DrainSeconds field.
 func (a *AppServiceSpecTermination) GetDrainSeconds() int32 {
 	if a == nil {
@@ -2187,14 +2099,6 @@ func (a *AppSpec) GetStaticSites() []*AppStaticSiteSpec {
 		return nil
 	}
 	return a.StaticSites
-}
-
-// GetVpc returns the Vpc field.
-func (a *AppSpec) GetVpc() *AppVpcSpec {
-	if a == nil {
-		return nil
-	}
-	return a.Vpc
 }
 
 // GetWorkers returns the Workers field.
@@ -2421,46 +2325,6 @@ func (a *AppVariableDefinition) GetValue() string {
 	return a.Value
 }
 
-// GetEgressIPs returns the EgressIPs field.
-func (a *AppVPC) GetEgressIPs() []*AppVPCEgressIP {
-	if a == nil {
-		return nil
-	}
-	return a.EgressIPs
-}
-
-// GetID returns the ID field.
-func (a *AppVPC) GetID() string {
-	if a == nil {
-		return ""
-	}
-	return a.ID
-}
-
-// GetIP returns the IP field.
-func (a *AppVPCEgressIP) GetIP() string {
-	if a == nil {
-		return ""
-	}
-	return a.IP
-}
-
-// GetID returns the ID field.
-func (a *AppVpcSpec) GetID() string {
-	if a == nil {
-		return ""
-	}
-	return a.ID
-}
-
-// GetPeeredVpcs returns the PeeredVpcs field.
-func (a *AppVpcSpec) GetPeeredVpcs() []*AppPeeredVpcSpec {
-	if a == nil {
-		return nil
-	}
-	return a.PeeredVpcs
-}
-
 // GetAlerts returns the Alerts field.
 func (a *AppWorkerSpec) GetAlerts() []*AppAlertSpec {
 	if a == nil {
@@ -2619,22 +2483,6 @@ func (a *AppWorkerSpecTermination) GetGracePeriodSeconds() int32 {
 		return 0
 	}
 	return a.GracePeriodSeconds
-}
-
-// GetFrom returns the From field.
-func (a *AutoscalerActionScaleChange) GetFrom() int64 {
-	if a == nil {
-		return 0
-	}
-	return a.From
-}
-
-// GetTo returns the To field.
-func (a *AutoscalerActionScaleChange) GetTo() int64 {
-	if a == nil {
-		return 0
-	}
-	return a.To
 }
 
 // GetBranch returns the Branch field.
@@ -2923,14 +2771,6 @@ func (d *DeploymentCauseDetailsAutoscalerAction) GetAutoscaled() bool {
 		return false
 	}
 	return d.Autoscaled
-}
-
-// GetScaledComponents returns the ScaledComponents map if it's non-nil, an empty map otherwise.
-func (d *DeploymentCauseDetailsAutoscalerAction) GetScaledComponents() map[string]AutoscalerActionScaleChange {
-	if d == nil || d.ScaledComponents == nil {
-		return map[string]AutoscalerActionScaleChange{}
-	}
-	return d.ScaledComponents
 }
 
 // GetEmail returns the Email field.

--- a/apps_accessors.go
+++ b/apps_accessors.go
@@ -181,6 +181,14 @@ func (a *App) GetUpdatedAt() time.Time {
 	return a.UpdatedAt
 }
 
+// GetVPC returns the VPC field.
+func (a *App) GetVPC() *AppVPC {
+	if a == nil {
+		return nil
+	}
+	return a.VPC
+}
+
 // GetComponentName returns the ComponentName field.
 func (a *AppAlert) GetComponentName() string {
 	if a == nil {
@@ -1053,6 +1061,14 @@ func (a *AppInstance) GetComponentType() AppInstanceComponentType {
 	return a.ComponentType
 }
 
+// GetInstanceAlias returns the InstanceAlias field.
+func (a *AppInstance) GetInstanceAlias() string {
+	if a == nil {
+		return ""
+	}
+	return a.InstanceAlias
+}
+
 // GetInstanceName returns the InstanceName field.
 func (a *AppInstance) GetInstanceName() string {
 	if a == nil {
@@ -1099,6 +1115,22 @@ func (a *AppInstanceSize) GetFeaturePreview() bool {
 		return false
 	}
 	return a.FeaturePreview
+}
+
+// GetIDleUSDPerMonth returns the IDleUSDPerMonth field.
+func (a *AppInstanceSize) GetIDleUSDPerMonth() string {
+	if a == nil {
+		return ""
+	}
+	return a.IDleUSDPerMonth
+}
+
+// GetIDleUSDPerSecond returns the IDleUSDPerSecond field.
+func (a *AppInstanceSize) GetIDleUSDPerSecond() string {
+	if a == nil {
+		return ""
+	}
+	return a.IDleUSDPerSecond
 }
 
 // GetMemoryBytes returns the MemoryBytes field.
@@ -1309,6 +1341,14 @@ func (a *AppJobSpec) GetRunCommand() string {
 	return a.RunCommand
 }
 
+// GetSchedule returns the Schedule field.
+func (a *AppJobSpec) GetSchedule() *AppJobSpecSchedule {
+	if a == nil {
+		return nil
+	}
+	return a.Schedule
+}
+
 // GetSourceDir returns the SourceDir field.
 func (a *AppJobSpec) GetSourceDir() string {
 	if a == nil {
@@ -1323,6 +1363,22 @@ func (a *AppJobSpec) GetTermination() *AppJobSpecTermination {
 		return nil
 	}
 	return a.Termination
+}
+
+// GetCron returns the Cron field.
+func (a *AppJobSpecSchedule) GetCron() string {
+	if a == nil {
+		return ""
+	}
+	return a.Cron
+}
+
+// GetTimeZone returns the TimeZone field.
+func (a *AppJobSpecSchedule) GetTimeZone() string {
+	if a == nil {
+		return ""
+	}
+	return a.TimeZone
 }
 
 // GetGracePeriodSeconds returns the GracePeriodSeconds field.
@@ -1499,6 +1555,14 @@ func (a *AppMaintenanceSpec) GetOfflinePageURL() string {
 		return ""
 	}
 	return a.OfflinePageURL
+}
+
+// GetName returns the Name field.
+func (a *AppPeeredVpcSpec) GetName() string {
+	if a == nil {
+		return ""
+	}
+	return a.Name
 }
 
 // GetAppID returns the AppID field.
@@ -1805,6 +1869,14 @@ func (a *AppServiceSpec) GetImage() *ImageSourceSpec {
 	return a.Image
 }
 
+// GetInactivitySleep returns the InactivitySleep field.
+func (a *AppServiceSpec) GetInactivitySleep() *AppServiceSpecInactivitySleep {
+	if a == nil {
+		return nil
+	}
+	return a.InactivitySleep
+}
+
 // GetInstanceCount returns the InstanceCount field.
 func (a *AppServiceSpec) GetInstanceCount() int64 {
 	if a == nil {
@@ -1827,6 +1899,14 @@ func (a *AppServiceSpec) GetInternalPorts() []int64 {
 		return nil
 	}
 	return a.InternalPorts
+}
+
+// GetLivenessHealthCheck returns the LivenessHealthCheck field.
+func (a *AppServiceSpec) GetLivenessHealthCheck() *HealthCheckSpec {
+	if a == nil {
+		return nil
+	}
+	return a.LivenessHealthCheck
 }
 
 // GetLogDestinations returns the LogDestinations field.
@@ -1947,6 +2027,14 @@ func (a *AppServiceSpecHealthCheck) GetTimeoutSeconds() int32 {
 		return 0
 	}
 	return a.TimeoutSeconds
+}
+
+// GetAfterSeconds returns the AfterSeconds field.
+func (a *AppServiceSpecInactivitySleep) GetAfterSeconds() int32 {
+	if a == nil {
+		return 0
+	}
+	return a.AfterSeconds
 }
 
 // GetDrainSeconds returns the DrainSeconds field.
@@ -2099,6 +2187,14 @@ func (a *AppSpec) GetStaticSites() []*AppStaticSiteSpec {
 		return nil
 	}
 	return a.StaticSites
+}
+
+// GetVpc returns the Vpc field.
+func (a *AppSpec) GetVpc() *AppVpcSpec {
+	if a == nil {
+		return nil
+	}
+	return a.Vpc
 }
 
 // GetWorkers returns the Workers field.
@@ -2325,6 +2421,46 @@ func (a *AppVariableDefinition) GetValue() string {
 	return a.Value
 }
 
+// GetEgressIPs returns the EgressIPs field.
+func (a *AppVPC) GetEgressIPs() []*AppVPCEgressIP {
+	if a == nil {
+		return nil
+	}
+	return a.EgressIPs
+}
+
+// GetID returns the ID field.
+func (a *AppVPC) GetID() string {
+	if a == nil {
+		return ""
+	}
+	return a.ID
+}
+
+// GetIP returns the IP field.
+func (a *AppVPCEgressIP) GetIP() string {
+	if a == nil {
+		return ""
+	}
+	return a.IP
+}
+
+// GetID returns the ID field.
+func (a *AppVpcSpec) GetID() string {
+	if a == nil {
+		return ""
+	}
+	return a.ID
+}
+
+// GetPeeredVpcs returns the PeeredVpcs field.
+func (a *AppVpcSpec) GetPeeredVpcs() []*AppPeeredVpcSpec {
+	if a == nil {
+		return nil
+	}
+	return a.PeeredVpcs
+}
+
 // GetAlerts returns the Alerts field.
 func (a *AppWorkerSpec) GetAlerts() []*AppAlertSpec {
 	if a == nil {
@@ -2429,6 +2565,14 @@ func (a *AppWorkerSpec) GetInstanceSizeSlug() string {
 	return a.InstanceSizeSlug
 }
 
+// GetLivenessHealthCheck returns the LivenessHealthCheck field.
+func (a *AppWorkerSpec) GetLivenessHealthCheck() *HealthCheckSpec {
+	if a == nil {
+		return nil
+	}
+	return a.LivenessHealthCheck
+}
+
 // GetLogDestinations returns the LogDestinations field.
 func (a *AppWorkerSpec) GetLogDestinations() []*AppLogDestinationSpec {
 	if a == nil {
@@ -2475,6 +2619,22 @@ func (a *AppWorkerSpecTermination) GetGracePeriodSeconds() int32 {
 		return 0
 	}
 	return a.GracePeriodSeconds
+}
+
+// GetFrom returns the From field.
+func (a *AutoscalerActionScaleChange) GetFrom() int64 {
+	if a == nil {
+		return 0
+	}
+	return a.From
+}
+
+// GetTo returns the To field.
+func (a *AutoscalerActionScaleChange) GetTo() int64 {
+	if a == nil {
+		return 0
+	}
+	return a.To
 }
 
 // GetBranch returns the Branch field.
@@ -2763,6 +2923,14 @@ func (d *DeploymentCauseDetailsAutoscalerAction) GetAutoscaled() bool {
 		return false
 	}
 	return d.Autoscaled
+}
+
+// GetScaledComponents returns the ScaledComponents map if it's non-nil, an empty map otherwise.
+func (d *DeploymentCauseDetailsAutoscalerAction) GetScaledComponents() map[string]AutoscalerActionScaleChange {
+	if d == nil || d.ScaledComponents == nil {
+		return map[string]AutoscalerActionScaleChange{}
+	}
+	return d.ScaledComponents
 }
 
 // GetEmail returns the Email field.
@@ -3485,6 +3653,14 @@ func (g *GetAppDatabaseConnectionDetailsResponse) GetConnectionDetails() []*GetD
 	return g.ConnectionDetails
 }
 
+// GetInstances returns the Instances field.
+func (g *GetAppInstancesResponse) GetInstances() []*AppInstance {
+	if g == nil {
+		return nil
+	}
+	return g.Instances
+}
+
 // GetComponentName returns the ComponentName field.
 func (g *GetDatabaseConnectionDetailsResponse) GetComponentName() string {
 	if g == nil {
@@ -3691,6 +3867,62 @@ func (g *GitSourceSpec) GetRepoCloneURL() string {
 		return ""
 	}
 	return g.RepoCloneURL
+}
+
+// GetFailureThreshold returns the FailureThreshold field.
+func (h *HealthCheckSpec) GetFailureThreshold() int32 {
+	if h == nil {
+		return 0
+	}
+	return h.FailureThreshold
+}
+
+// GetHTTPPath returns the HTTPPath field.
+func (h *HealthCheckSpec) GetHTTPPath() string {
+	if h == nil {
+		return ""
+	}
+	return h.HTTPPath
+}
+
+// GetInitialDelaySeconds returns the InitialDelaySeconds field.
+func (h *HealthCheckSpec) GetInitialDelaySeconds() int32 {
+	if h == nil {
+		return 0
+	}
+	return h.InitialDelaySeconds
+}
+
+// GetPeriodSeconds returns the PeriodSeconds field.
+func (h *HealthCheckSpec) GetPeriodSeconds() int32 {
+	if h == nil {
+		return 0
+	}
+	return h.PeriodSeconds
+}
+
+// GetPort returns the Port field.
+func (h *HealthCheckSpec) GetPort() int64 {
+	if h == nil {
+		return 0
+	}
+	return h.Port
+}
+
+// GetSuccessThreshold returns the SuccessThreshold field.
+func (h *HealthCheckSpec) GetSuccessThreshold() int32 {
+	if h == nil {
+		return 0
+	}
+	return h.SuccessThreshold
+}
+
+// GetTimeoutSeconds returns the TimeoutSeconds field.
+func (h *HealthCheckSpec) GetTimeoutSeconds() int32 {
+	if h == nil {
+		return 0
+	}
+	return h.TimeoutSeconds
 }
 
 // GetDeployOnPush returns the DeployOnPush field.

--- a/apps_accessors.go
+++ b/apps_accessors.go
@@ -1501,6 +1501,22 @@ func (a *AppMaintenanceSpec) GetEnabled() bool {
 	return a.Enabled
 }
 
+// GetAppID returns the AppID field.
+func (a *AppProposeRequest) GetAppID() string {
+	if a == nil {
+		return ""
+	}
+	return a.AppID
+}
+
+// GetSpec returns the Spec field.
+func (a *AppProposeRequest) GetSpec() *AppSpec {
+	if a == nil {
+		return nil
+	}
+	return a.Spec
+}
+
 // GetOfflinePageURL returns the OfflinePageURL field.
 func (a *AppMaintenanceSpec) GetOfflinePageURL() string {
 	if a == nil {
@@ -1819,14 +1835,6 @@ func (a *AppServiceSpec) GetInternalPorts() []int64 {
 		return nil
 	}
 	return a.InternalPorts
-}
-
-// GetLivenessHealthCheck returns the LivenessHealthCheck field.
-func (a *AppServiceSpec) GetLivenessHealthCheck() *HealthCheckSpec {
-	if a == nil {
-		return nil
-	}
-	return a.LivenessHealthCheck
 }
 
 // GetLogDestinations returns the LogDestinations field.
@@ -2427,14 +2435,6 @@ func (a *AppWorkerSpec) GetInstanceSizeSlug() string {
 		return ""
 	}
 	return a.InstanceSizeSlug
-}
-
-// GetLivenessHealthCheck returns the LivenessHealthCheck field.
-func (a *AppWorkerSpec) GetLivenessHealthCheck() *HealthCheckSpec {
-	if a == nil {
-		return nil
-	}
-	return a.LivenessHealthCheck
 }
 
 // GetLogDestinations returns the LogDestinations field.
@@ -3707,62 +3707,6 @@ func (g *GitSourceSpec) GetRepoCloneURL() string {
 		return ""
 	}
 	return g.RepoCloneURL
-}
-
-// GetFailureThreshold returns the FailureThreshold field.
-func (h *HealthCheckSpec) GetFailureThreshold() int32 {
-	if h == nil {
-		return 0
-	}
-	return h.FailureThreshold
-}
-
-// GetHTTPPath returns the HTTPPath field.
-func (h *HealthCheckSpec) GetHTTPPath() string {
-	if h == nil {
-		return ""
-	}
-	return h.HTTPPath
-}
-
-// GetInitialDelaySeconds returns the InitialDelaySeconds field.
-func (h *HealthCheckSpec) GetInitialDelaySeconds() int32 {
-	if h == nil {
-		return 0
-	}
-	return h.InitialDelaySeconds
-}
-
-// GetPeriodSeconds returns the PeriodSeconds field.
-func (h *HealthCheckSpec) GetPeriodSeconds() int32 {
-	if h == nil {
-		return 0
-	}
-	return h.PeriodSeconds
-}
-
-// GetPort returns the Port field.
-func (h *HealthCheckSpec) GetPort() int64 {
-	if h == nil {
-		return 0
-	}
-	return h.Port
-}
-
-// GetSuccessThreshold returns the SuccessThreshold field.
-func (h *HealthCheckSpec) GetSuccessThreshold() int32 {
-	if h == nil {
-		return 0
-	}
-	return h.SuccessThreshold
-}
-
-// GetTimeoutSeconds returns the TimeoutSeconds field.
-func (h *HealthCheckSpec) GetTimeoutSeconds() int32 {
-	if h == nil {
-		return 0
-	}
-	return h.TimeoutSeconds
 }
 
 // GetDeployOnPush returns the DeployOnPush field.

--- a/apps_accessors_test.go
+++ b/apps_accessors_test.go
@@ -160,6 +160,13 @@ func TestApp_GetUpdatedAt(tt *testing.T) {
 	a.GetUpdatedAt()
 }
 
+func TestApp_GetVPC(tt *testing.T) {
+	a := &App{}
+	a.GetVPC()
+	a = nil
+	a.GetVPC()
+}
+
 func TestAppAlert_GetComponentName(tt *testing.T) {
 	a := &AppAlert{}
 	a.GetComponentName()
@@ -909,6 +916,34 @@ func TestAppIngressSpecRuleStringMatch_GetPrefix(tt *testing.T) {
 	a.GetPrefix()
 }
 
+func TestAppInstance_GetComponentName(tt *testing.T) {
+	a := &AppInstance{}
+	a.GetComponentName()
+	a = nil
+	a.GetComponentName()
+}
+
+func TestAppInstance_GetComponentType(tt *testing.T) {
+	a := &AppInstance{}
+	a.GetComponentType()
+	a = nil
+	a.GetComponentType()
+}
+
+func TestAppInstance_GetInstanceAlias(tt *testing.T) {
+	a := &AppInstance{}
+	a.GetInstanceAlias()
+	a = nil
+	a.GetInstanceAlias()
+}
+
+func TestAppInstance_GetInstanceName(tt *testing.T) {
+	a := &AppInstance{}
+	a.GetInstanceName()
+	a = nil
+	a.GetInstanceName()
+}
+
 func TestAppInstanceSize_GetBandwidthAllowanceGib(tt *testing.T) {
 	a := &AppInstanceSize{}
 	a.GetBandwidthAllowanceGib()
@@ -942,6 +977,20 @@ func TestAppInstanceSize_GetFeaturePreview(tt *testing.T) {
 	a.GetFeaturePreview()
 	a = nil
 	a.GetFeaturePreview()
+}
+
+func TestAppInstanceSize_GetIDleUSDPerMonth(tt *testing.T) {
+	a := &AppInstanceSize{}
+	a.GetIDleUSDPerMonth()
+	a = nil
+	a.GetIDleUSDPerMonth()
+}
+
+func TestAppInstanceSize_GetIDleUSDPerSecond(tt *testing.T) {
+	a := &AppInstanceSize{}
+	a.GetIDleUSDPerSecond()
+	a = nil
+	a.GetIDleUSDPerSecond()
 }
 
 func TestAppInstanceSize_GetMemoryBytes(tt *testing.T) {
@@ -1126,6 +1175,13 @@ func TestAppJobSpec_GetRunCommand(tt *testing.T) {
 	a.GetRunCommand()
 }
 
+func TestAppJobSpec_GetSchedule(tt *testing.T) {
+	a := &AppJobSpec{}
+	a.GetSchedule()
+	a = nil
+	a.GetSchedule()
+}
+
 func TestAppJobSpec_GetSourceDir(tt *testing.T) {
 	a := &AppJobSpec{}
 	a.GetSourceDir()
@@ -1138,6 +1194,20 @@ func TestAppJobSpec_GetTermination(tt *testing.T) {
 	a.GetTermination()
 	a = nil
 	a.GetTermination()
+}
+
+func TestAppJobSpecSchedule_GetCron(tt *testing.T) {
+	a := &AppJobSpecSchedule{}
+	a.GetCron()
+	a = nil
+	a.GetCron()
+}
+
+func TestAppJobSpecSchedule_GetTimeZone(tt *testing.T) {
+	a := &AppJobSpecSchedule{}
+	a.GetTimeZone()
+	a = nil
+	a.GetTimeZone()
 }
 
 func TestAppJobSpecTermination_GetGracePeriodSeconds(tt *testing.T) {
@@ -1292,6 +1362,13 @@ func TestAppMaintenanceSpec_GetOfflinePageURL(tt *testing.T) {
 	a.GetOfflinePageURL()
 	a = nil
 	a.GetOfflinePageURL()
+}
+
+func TestAppPeeredVpcSpec_GetName(tt *testing.T) {
+	a := &AppPeeredVpcSpec{}
+	a.GetName()
+	a = nil
+	a.GetName()
 }
 
 func TestAppProposeRequest_GetAppID(tt *testing.T) {
@@ -1560,6 +1637,13 @@ func TestAppServiceSpec_GetImage(tt *testing.T) {
 	a.GetImage()
 }
 
+func TestAppServiceSpec_GetInactivitySleep(tt *testing.T) {
+	a := &AppServiceSpec{}
+	a.GetInactivitySleep()
+	a = nil
+	a.GetInactivitySleep()
+}
+
 func TestAppServiceSpec_GetInstanceCount(tt *testing.T) {
 	a := &AppServiceSpec{}
 	a.GetInstanceCount()
@@ -1579,6 +1663,13 @@ func TestAppServiceSpec_GetInternalPorts(tt *testing.T) {
 	a.GetInternalPorts()
 	a = nil
 	a.GetInternalPorts()
+}
+
+func TestAppServiceSpec_GetLivenessHealthCheck(tt *testing.T) {
+	a := &AppServiceSpec{}
+	a.GetLivenessHealthCheck()
+	a = nil
+	a.GetLivenessHealthCheck()
 }
 
 func TestAppServiceSpec_GetLogDestinations(tt *testing.T) {
@@ -1684,6 +1775,13 @@ func TestAppServiceSpecHealthCheck_GetTimeoutSeconds(tt *testing.T) {
 	a.GetTimeoutSeconds()
 	a = nil
 	a.GetTimeoutSeconds()
+}
+
+func TestAppServiceSpecInactivitySleep_GetAfterSeconds(tt *testing.T) {
+	a := &AppServiceSpecInactivitySleep{}
+	a.GetAfterSeconds()
+	a = nil
+	a.GetAfterSeconds()
 }
 
 func TestAppServiceSpecTermination_GetDrainSeconds(tt *testing.T) {
@@ -1817,6 +1915,13 @@ func TestAppSpec_GetStaticSites(tt *testing.T) {
 	a.GetStaticSites()
 	a = nil
 	a.GetStaticSites()
+}
+
+func TestAppSpec_GetVpc(tt *testing.T) {
+	a := &AppSpec{}
+	a.GetVpc()
+	a = nil
+	a.GetVpc()
 }
 
 func TestAppSpec_GetWorkers(tt *testing.T) {
@@ -2015,6 +2120,41 @@ func TestAppVariableDefinition_GetValue(tt *testing.T) {
 	a.GetValue()
 }
 
+func TestAppVPC_GetEgressIPs(tt *testing.T) {
+	a := &AppVPC{}
+	a.GetEgressIPs()
+	a = nil
+	a.GetEgressIPs()
+}
+
+func TestAppVPC_GetID(tt *testing.T) {
+	a := &AppVPC{}
+	a.GetID()
+	a = nil
+	a.GetID()
+}
+
+func TestAppVPCEgressIP_GetIP(tt *testing.T) {
+	a := &AppVPCEgressIP{}
+	a.GetIP()
+	a = nil
+	a.GetIP()
+}
+
+func TestAppVpcSpec_GetID(tt *testing.T) {
+	a := &AppVpcSpec{}
+	a.GetID()
+	a = nil
+	a.GetID()
+}
+
+func TestAppVpcSpec_GetPeeredVpcs(tt *testing.T) {
+	a := &AppVpcSpec{}
+	a.GetPeeredVpcs()
+	a = nil
+	a.GetPeeredVpcs()
+}
+
 func TestAppWorkerSpec_GetAlerts(tt *testing.T) {
 	a := &AppWorkerSpec{}
 	a.GetAlerts()
@@ -2106,6 +2246,13 @@ func TestAppWorkerSpec_GetInstanceSizeSlug(tt *testing.T) {
 	a.GetInstanceSizeSlug()
 }
 
+func TestAppWorkerSpec_GetLivenessHealthCheck(tt *testing.T) {
+	a := &AppWorkerSpec{}
+	a.GetLivenessHealthCheck()
+	a = nil
+	a.GetLivenessHealthCheck()
+}
+
 func TestAppWorkerSpec_GetLogDestinations(tt *testing.T) {
 	a := &AppWorkerSpec{}
 	a.GetLogDestinations()
@@ -2146,6 +2293,20 @@ func TestAppWorkerSpecTermination_GetGracePeriodSeconds(tt *testing.T) {
 	a.GetGracePeriodSeconds()
 	a = nil
 	a.GetGracePeriodSeconds()
+}
+
+func TestAutoscalerActionScaleChange_GetFrom(tt *testing.T) {
+	a := &AutoscalerActionScaleChange{}
+	a.GetFrom()
+	a = nil
+	a.GetFrom()
+}
+
+func TestAutoscalerActionScaleChange_GetTo(tt *testing.T) {
+	a := &AutoscalerActionScaleChange{}
+	a.GetTo()
+	a = nil
+	a.GetTo()
 }
 
 func TestBitbucketSourceSpec_GetBranch(tt *testing.T) {
@@ -2398,6 +2559,16 @@ func TestDeploymentCauseDetailsAutoscalerAction_GetAutoscaled(tt *testing.T) {
 	d.GetAutoscaled()
 	d = nil
 	d.GetAutoscaled()
+}
+
+func TestDeploymentCauseDetailsAutoscalerAction_GetScaledComponents(tt *testing.T) {
+	zeroValue := map[string]AutoscalerActionScaleChange{}
+	d := &DeploymentCauseDetailsAutoscalerAction{ScaledComponents: zeroValue}
+	d.GetScaledComponents()
+	d = &DeploymentCauseDetailsAutoscalerAction{}
+	d.GetScaledComponents()
+	d = nil
+	d.GetScaledComponents()
 }
 
 func TestDeploymentCauseDetailsDigitalOceanUser_GetEmail(tt *testing.T) {
@@ -3030,6 +3201,13 @@ func TestGetAppDatabaseConnectionDetailsResponse_GetConnectionDetails(tt *testin
 	g.GetConnectionDetails()
 }
 
+func TestGetAppInstancesResponse_GetInstances(tt *testing.T) {
+	g := &GetAppInstancesResponse{}
+	g.GetInstances()
+	g = nil
+	g.GetInstances()
+}
+
 func TestGetDatabaseConnectionDetailsResponse_GetComponentName(tt *testing.T) {
 	g := &GetDatabaseConnectionDetailsResponse{}
 	g.GetComponentName()
@@ -3212,6 +3390,55 @@ func TestGitSourceSpec_GetRepoCloneURL(tt *testing.T) {
 	g.GetRepoCloneURL()
 }
 
+func TestHealthCheckSpec_GetFailureThreshold(tt *testing.T) {
+	h := &HealthCheckSpec{}
+	h.GetFailureThreshold()
+	h = nil
+	h.GetFailureThreshold()
+}
+
+func TestHealthCheckSpec_GetHTTPPath(tt *testing.T) {
+	h := &HealthCheckSpec{}
+	h.GetHTTPPath()
+	h = nil
+	h.GetHTTPPath()
+}
+
+func TestHealthCheckSpec_GetInitialDelaySeconds(tt *testing.T) {
+	h := &HealthCheckSpec{}
+	h.GetInitialDelaySeconds()
+	h = nil
+	h.GetInitialDelaySeconds()
+}
+
+func TestHealthCheckSpec_GetPeriodSeconds(tt *testing.T) {
+	h := &HealthCheckSpec{}
+	h.GetPeriodSeconds()
+	h = nil
+	h.GetPeriodSeconds()
+}
+
+func TestHealthCheckSpec_GetPort(tt *testing.T) {
+	h := &HealthCheckSpec{}
+	h.GetPort()
+	h = nil
+	h.GetPort()
+}
+
+func TestHealthCheckSpec_GetSuccessThreshold(tt *testing.T) {
+	h := &HealthCheckSpec{}
+	h.GetSuccessThreshold()
+	h = nil
+	h.GetSuccessThreshold()
+}
+
+func TestHealthCheckSpec_GetTimeoutSeconds(tt *testing.T) {
+	h := &HealthCheckSpec{}
+	h.GetTimeoutSeconds()
+	h = nil
+	h.GetTimeoutSeconds()
+}
+
 func TestImageSourceSpec_GetDeployOnPush(tt *testing.T) {
 	i := &ImageSourceSpec{}
 	i.GetDeployOnPush()
@@ -3350,25 +3577,4 @@ func TestUpgradeBuildpackResponse_GetDeployment(tt *testing.T) {
 	u.GetDeployment()
 	u = nil
 	u.GetDeployment()
-}
-
-func TestAppInstance_GetComponentName(tt *testing.T) {
-	a := &AppInstance{}
-	a.GetComponentName()
-	a = nil
-	a.GetComponentName()
-}
-
-func TestAppInstance_GetComponentType(tt *testing.T) {
-	a := &AppInstance{}
-	a.GetComponentType()
-	a = nil
-	a.GetComponentType()
-}
-
-func TestAppInstance_GetInstanceName(tt *testing.T) {
-	a := &AppInstance{}
-	a.GetInstanceName()
-	a = nil
-	a.GetInstanceName()
 }

--- a/apps_accessors_test.go
+++ b/apps_accessors_test.go
@@ -160,13 +160,6 @@ func TestApp_GetUpdatedAt(tt *testing.T) {
 	a.GetUpdatedAt()
 }
 
-func TestApp_GetVPC(tt *testing.T) {
-	a := &App{}
-	a.GetVPC()
-	a = nil
-	a.GetVPC()
-}
-
 func TestAppAlert_GetComponentName(tt *testing.T) {
 	a := &AppAlert{}
 	a.GetComponentName()
@@ -979,20 +972,6 @@ func TestAppInstanceSize_GetFeaturePreview(tt *testing.T) {
 	a.GetFeaturePreview()
 }
 
-func TestAppInstanceSize_GetIDleUSDPerMonth(tt *testing.T) {
-	a := &AppInstanceSize{}
-	a.GetIDleUSDPerMonth()
-	a = nil
-	a.GetIDleUSDPerMonth()
-}
-
-func TestAppInstanceSize_GetIDleUSDPerSecond(tt *testing.T) {
-	a := &AppInstanceSize{}
-	a.GetIDleUSDPerSecond()
-	a = nil
-	a.GetIDleUSDPerSecond()
-}
-
 func TestAppInstanceSize_GetMemoryBytes(tt *testing.T) {
 	a := &AppInstanceSize{}
 	a.GetMemoryBytes()
@@ -1175,13 +1154,6 @@ func TestAppJobSpec_GetRunCommand(tt *testing.T) {
 	a.GetRunCommand()
 }
 
-func TestAppJobSpec_GetSchedule(tt *testing.T) {
-	a := &AppJobSpec{}
-	a.GetSchedule()
-	a = nil
-	a.GetSchedule()
-}
-
 func TestAppJobSpec_GetSourceDir(tt *testing.T) {
 	a := &AppJobSpec{}
 	a.GetSourceDir()
@@ -1194,20 +1166,6 @@ func TestAppJobSpec_GetTermination(tt *testing.T) {
 	a.GetTermination()
 	a = nil
 	a.GetTermination()
-}
-
-func TestAppJobSpecSchedule_GetCron(tt *testing.T) {
-	a := &AppJobSpecSchedule{}
-	a.GetCron()
-	a = nil
-	a.GetCron()
-}
-
-func TestAppJobSpecSchedule_GetTimeZone(tt *testing.T) {
-	a := &AppJobSpecSchedule{}
-	a.GetTimeZone()
-	a = nil
-	a.GetTimeZone()
 }
 
 func TestAppJobSpecTermination_GetGracePeriodSeconds(tt *testing.T) {
@@ -1336,6 +1294,20 @@ func TestAppLogDestinationSpecOpenSearch_GetIndexName(tt *testing.T) {
 	a.GetIndexName()
 }
 
+func TestAppProposeRequest_GetAppID(tt *testing.T) {
+	a := &AppProposeRequest{}
+	a.GetAppID()
+	a = nil
+	a.GetAppID()
+}
+
+func TestAppProposeRequest_GetSpec(tt *testing.T) {
+	a := &AppProposeRequest{}
+	a.GetSpec()
+	a = nil
+	a.GetSpec()
+}
+
 func TestAppLogDestinationSpecPapertrail_GetEndpoint(tt *testing.T) {
 	a := &AppLogDestinationSpecPapertrail{}
 	a.GetEndpoint()
@@ -1362,27 +1334,6 @@ func TestAppMaintenanceSpec_GetOfflinePageURL(tt *testing.T) {
 	a.GetOfflinePageURL()
 	a = nil
 	a.GetOfflinePageURL()
-}
-
-func TestAppPeeredVpcSpec_GetName(tt *testing.T) {
-	a := &AppPeeredVpcSpec{}
-	a.GetName()
-	a = nil
-	a.GetName()
-}
-
-func TestAppProposeRequest_GetAppID(tt *testing.T) {
-	a := &AppProposeRequest{}
-	a.GetAppID()
-	a = nil
-	a.GetAppID()
-}
-
-func TestAppProposeRequest_GetSpec(tt *testing.T) {
-	a := &AppProposeRequest{}
-	a.GetSpec()
-	a = nil
-	a.GetSpec()
 }
 
 func TestAppProposeResponse_GetAppCost(tt *testing.T) {
@@ -1637,13 +1588,6 @@ func TestAppServiceSpec_GetImage(tt *testing.T) {
 	a.GetImage()
 }
 
-func TestAppServiceSpec_GetInactivitySleep(tt *testing.T) {
-	a := &AppServiceSpec{}
-	a.GetInactivitySleep()
-	a = nil
-	a.GetInactivitySleep()
-}
-
 func TestAppServiceSpec_GetInstanceCount(tt *testing.T) {
 	a := &AppServiceSpec{}
 	a.GetInstanceCount()
@@ -1663,13 +1607,6 @@ func TestAppServiceSpec_GetInternalPorts(tt *testing.T) {
 	a.GetInternalPorts()
 	a = nil
 	a.GetInternalPorts()
-}
-
-func TestAppServiceSpec_GetLivenessHealthCheck(tt *testing.T) {
-	a := &AppServiceSpec{}
-	a.GetLivenessHealthCheck()
-	a = nil
-	a.GetLivenessHealthCheck()
 }
 
 func TestAppServiceSpec_GetLogDestinations(tt *testing.T) {
@@ -1775,13 +1712,6 @@ func TestAppServiceSpecHealthCheck_GetTimeoutSeconds(tt *testing.T) {
 	a.GetTimeoutSeconds()
 	a = nil
 	a.GetTimeoutSeconds()
-}
-
-func TestAppServiceSpecInactivitySleep_GetAfterSeconds(tt *testing.T) {
-	a := &AppServiceSpecInactivitySleep{}
-	a.GetAfterSeconds()
-	a = nil
-	a.GetAfterSeconds()
 }
 
 func TestAppServiceSpecTermination_GetDrainSeconds(tt *testing.T) {
@@ -1915,13 +1845,6 @@ func TestAppSpec_GetStaticSites(tt *testing.T) {
 	a.GetStaticSites()
 	a = nil
 	a.GetStaticSites()
-}
-
-func TestAppSpec_GetVpc(tt *testing.T) {
-	a := &AppSpec{}
-	a.GetVpc()
-	a = nil
-	a.GetVpc()
 }
 
 func TestAppSpec_GetWorkers(tt *testing.T) {
@@ -2120,41 +2043,6 @@ func TestAppVariableDefinition_GetValue(tt *testing.T) {
 	a.GetValue()
 }
 
-func TestAppVPC_GetEgressIPs(tt *testing.T) {
-	a := &AppVPC{}
-	a.GetEgressIPs()
-	a = nil
-	a.GetEgressIPs()
-}
-
-func TestAppVPC_GetID(tt *testing.T) {
-	a := &AppVPC{}
-	a.GetID()
-	a = nil
-	a.GetID()
-}
-
-func TestAppVPCEgressIP_GetIP(tt *testing.T) {
-	a := &AppVPCEgressIP{}
-	a.GetIP()
-	a = nil
-	a.GetIP()
-}
-
-func TestAppVpcSpec_GetID(tt *testing.T) {
-	a := &AppVpcSpec{}
-	a.GetID()
-	a = nil
-	a.GetID()
-}
-
-func TestAppVpcSpec_GetPeeredVpcs(tt *testing.T) {
-	a := &AppVpcSpec{}
-	a.GetPeeredVpcs()
-	a = nil
-	a.GetPeeredVpcs()
-}
-
 func TestAppWorkerSpec_GetAlerts(tt *testing.T) {
 	a := &AppWorkerSpec{}
 	a.GetAlerts()
@@ -2246,13 +2134,6 @@ func TestAppWorkerSpec_GetInstanceSizeSlug(tt *testing.T) {
 	a.GetInstanceSizeSlug()
 }
 
-func TestAppWorkerSpec_GetLivenessHealthCheck(tt *testing.T) {
-	a := &AppWorkerSpec{}
-	a.GetLivenessHealthCheck()
-	a = nil
-	a.GetLivenessHealthCheck()
-}
-
 func TestAppWorkerSpec_GetLogDestinations(tt *testing.T) {
 	a := &AppWorkerSpec{}
 	a.GetLogDestinations()
@@ -2293,20 +2174,6 @@ func TestAppWorkerSpecTermination_GetGracePeriodSeconds(tt *testing.T) {
 	a.GetGracePeriodSeconds()
 	a = nil
 	a.GetGracePeriodSeconds()
-}
-
-func TestAutoscalerActionScaleChange_GetFrom(tt *testing.T) {
-	a := &AutoscalerActionScaleChange{}
-	a.GetFrom()
-	a = nil
-	a.GetFrom()
-}
-
-func TestAutoscalerActionScaleChange_GetTo(tt *testing.T) {
-	a := &AutoscalerActionScaleChange{}
-	a.GetTo()
-	a = nil
-	a.GetTo()
 }
 
 func TestBitbucketSourceSpec_GetBranch(tt *testing.T) {
@@ -2559,16 +2426,6 @@ func TestDeploymentCauseDetailsAutoscalerAction_GetAutoscaled(tt *testing.T) {
 	d.GetAutoscaled()
 	d = nil
 	d.GetAutoscaled()
-}
-
-func TestDeploymentCauseDetailsAutoscalerAction_GetScaledComponents(tt *testing.T) {
-	zeroValue := map[string]AutoscalerActionScaleChange{}
-	d := &DeploymentCauseDetailsAutoscalerAction{ScaledComponents: zeroValue}
-	d.GetScaledComponents()
-	d = &DeploymentCauseDetailsAutoscalerAction{}
-	d.GetScaledComponents()
-	d = nil
-	d.GetScaledComponents()
 }
 
 func TestDeploymentCauseDetailsDigitalOceanUser_GetEmail(tt *testing.T) {
@@ -3388,41 +3245,6 @@ func TestGitSourceSpec_GetRepoCloneURL(tt *testing.T) {
 	g.GetRepoCloneURL()
 	g = nil
 	g.GetRepoCloneURL()
-}
-
-func TestHealthCheckSpec_GetFailureThreshold(tt *testing.T) {
-	h := &HealthCheckSpec{}
-	h.GetFailureThreshold()
-	h = nil
-	h.GetFailureThreshold()
-}
-
-func TestHealthCheckSpec_GetHTTPPath(tt *testing.T) {
-	h := &HealthCheckSpec{}
-	h.GetHTTPPath()
-	h = nil
-	h.GetHTTPPath()
-}
-
-func TestHealthCheckSpec_GetInitialDelaySeconds(tt *testing.T) {
-	h := &HealthCheckSpec{}
-	h.GetInitialDelaySeconds()
-	h = nil
-	h.GetInitialDelaySeconds()
-}
-
-func TestHealthCheckSpec_GetPeriodSeconds(tt *testing.T) {
-	h := &HealthCheckSpec{}
-	h.GetPeriodSeconds()
-	h = nil
-	h.GetPeriodSeconds()
-}
-
-func TestHealthCheckSpec_GetPort(tt *testing.T) {
-	h := &HealthCheckSpec{}
-	h.GetPort()
-	h = nil
-	h.GetPort()
 }
 
 func TestHealthCheckSpec_GetSuccessThreshold(tt *testing.T) {

--- a/apps_accessors_test.go
+++ b/apps_accessors_test.go
@@ -3247,20 +3247,6 @@ func TestGitSourceSpec_GetRepoCloneURL(tt *testing.T) {
 	g.GetRepoCloneURL()
 }
 
-func TestHealthCheckSpec_GetSuccessThreshold(tt *testing.T) {
-	h := &HealthCheckSpec{}
-	h.GetSuccessThreshold()
-	h = nil
-	h.GetSuccessThreshold()
-}
-
-func TestHealthCheckSpec_GetTimeoutSeconds(tt *testing.T) {
-	h := &HealthCheckSpec{}
-	h.GetTimeoutSeconds()
-	h = nil
-	h.GetTimeoutSeconds()
-}
-
 func TestImageSourceSpec_GetDeployOnPush(tt *testing.T) {
 	i := &ImageSourceSpec{}
 	i.GetDeployOnPush()


### PR DESCRIPTION
This PR exposes `instance_alias` name for `AppInstances` response from `/apps/{app_id}/instances`. Reference: https://docs.digitalocean.com/reference/api/digitalocean/#tag/Apps/operation/apps_get_instances