### PR TITLE
Adding endpoints for FunctionRoute to Agent for GenAI Service

### DIFF
--- a/genai.go
+++ b/genai.go
@@ -2,6 +2,7 @@ package godo
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -11,12 +12,15 @@ const (
 	genAIBasePath                = "/v2/gen-ai/agents"
 	agentModelBasePath           = "/v2/gen-ai/models"
 	KnowledgeBasePath            = "/v2/gen-ai/knowledge_bases"
+	functionRouteBasePath        = genAIBasePath + "/%s/functions"
 	KnowledgeBaseDataSourcesPath = KnowledgeBasePath + "/%s/data_sources"
 	GetKnowledgeBaseByIDPath     = KnowledgeBasePath + "/%s"
 	UpdateKnowledgeBaseByIDPath  = KnowledgeBasePath + "/%s"
 	DeleteKnowledgeBaseByIDPath  = KnowledgeBasePath + "/%s"
 	AgentKnowledgeBasePath       = "/v2/gen-ai/agents" + "/%s/knowledge_bases/%s"
 	DeleteDataSourcePath         = KnowledgeBasePath + "/%s/data_sources/%s"
+	UpdateFunctionRoutePath      = functionRouteBasePath + "/%s"
+	DeleteFunctionRoutePath      = functionRouteBasePath + "/%s"
 )
 
 // GenAIService is an interface for interfacing with the Gen AI Agent endpoints
@@ -45,6 +49,9 @@ type GenAIService interface {
 	DeleteKnowledgeBase(ctx context.Context, knowledgeBaseID string) (string, *Response, error)
 	AttachKnowledgeBaseToAgent(ctx context.Context, agentID string, knowledgeBaseID string) (*Agent, *Response, error)
 	DetachKnowledgeBaseToAgent(ctx context.Context, agentID string, knowledgeBaseID string) (*Agent, *Response, error)
+	CreateFunctionRoute(context.Context, string, *FunctionRouteCreateRequest) (*Agent, *Response, error)
+	DeleteFunctionRoute(context.Context, string, string) (*Agent, *Response, error)
+	UpdateFunctionRoute(context.Context, string, string, *FunctionRouteUpdateRequest) (*Agent, *Response, error)
 }
 
 var _ GenAIService = &GenAIServiceOp{}
@@ -437,6 +444,44 @@ type UpdateKnowledgeBaseRequest struct {
 
 type genAIAgentKBRoot struct {
 	Agent *Agent `json:"agent"`
+}
+type NestedSchema struct {
+	Type        string                   `json:"type" validate:"required,oneof=string boolean number integer array object"`
+	Items       *NestedSchema            `json:"items,omitempty"`
+	Properties  map[string]*NestedSchema `json:"properties,omitempty"`
+	Enum        []string                 `json:"enum,omitempty"`
+	Description string                   `json:"description,omitempty"`
+}
+
+type OpenAPIParameterSchema struct {
+	Name        string       `json:"name" validate:"required"`
+	In          string       `json:"in" validate:"omitempty,oneof=query header path cookie"`
+	Schema      NestedSchema `json:"schema" validate:"required"`
+	Description string       `json:"description,omitempty"`
+	Required    bool         `json:"required,omitempty"`
+}
+type FunctionInputSchema struct {
+	Parameters []OpenAPIParameterSchema `json:"parameters" validate:"required,min=1,dive"`
+}
+type FunctionRouteCreateRequest struct {
+	AgentUuid     string              `json:"agent_uuid,omitempty"`
+	Description   string              `json:"description,omitempty"`
+	FaasName      string              `json:"faas_name,omitempty"`
+	FaasNamespace string              `json:"faas_namespace,omitempty"`
+	FunctionName  string              `json:"function_name,omitempty"`
+	InputSchema   FunctionInputSchema `json:"input_schema,omitempty"`
+	OutputSchema  json.RawMessage     `json:"output_schema,omitempty"`
+}
+
+type FunctionRouteUpdateRequest struct {
+	AgentUuid     string              `json:"agent_uuid,omitempty"`
+	Description   string              `json:"description,omitempty"`
+	FaasName      string              `json:"faas_name,omitempty"`
+	FaasNamespace string              `json:"faas_namespace,omitempty"`
+	FunctionName  string              `json:"function_name,omitempty"`
+	FunctionUuid  string              `json:"function_uuid,omitempty"`
+	InputSchema   FunctionInputSchema `json:"input_schema,omitempty"`
+	OutputSchema  json.RawMessage     `json:"output_schema,omitempty"`
 }
 
 // ListAgents returns a list of Gen AI Agents
@@ -904,6 +949,80 @@ func (s *GenAIServiceOp) DetachKnowledgeBaseToAgent(ctx context.Context, agentID
 	if err != nil {
 		return nil, resp, err
 	}
+	return root.Agent, resp, nil
+}
+
+// Attaches a functionroute to an agent.
+func (g *GenAIServiceOp) CreateFunctionRoute(ctx context.Context, id string, create *FunctionRouteCreateRequest) (*Agent, *Response, error) {
+	path := fmt.Sprintf(functionRouteBasePath, id)
+
+	if create.AgentUuid == "" {
+		return nil, nil, fmt.Errorf("AgentUuid is required")
+	}
+	if create.Description == "" {
+		return nil, nil, fmt.Errorf("Description is required")
+	}
+	if create.FaasName == "" {
+		return nil, nil, fmt.Errorf("FaasName is required")
+	}
+	if create.FaasNamespace == "" {
+		return nil, nil, fmt.Errorf("FaasNamespace is required")
+	}
+	if create.FunctionName == "" {
+		return nil, nil, fmt.Errorf("FunctionName is required")
+	}
+	if len(create.InputSchema.Parameters) == 0 {
+		return nil, nil, fmt.Errorf("InputSchema is required")
+	}
+
+	req, err := g.client.NewRequest(ctx, http.MethodPost, path, create)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(genAIAgentRoot)
+	resp, err := g.client.Do(ctx, req, root)
+
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Agent, resp, nil
+}
+
+// Deletes a functionroute to an agent.
+func (g *GenAIServiceOp) DeleteFunctionRoute(ctx context.Context, agent_id string, function_id string) (*Agent, *Response, error) {
+	path := fmt.Sprintf(UpdateFunctionRoutePath, agent_id, function_id)
+	req, err := g.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(genAIAgentRoot)
+	resp, err := g.client.Do(ctx, req, root)
+
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Agent, resp, nil
+}
+
+// Updates a functionroute to an agent.
+func (g *GenAIServiceOp) UpdateFunctionRoute(ctx context.Context, agent_id string, function_id string, update *FunctionRouteUpdateRequest) (*Agent, *Response, error) {
+	path := fmt.Sprintf(UpdateFunctionRoutePath, agent_id, function_id)
+	req, err := g.client.NewRequest(ctx, http.MethodPut, path, update)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(genAIAgentRoot)
+	resp, err := g.client.Do(ctx, req, root)
+
+	if err != nil {
+		return nil, resp, err
+	}
+
 	return root.Agent, resp, nil
 }
 

--- a/genai_test.go
+++ b/genai_test.go
@@ -127,6 +127,19 @@ var agentResponse = `
 		"updated_at": "2025-05-14T13:18:05Z",
 		"instruction": "You are an agent who thinks deeply about the world",
 		"description": "My Agent Description",
+		"functions": [
+		{
+			"uuid": "00000000-0000-0000-0000-000000000000",
+			"name": "godo-test-function",
+			"description": "My Agent Description",
+			"input_schema": "{}",
+			"output_schema": "{}",
+			"api_key":"",
+			"created_at": "2025-01-13T20:56:20Z",
+			"updated_at": "2025-05-13T15:16:21Z"
+
+		}
+		],
 		"model": {
 			"uuid": "00000000-0000-0000-0000-000000000000",
 			"name": "Llama 3.3 Instruct (70B)",
@@ -1017,5 +1030,141 @@ func TestDetachKnowledgeBase(t *testing.T) {
 	}
 
 	assert.Equal(t, "testing-godo", res.Name)
+	assert.Equal(t, 200, resp.Response.StatusCode)
+}
+
+func TestCreateFunctionRoute(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/gen-ai/agents/00000000-0000-0000-0000-000000000000/functions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		fmt.Fprint(w, agentResponse)
+	})
+
+	req := &FunctionRouteCreateRequest{
+		Description:   "Creating Function Route",
+		AgentUuid:     "00000000-0000-0000-0000-000000000000",
+		FaasName:      "godo-test-faasname",
+		FaasNamespace: "fn-00000000-0000-0000-0000-000000000000",
+		InputSchema: FunctionInputSchema{
+			Parameters: []OpenAPIParameterSchema{
+				{
+					Name: "zipCode",
+					In:   "query",
+					Schema: NestedSchema{
+						Type: "string",
+					},
+					Required:    false,
+					Description: "The ZIP code for which to fetch the weather",
+				},
+				{
+					Name: "measurement",
+					In:   "query",
+					Schema: NestedSchema{
+						Type: "string",
+						Enum: []string{"F", "C"},
+					},
+					Required:    false,
+					Description: "The measurement unit for temperature (F or C)",
+				},
+			},
+		},
+		FunctionName: "godo-test-function",
+		OutputSchema: json.RawMessage(`{
+  "properties": [
+    {
+      "name": "temperature",
+      "type": "number",
+      "description": "The temperature for the specified location"
+    },
+    {
+      "name": "measurement",
+      "type": "string",
+      "description": "The measurement unit used for the temperature (F or C)"
+    },
+    {
+      "name": "conditions",
+      "type": "string",
+      "description": "A description of the current weather conditions (Sunny, Cloudy, etc)"
+    }
+  ]
+}`),
+	}
+
+	agent, res, err := client.GenAI.CreateFunctionRoute(ctx, "00000000-0000-0000-0000-000000000000", req)
+	if err != nil {
+		t.Errorf("GenAI.Create returned error: %v", err)
+	}
+
+	assert.NoError(t, err)
+	assert.Equal(t, 200, res.Response.StatusCode)
+	t.Log(agent)
+	assert.Equal(t, req.FunctionName, agent.Functions[0].Name)
+}
+
+func TestUpdateFunctionRoute(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/gen-ai/agents/00000000-0000-0000-0000-000000000000/functions/00000000-0000-0000-0000-000000000000", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPut)
+		fmt.Fprint(w, agentResponse)
+	})
+
+	req := &FunctionRouteUpdateRequest{
+		Description: "My Agent Description",
+		InputSchema: FunctionInputSchema{
+			Parameters: []OpenAPIParameterSchema{
+				{
+					Name: "zipCode",
+					In:   "query",
+					Schema: NestedSchema{
+						Type: "string",
+					},
+					Required:    false,
+					Description: "The ZIP code for which to fetch the weather",
+				},
+				{
+					Name: "measurement",
+					In:   "query",
+					Schema: NestedSchema{
+						Type: "string",
+						Enum: []string{"F", "C"},
+					},
+					Required:    false,
+					Description: "The measurement unit for temperature (F or C)",
+				},
+			},
+		},
+		OutputSchema: json.RawMessage(`{
+            "properties": [
+                {
+                    "name": "temperature",
+                    "type": "number",
+                    "description": "The temperature for the specified location"
+                }
+            ]
+        }`),
+	}
+
+	agent, resp, err := client.GenAI.UpdateFunctionRoute(ctx, "00000000-0000-0000-0000-000000000000", "00000000-0000-0000-0000-000000000000", req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.Response.StatusCode)
+	assert.Equal(t, req.Description, agent.Functions[0].Description)
+}
+
+func TestDeleteFunctionRoute(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/gen-ai/agents/00000000-0000-0000-0000-000000000000/functions/00000000-0000-0000-0000-000000000000", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{}`)
+	})
+
+	_, resp, err := client.GenAI.DeleteFunctionRoute(ctx, "00000000-0000-0000-0000-000000000000", "00000000-0000-0000-0000-000000000000")
+	assert.NoError(t, err)
 	assert.Equal(t, 200, resp.Response.StatusCode)
 }


### PR DESCRIPTION
Implemented methods for FunctionRoute endpoints for the GenAI Service


[Add Function Route to an Agent](https://docs.digitalocean.com/reference/api/digitalocean/#tag/GenAI-Platform-(Public-Preview)/operation/genai_attach_agent_function)
[Delete/Detach Function Route from an Agent](https://docs.digitalocean.com/reference/api/digitalocean/#tag/GenAI-Platform-(Public-Preview)/operation/genai_detach_agent_function)
[Update Function Route to an Agent](https://docs.digitalocean.com/reference/api/digitalocean/#tag/GenAI-Platform-(Public-Preview)/operation/genai_update_agent_function)
