### PR TITLE
Added support for Valkey Configuration

### DIFF
--- a/databases.go
+++ b/databases.go
@@ -154,12 +154,14 @@ type DatabasesService interface {
 	UpdateFirewallRules(context.Context, string, *DatabaseUpdateFirewallRulesRequest) (*Response, error)
 	GetPostgreSQLConfig(context.Context, string) (*PostgreSQLConfig, *Response, error)
 	GetRedisConfig(context.Context, string) (*RedisConfig, *Response, error)
+	GetValkeyConfig(context.Context, string) (*ValkeyConfig, *Response, error)
 	GetMySQLConfig(context.Context, string) (*MySQLConfig, *Response, error)
 	GetMongoDBConfig(context.Context, string) (*MongoDBConfig, *Response, error)
 	GetOpensearchConfig(context.Context, string) (*OpensearchConfig, *Response, error)
 	GetKafkaConfig(context.Context, string) (*KafkaConfig, *Response, error)
 	UpdatePostgreSQLConfig(context.Context, string, *PostgreSQLConfig) (*Response, error)
 	UpdateRedisConfig(context.Context, string, *RedisConfig) (*Response, error)
+	UpdateValkeyConfig(context.Context, string, *ValkeyConfig) (*Response, error)
 	UpdateMySQLConfig(context.Context, string, *MySQLConfig) (*Response, error)
 	UpdateMongoDBConfig(context.Context, string, *MongoDBConfig) (*Response, error)
 	UpdateOpensearchConfig(context.Context, string, *OpensearchConfig) (*Response, error)
@@ -670,6 +672,21 @@ type RedisConfig struct {
 	RedisACLChannelsDefault            *string `json:"redis_acl_channels_default,omitempty"`
 }
 
+// ValkeyConfig holds advanced configurations for Valkey database clusters.
+type ValkeyConfig struct {
+	ValkeyMaxmemoryPolicy      *string `json:"valkey_maxmemory_policy,omitempty"`
+	ValkeyIOThreads            *int    `json:"valkey_io_threads,omitempty"`
+	ValkeyLFULogFactor         *int    `json:"valkey_lfu_log_factor,omitempty"`
+	ValkeyLFUDecayTime         *int    `json:"valkey_lfu_decay_time,omitempty"`
+	ValkeySSL                  *bool   `json:"valkey_ssl,omitempty"`
+	ValkeyTimeout              *int    `json:"valkey_timeout,omitempty"`
+	ValkeyNotifyKeyspaceEvents *string `json:"valkey_notify_keyspace_events,omitempty"`
+	ValkeyPersistence          *string `json:"valkey_persistence,omitempty"`
+	ValkeyACLChannelsDefault   *string `json:"valkey_acl_channels_default,omitempty"`
+	FrequentSnapshots          *bool   `json:"frequent_snapshots,omitempty"`
+	ValkeyActiveExpireEffort   *int    `json:"valkey_active_expire_effort,omitempty"`
+}
+
 // MySQLConfig holds advanced configurations for MySQL database clusters.
 type MySQLConfig struct {
 	ConnectTimeout               *int     `json:"connect_timeout,omitempty"`
@@ -816,6 +833,10 @@ type databaseRedisConfigRoot struct {
 	Config *RedisConfig `json:"config"`
 }
 
+type databaseValkeyConfigRoot struct {
+	Config *ValkeyConfig `json:"config"`
+}
+
 type databaseMySQLConfigRoot struct {
 	Config *MySQLConfig `json:"config"`
 }
@@ -904,9 +925,9 @@ type DatabaseOptions struct {
 	MySQLOptions       DatabaseEngineOptions `json:"mysql"`
 	PostgresSQLOptions DatabaseEngineOptions `json:"pg"`
 	RedisOptions       DatabaseEngineOptions `json:"redis"`
+	ValkeyOptions      DatabaseEngineOptions `json:"valkey"`
 	KafkaOptions       DatabaseEngineOptions `json:"kafka"`
 	OpensearchOptions  DatabaseEngineOptions `json:"opensearch"`
-	ValkeyOptions      DatabaseEngineOptions `json:"valkey"`
 }
 
 // DatabaseEngineOptions represents the configuration options that are available for a given database engine
@@ -1612,6 +1633,38 @@ func (svc *DatabasesServiceOp) UpdateRedisConfig(ctx context.Context, databaseID
 	return resp, nil
 }
 
+// GetValkeyConfig updates the config for a Valkey database cluster.
+func (svc *DatabasesServiceOp) GetValkeyConfig(ctx context.Context, databaseID string) (*ValkeyConfig, *Response, error) {
+	path := fmt.Sprintf(databaseConfigPath, databaseID)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(databaseValkeyConfigRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Config, resp, nil
+}
+
+// UpdateValkeyConfig updates the config for a Valkey database cluster.
+func (svc *DatabasesServiceOp) UpdateValkeyConfig(ctx context.Context, databaseID string, config *ValkeyConfig) (*Response, error) {
+	path := fmt.Sprintf(databaseConfigPath, databaseID)
+	root := &databaseValkeyConfigRoot{
+		Config: config,
+	}
+	req, err := svc.client.NewRequest(ctx, http.MethodPatch, path, root)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := svc.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}
+
 // GetMySQLConfig retrieves the config for a MySQL database cluster.
 func (svc *DatabasesServiceOp) GetMySQLConfig(ctx context.Context, databaseID string) (*MySQLConfig, *Response, error) {
 	path := fmt.Sprintf(databaseConfigPath, databaseID)
@@ -2013,7 +2066,7 @@ func (svc *DatabasesServiceOp) DeleteLogsink(ctx context.Context, databaseID, lo
 }
 
 // StartOnlineMigration starts an online migration for a database. Migrating a cluster establishes a connection with an existing cluster
-// and replicates its contents to the target cluster. Online migration is only available for MySQL, PostgreSQL, and Redis clusters.
+// and replicates its contents to the target cluster. Online migration is only available for MySQL, PostgreSQL, Redis and Valkey clusters.
 func (svc *DatabasesServiceOp) StartOnlineMigration(ctx context.Context, databaseID string, onlineMigration *DatabaseStartOnlineMigrationRequest) (*DatabaseOnlineMigrationStatus, *Response, error) {
 	path := fmt.Sprintf(databaseOnlineMigrationsPath, databaseID)
 	req, err := svc.client.NewRequest(ctx, http.MethodPut, path, onlineMigration)

--- a/databases_test.go
+++ b/databases_test.go
@@ -3072,6 +3072,83 @@ func TestDatabases_UpdateConfigRedisNormalizeEvictionPolicy(t *testing.T) {
 	}
 }
 
+func TestDatabases_GetConfigValkey(t *testing.T) {
+	setup()
+	defer teardown()
+
+	var (
+		dbSvc = client.Databases
+		dbID  = "da4e0206-d019-41d7-b51f-deadbeefbb8f"
+		path  = fmt.Sprintf("/v2/databases/%s/config", dbID)
+
+		valkeyConfigJSON = `{
+  "config": {
+	"valkey_maxmemory_policy": "allkeys-lru",
+	"valkey_lfu_log_factor": 10,
+	"valkey_lfu_decay_time": 1,
+	"valkey_ssl": true,
+	"valkey_timeout": 300,
+	"valkey_notify_keyspace_events": "",
+	"valkey_persistence": "off",
+	"valkey_acl_channels_default": "allchannels"
+  }
+}`
+
+		valkeyConfig = ValkeyConfig{
+			ValkeyMaxmemoryPolicy:      PtrTo("allkeys-lru"),
+			ValkeyLFULogFactor:         PtrTo(10),
+			ValkeyLFUDecayTime:         PtrTo(1),
+			ValkeySSL:                  PtrTo(true),
+			ValkeyTimeout:              PtrTo(300),
+			ValkeyNotifyKeyspaceEvents: PtrTo(""),
+			ValkeyPersistence:          PtrTo("off"),
+			ValkeyACLChannelsDefault:   PtrTo("allchannels"),
+		}
+	)
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, valkeyConfigJSON)
+	})
+
+	got, _, err := dbSvc.GetValkeyConfig(ctx, dbID)
+	require.NoError(t, err)
+	require.Equal(t, &valkeyConfig, got)
+}
+
+func TestDatabases_UpdateConfigValkey(t *testing.T) {
+	setup()
+	defer teardown()
+
+	var (
+		dbID         = "deadbeef-dead-4aa5-beef-deadbeef347d"
+		path         = fmt.Sprintf("/v2/databases/%s/config", dbID)
+		valkeyConfig = &ValkeyConfig{
+			ValkeyMaxmemoryPolicy:      PtrTo("allkeys-lru"),
+			ValkeyLFULogFactor:         PtrTo(10),
+			ValkeyNotifyKeyspaceEvents: PtrTo(""),
+		}
+	)
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+
+		var b databaseValkeyConfigRoot
+		decoder := json.NewDecoder(r.Body)
+		err := decoder.Decode(&b)
+		require.NoError(t, err)
+
+		assert.Equal(t, b.Config, valkeyConfig)
+		assert.Equal(t, "", *b.Config.ValkeyNotifyKeyspaceEvents, "pointers to zero value should be sent")
+		assert.Nil(t, b.Config.ValkeyPersistence, "excluded value should not be sent")
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	_, err := client.Databases.UpdateValkeyConfig(ctx, dbID, valkeyConfig)
+	require.NoError(t, err)
+}
+
 func TestDatabases_GetConfigMySQL(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
Added methods to get and update Valkey database configuration

Test :

**Get Cluster Configuration:**

```go
package main

import (
    "context"
    "encoding/json"
    "fmt"
    "log"

    "github.com/digitalocean/godo"
)

func main() {
    token := "DO_Token"
    client := godo.NewFromToken(token)
    ctx := context.TODO()

    valkeyDatabaseID := "Cluster_ID"

    config, resp, err := client.Databases.GetValkeyConfig(ctx, valkeyDatabaseID)
    if err != nil {
        log.Fatalf("Failed to get Valkey config: %v\nResponse: %+v", err, resp)
    }

    fmt.Println("Valkey Config:")
    b, _ := json.MarshalIndent(config, "", "  ")
    fmt.Println(string(b))
}
```
**Update Cluster Configuration:**

```go
package main

import (
    "context"
    "encoding/json"
    "fmt"
    "log"

    "github.com/digitalocean/godo"
)

func main() {
    token := "DO_Token"
    client := godo.NewFromToken(token)
    ctx := context.TODO()

    valkeyDatabaseID := "Cluster_ID"

    // Get current config
    config, resp, err := client.Databases.GetValkeyConfig(ctx, valkeyDatabaseID)
    if err != nil {
        log.Fatalf("Failed to get Valkey config: %v\nResponse: %+v", err, resp)
    }

    // Example: Update a config value (e.g., ValkeyTimeout)
    if config.ValkeyTimeout != nil {
        *config.ValkeyTimeout = 3700
    } else {
        timeout := 3700
        config.ValkeyTimeout = &timeout
    }

    updatedConfig, err := client.Databases.UpdateValkeyConfig(ctx, valkeyDatabaseID, config)
    if err != nil {
        log.Fatalf("Failed to update Valkey config: %v", err)
    }

    fmt.Println("Updated Valkey Config:")
    b, _ := json.MarshalIndent(updatedConfig, "", "  ")
    fmt.Println(string(b))
}
```

