### PR TITLE
[APICLI-2889] removed SET partner routes for partner attachment

### DIFF
--- a/partner_network_connect.go
+++ b/partner_network_connect.go
@@ -20,7 +20,6 @@ type PartnerAttachmentService interface {
 	Update(context.Context, string, *PartnerAttachmentUpdateRequest) (*PartnerAttachment, *Response, error)
 	Delete(context.Context, string) (*Response, error)
 	GetServiceKey(context.Context, string) (*ServiceKey, *Response, error)
-	SetRoutes(context.Context, string, *PartnerAttachmentSetRoutesRequest) (*PartnerAttachment, *Response, error)
 	ListRoutes(context.Context, string, *ListOptions) ([]*RemoteRoute, *Response, error)
 	GetBGPAuthKey(ctx context.Context, iaID string) (*BgpAuthKey, *Response, error)
 	RegenerateServiceKey(ctx context.Context, iaID string) (*RegenerateServiceKey, *Response, error)
@@ -102,11 +101,6 @@ type PartnerAttachmentUpdateRequest struct {
 	Name string `json:"name,omitempty"`
 	//VPCIDs is the IDs of the VPCs to which the Partner Attachment is connected to
 	VPCIDs []string `json:"vpc_ids,omitempty"`
-}
-
-type PartnerAttachmentSetRoutesRequest struct {
-	// Routes is the list of routes to be used for the Partner Attachment
-	Routes []string `json:"routes,omitempty"`
 }
 
 // BGP represents the BGP configuration of a Partner Attachment.
@@ -378,23 +372,6 @@ func (s *PartnerAttachmentServiceOp) ListRoutes(ctx context.Context, id string, 
 	}
 
 	return root.RemoteRoutes, resp, nil
-}
-
-// SetRoutes updates specific properties of a Partner Attachment.
-func (s *PartnerAttachmentServiceOp) SetRoutes(ctx context.Context, id string, set *PartnerAttachmentSetRoutesRequest) (*PartnerAttachment, *Response, error) {
-	path := fmt.Sprintf("%s/%s/remote_routes", partnerNetworkConnectBasePath, id)
-	req, err := s.client.NewRequest(ctx, http.MethodPut, path, set)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	root := new(partnerNetworkConnectAttachmentRoot)
-	resp, err := s.client.Do(ctx, req, root)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return root.PartnerAttachment, resp, nil
 }
 
 // GetBGPAuthKey returns Partner Attachment bgp auth key

--- a/partner_network_connect_test.go
+++ b/partner_network_connect_test.go
@@ -532,56 +532,6 @@ func TestPartnerAttachment_ListRoutes(t *testing.T) {
 	assert.Equal(t, resp.Meta, meta)
 }
 
-func TestPartnerAttachment_Set(t *testing.T) {
-	tests := []struct {
-		desc                        string
-		id                          string
-		req                         *PartnerAttachmentSetRoutesRequest
-		mockResponse                string
-		expectedRequestBody         string
-		expectedUpdatedInterconnect *PartnerAttachment
-	}{
-		{
-			desc: "set remote routes",
-			id:   "880b7f98-f062-404d-b33c-458d545696f6",
-			req: &PartnerAttachmentSetRoutesRequest{
-				Routes: []string{"169.250.0.1/29", "169.250.0.6/29"},
-			},
-			mockResponse: `
-{
-	"partner_attachment":
-` + vPartnerAttachmentTestJSON + `
-}
-			`,
-			expectedRequestBody:         `{"routes":["169.250.0.1/29", "169.250.0.6/29"]}`,
-			expectedUpdatedInterconnect: vPartnerAttachmentTestObj,
-		},
-	}
-
-	for _, tt := range tests {
-		setup()
-
-		mux.HandleFunc("/v2/partner_network_connect/attachments/"+tt.id+"/remote_routes", func(w http.ResponseWriter, r *http.Request) {
-			v := new(PartnerAttachmentSetRoutesRequest)
-			err := json.NewDecoder(r.Body).Decode(v)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			testMethod(t, r, http.MethodPut)
-			require.Equal(t, v, tt.req)
-			w.Write([]byte(tt.mockResponse))
-		})
-
-		got, _, err := client.PartnerAttachment.SetRoutes(ctx, tt.id, tt.req)
-
-		teardown()
-
-		require.NoError(t, err)
-		require.Equal(t, tt.expectedUpdatedInterconnect, got)
-	}
-}
-
 func TestPartnerAttachment_GetBGPAuthKey(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
The endpoint SET partner routes has been deprecated.
It was removed from openapi in the PR -  https://github.com/digitalocean/openapi/pull/1066 .
In this PR, I am removing the endpoint from godo repo as well.