### PR TITLE
List remote route | removed id field from remote route

### DIFF
--- a/partner_network_connect.go
+++ b/partner_network_connect.go
@@ -169,8 +169,6 @@ type ServiceKey struct {
 
 // RemoteRoute represents a route for a Partner Attachment.
 type RemoteRoute struct {
-	// ID is the generated ID of the Route
-	ID string `json:"id,omitempty"`
 	// Cidr is the CIDR of the route
 	Cidr string `json:"cidr,omitempty"`
 }

--- a/partner_network_connect_test.go
+++ b/partner_network_connect_test.go
@@ -491,7 +491,6 @@ func TestPartnerAttachment_ListRoutes(t *testing.T) {
 	path := "/v2/partner_network_connect/attachments"
 	want := []*RemoteRoute{
 		{
-			ID:   "a0eb6eb0-fa38-41a8-a5de-1a75524667fe",
 			Cidr: "169.250.0.0/29",
 		},
 	}
@@ -508,7 +507,7 @@ func TestPartnerAttachment_ListRoutes(t *testing.T) {
 	jsonBlob := `
 {
   "remote_routes": [
-	{"id": "a0eb6eb0-fa38-41a8-a5de-1a75524667fe", "cidr": "169.250.0.0/29"}
+	{"cidr": "169.250.0.0/29"}
   ],
   "links": {
     "pages": {


### PR DESCRIPTION
Issue - [APICLI-2888](https://do-internal.atlassian.net/browse/APICLI-2888)

[APICLI-2888]: https://do-internal.atlassian.net/browse/APICLI-2888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ