### PR TITLE
Databases: Add mongo_user_settings

### DIFF
--- a/databases.go
+++ b/databases.go
@@ -272,10 +272,17 @@ type OpenSearchACL struct {
 	Index      string `json:"index,omitempty"`
 }
 
+// MongoUserSettings represents additional settings for MongoDB users.
+type MongoUserSettings struct {
+	Databases []string `json:"databases,omitempty"`
+	Role      string   `json:"role,omitempty"`
+}
+
 // DatabaseUserSettings contains user settings
 type DatabaseUserSettings struct {
-	ACL           []*KafkaACL      `json:"acl,omitempty"`
-	OpenSearchACL []*OpenSearchACL `json:"opensearch_acl,omitempty"`
+	ACL               []*KafkaACL        `json:"acl,omitempty"`
+	OpenSearchACL     []*OpenSearchACL   `json:"opensearch_acl,omitempty"`
+	MongoUserSettings *MongoUserSettings `json:"mongo_user_settings,omitempty"`
 }
 
 // DatabaseMySQLUserSettings contains MySQL-specific user settings

--- a/databases_test.go
+++ b/databases_test.go
@@ -4346,7 +4346,7 @@ func TestDatabases_CreateDatabaseUserWithMongoUserSettings(t *testing.T) {
 
 	user, _, err := client.Databases.CreateUser(ctx, dbID, &DatabaseCreateUserRequest{
 		Name:     expectedUser.Name,
-		Settings: &DatabaseUserSettings{OpenSearchACL: expectedUser.Settings.OpenSearchACL},
+		Settings: &DatabaseUserSettings{MongoUserSettings: expectedUser.Settings.MongoUserSettings},
 	})
 	require.NoError(t, err)
 	require.Equal(t, expectedUser, user)


### PR DESCRIPTION
Updated godo to eventually update terraform-provider-digitalocean to address 
[terraform issue](https://github.com/digitalocean/terraform-provider-digitalocean/issues/1380)

```
Running tool: /opt/homebrew/bin/go test -timeout 30s -run ^TestDatabases_CreateDatabaseUserWithMongoUserSettings$ github.com/digitalocean/godo

ok  	github.com/digitalocean/godo	(cached)
```

