### PR TITLE
update interface{} to any

### DIFF
--- a/apps_test.go
+++ b/apps_test.go
@@ -999,7 +999,7 @@ func TestApps_ToURN(t *testing.T) {
 
 func TestApps_Interfaces(t *testing.T) {
 	t.Run("AppComponentSpec", func(t *testing.T) {
-		for _, impl := range []interface{}{
+		for _, impl := range []any{
 			&AppServiceSpec{},
 			&AppWorkerSpec{},
 			&AppJobSpec{},
@@ -1109,7 +1109,7 @@ func TestApps_Interfaces(t *testing.T) {
 	})
 
 	t.Run("SourceSpec", func(t *testing.T) {
-		for _, impl := range []interface{}{
+		for _, impl := range []any{
 			&GitSourceSpec{},
 			&GitHubSourceSpec{},
 			&GitLabSourceSpec{},
@@ -1123,7 +1123,7 @@ func TestApps_Interfaces(t *testing.T) {
 	})
 
 	t.Run("VCSSourceSpec", func(t *testing.T) {
-		for _, impl := range []interface{}{
+		for _, impl := range []any{
 			&GitSourceSpec{},
 			&GitHubSourceSpec{},
 			&GitLabSourceSpec{},

--- a/droplet_actions.go
+++ b/droplet_actions.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ActionRequest represents DigitalOcean Action Request
-type ActionRequest map[string]interface{}
+type ActionRequest map[string]any
 
 // DropletActionsService is an interface for interfacing with the Droplet actions
 // endpoints of the DigitalOcean API
@@ -177,7 +177,7 @@ func (s *DropletActionsServiceOp) EnableBackupsWithPolicy(ctx context.Context, i
 		return nil, nil, NewArgError("policy", "policy can't be nil")
 	}
 
-	policyMap := map[string]interface{}{
+	policyMap := map[string]any{
 		"plan":    policy.Plan,
 		"weekday": policy.Weekday,
 	}
@@ -195,7 +195,7 @@ func (s *DropletActionsServiceOp) ChangeBackupPolicy(ctx context.Context, id int
 		return nil, nil, NewArgError("policy", "policy can't be nil")
 	}
 
-	policyMap := map[string]interface{}{
+	policyMap := map[string]any{
 		"plan":    policy.Plan,
 		"weekday": policy.Weekday,
 	}

--- a/droplet_actions_test.go
+++ b/droplet_actions_test.go
@@ -602,7 +602,7 @@ func TestDropletAction_EnableBackupsWithPolicy(t *testing.T) {
 		Hour:    PtrTo(20),
 	}
 
-	policy := map[string]interface{}{
+	policy := map[string]any{
 		"hour":    float64(20),
 		"plan":    "weekly",
 		"weekday": "TUE",
@@ -650,7 +650,7 @@ func TestDropletAction_ChangeBackupPolicy(t *testing.T) {
 		Hour:    PtrTo(0),
 	}
 
-	policy := map[string]interface{}{
+	policy := map[string]any{
 		"hour":    float64(0),
 		"plan":    "weekly",
 		"weekday": "SUN",

--- a/droplets_test.go
+++ b/droplets_test.go
@@ -330,7 +330,7 @@ func TestDroplets_Create(t *testing.T) {
 	}
 
 	mux.HandleFunc("/v2/droplets", func(w http.ResponseWriter, r *http.Request) {
-		expected := map[string]interface{}{
+		expected := map[string]any{
 			"name":               "name",
 			"region":             "region",
 			"size":               "size",
@@ -339,14 +339,14 @@ func TestDroplets_Create(t *testing.T) {
 			"ipv6":               false,
 			"private_networking": false,
 			"monitoring":         false,
-			"volumes": []interface{}{
-				map[string]interface{}{"id": "hello-im-another-volume"},
-				map[string]interface{}{"id": "aaa-111-bbb-222-ccc"},
+			"volumes": []any{
+				map[string]any{"id": "hello-im-another-volume"},
+				map[string]any{"id": "aaa-111-bbb-222-ccc"},
 			},
-			"tags":          []interface{}{"one", "two"},
+			"tags":          []any{"one", "two"},
 			"vpc_uuid":      "880b7f98-f062-404d-b33c-458d545696f6",
 			"backups":       true,
-			"backup_policy": map[string]interface{}{"plan": "weekly", "weekday": "MON", "hour": float64(0)},
+			"backup_policy": map[string]any{"plan": "weekly", "weekday": "MON", "hour": float64(0)},
 		}
 		jsonBlob := `
 {
@@ -366,7 +366,7 @@ func TestDroplets_Create(t *testing.T) {
 }
 `
 
-		var v map[string]interface{}
+		var v map[string]any
 		err := json.NewDecoder(r.Body).Decode(&v)
 		if err != nil {
 			t.Fatalf("decode json: %v", err)
@@ -420,7 +420,7 @@ func TestDroplets_CreateWithoutDropletAgent(t *testing.T) {
 	}
 
 	mux.HandleFunc("/v2/droplets", func(w http.ResponseWriter, r *http.Request) {
-		expected := map[string]interface{}{
+		expected := map[string]any{
 			"name":               "name",
 			"region":             "region",
 			"size":               "size",
@@ -430,11 +430,11 @@ func TestDroplets_CreateWithoutDropletAgent(t *testing.T) {
 			"ipv6":               false,
 			"private_networking": false,
 			"monitoring":         false,
-			"volumes": []interface{}{
-				map[string]interface{}{"id": "hello-im-another-volume"},
-				map[string]interface{}{"id": "aaa-111-bbb-222-ccc"},
+			"volumes": []any{
+				map[string]any{"id": "hello-im-another-volume"},
+				map[string]any{"id": "aaa-111-bbb-222-ccc"},
 			},
-			"tags":               []interface{}{"one", "two"},
+			"tags":               []any{"one", "two"},
 			"vpc_uuid":           "880b7f98-f062-404d-b33c-458d545696f6",
 			"with_droplet_agent": false,
 		}
@@ -456,7 +456,7 @@ func TestDroplets_CreateWithoutDropletAgent(t *testing.T) {
 }
 `
 
-		var v map[string]interface{}
+		var v map[string]any
 		err := json.NewDecoder(r.Body).Decode(&v)
 		if err != nil {
 			t.Fatalf("decode json: %v", err)
@@ -540,7 +540,7 @@ func TestDroplets_CreateWithDisabledPublicNetworking(t *testing.T) {
 	}
 
 	mux.HandleFunc("/v2/droplets", func(w http.ResponseWriter, r *http.Request) {
-		expected := map[string]interface{}{
+		expected := map[string]any{
 			"name":               "name",
 			"region":             "region",
 			"size":               "size",
@@ -550,11 +550,11 @@ func TestDroplets_CreateWithDisabledPublicNetworking(t *testing.T) {
 			"ipv6":               false,
 			"private_networking": false,
 			"monitoring":         false,
-			"volumes": []interface{}{
-				map[string]interface{}{"id": "hello-im-another-volume"},
-				map[string]interface{}{"id": "aaa-111-bbb-222-ccc"},
+			"volumes": []any{
+				map[string]any{"id": "hello-im-another-volume"},
+				map[string]any{"id": "aaa-111-bbb-222-ccc"},
 			},
-			"tags":     []interface{}{"one", "two"},
+			"tags":     []any{"one", "two"},
 			"vpc_uuid": "880b7f98-f062-404d-b33c-458d545696f6",
 		}
 		jsonBlob := `
@@ -575,7 +575,7 @@ func TestDroplets_CreateWithDisabledPublicNetworking(t *testing.T) {
 }
 `
 
-		var v map[string]interface{}
+		var v map[string]any
 		err := json.NewDecoder(r.Body).Decode(&v)
 		if err != nil {
 			t.Fatalf("decode json: %v", err)
@@ -614,8 +614,8 @@ func TestDroplets_CreateMultiple(t *testing.T) {
 	}
 
 	mux.HandleFunc("/v2/droplets", func(w http.ResponseWriter, r *http.Request) {
-		expected := map[string]interface{}{
-			"names":              []interface{}{"name1", "name2"},
+		expected := map[string]any{
+			"names":              []any{"name1", "name2"},
 			"region":             "region",
 			"size":               "size",
 			"image":              float64(1),
@@ -624,7 +624,7 @@ func TestDroplets_CreateMultiple(t *testing.T) {
 			"ipv6":               false,
 			"private_networking": false,
 			"monitoring":         false,
-			"tags":               []interface{}{"one", "two"},
+			"tags":               []any{"one", "two"},
 			"vpc_uuid":           "880b7f98-f062-404d-b33c-458d545696f6",
 		}
 		jsonBlob := `
@@ -651,7 +651,7 @@ func TestDroplets_CreateMultiple(t *testing.T) {
 }
 `
 
-		var v map[string]interface{}
+		var v map[string]any
 		err := json.NewDecoder(r.Body).Decode(&v)
 		if err != nil {
 			t.Fatalf("decode json: %v", err)

--- a/functions.go
+++ b/functions.go
@@ -77,8 +77,8 @@ type FunctionsTrigger struct {
 }
 
 type TriggerScheduledDetails struct {
-	Cron string                 `json:"cron,omitempty"`
-	Body map[string]interface{} `json:"body,omitempty"`
+	Cron string         `json:"cron,omitempty"`
+	Body map[string]any `json:"body,omitempty"`
 }
 
 type TriggerScheduledRuns struct {

--- a/functions_test.go
+++ b/functions_test.go
@@ -216,7 +216,7 @@ func TestFunctions_ListTriggers(t *testing.T) {
 			UpdatedAt: time.Date(2022, 10, 17, 18, 41, 30, 0, time.UTC),
 			ScheduledDetails: &TriggerScheduledDetails{
 				Cron: "* * * * *",
-				Body: map[string]interface{}{
+				Body: map[string]any{
 					"foo": "bar",
 				},
 			},
@@ -234,7 +234,7 @@ func TestFunctions_ListTriggers(t *testing.T) {
 			UpdatedAt: time.Date(2022, 10, 14, 20, 29, 43, 0, time.UTC),
 			ScheduledDetails: &TriggerScheduledDetails{
 				Cron: "* * * * *",
-				Body: map[string]interface{}{},
+				Body: map[string]any{},
 			},
 			ScheduledRuns: &TriggerScheduledRuns{
 				LastRunAt: time.Date(2022, 11, 03, 17, 02, 43, 0, time.UTC),
@@ -286,7 +286,7 @@ func TestFunctions_GetTrigger(t *testing.T) {
 		UpdatedAt: time.Date(2022, 10, 17, 18, 41, 30, 0, time.UTC),
 		ScheduledDetails: &TriggerScheduledDetails{
 			Cron: "* * * * *",
-			Body: map[string]interface{}{
+			Body: map[string]any{
 				"foo": "bar",
 			},
 		},
@@ -332,7 +332,7 @@ func TestFunctions_CreateTrigger(t *testing.T) {
 		IsEnabled: true,
 		ScheduledDetails: &TriggerScheduledDetails{
 			Cron: "* * * * *",
-			Body: map[string]interface{}{
+			Body: map[string]any{
 				"foo": "bar",
 			},
 		},
@@ -349,7 +349,7 @@ func TestFunctions_CreateTrigger(t *testing.T) {
 		UpdatedAt: time.Date(2022, 10, 17, 18, 41, 30, 0, time.UTC),
 		ScheduledDetails: &TriggerScheduledDetails{
 			Cron: "* * * * *",
-			Body: map[string]interface{}{
+			Body: map[string]any{
 				"foo": "bar",
 			},
 		},
@@ -406,7 +406,7 @@ func TestFunctions_UpdateTrigger(t *testing.T) {
 		UpdatedAt: time.Date(2022, 10, 17, 18, 41, 30, 0, time.UTC),
 		ScheduledDetails: &TriggerScheduledDetails{
 			Cron: "* * * * *",
-			Body: map[string]interface{}{
+			Body: map[string]any{
 				"foo": "bar",
 			},
 		},

--- a/godo.go
+++ b/godo.go
@@ -127,9 +127,9 @@ type Client struct {
 // Only the oauth2.TokenSource and Timeout will be maintained.
 type RetryConfig struct {
 	RetryMax     int
-	RetryWaitMin *float64    // Minimum time to wait
-	RetryWaitMax *float64    // Maximum time to wait
-	Logger       interface{} // Customer logger instance. Must implement either go-retryablehttp.Logger or go-retryablehttp.LeveledLogger
+	RetryWaitMin *float64 // Minimum time to wait
+	RetryWaitMax *float64 // Maximum time to wait
+	Logger       any      // Customer logger instance. Must implement either go-retryablehttp.Logger or go-retryablehttp.LeveledLogger
 }
 
 // RequestCompletionCallback defines the type of the request callback function
@@ -217,7 +217,7 @@ type Rate struct {
 	Reset Timestamp `json:"reset"`
 }
 
-func addOptions(s string, opt interface{}) (string, error) {
+func addOptions(s string, opt any) (string, error) {
 	v := reflect.ValueOf(opt)
 
 	if v.Kind() == reflect.Ptr && v.IsNil() {
@@ -455,7 +455,7 @@ func WithRetryAndBackoffs(retryConfig RetryConfig) ClientOpt {
 // NewRequest creates an API request. A relative URL can be provided in urlStr, which will be resolved to the
 // BaseURL of the Client. Relative URLS should always be specified without a preceding slash. If specified, the
 // value pointed to by body is JSON encoded and included in as the request body.
-func (c *Client) NewRequest(ctx context.Context, method, urlStr string, body interface{}) (*http.Request, error) {
+func (c *Client) NewRequest(ctx context.Context, method, urlStr string, body any) (*http.Request, error) {
 	u, err := c.BaseURL.Parse(urlStr)
 	if err != nil {
 		return nil, err
@@ -534,7 +534,7 @@ func (r *Response) populateRate() {
 // Do sends an API request and returns the API response. The API response is JSON decoded and stored in the value
 // pointed to by v, or returned as an error if an API error has occurred. If v implements the io.Writer interface,
 // the raw response will be written to v, without attempting to decode it.
-func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*Response, error) {
+func (c *Client) Do(ctx context.Context, req *http.Request, v any) (*Response, error) {
 	if c.rateLimiter != nil {
 		err := c.rateLimiter.Wait(ctx)
 		if err != nil {

--- a/images.go
+++ b/images.go
@@ -122,7 +122,7 @@ func (s *ImagesServiceOp) GetByID(ctx context.Context, imageID int) (*Image, *Re
 		return nil, nil, NewArgError("imageID", "cannot be less than 1")
 	}
 
-	return s.get(ctx, interface{}(imageID))
+	return s.get(ctx, any(imageID))
 }
 
 // GetBySlug retrieves an image by slug.
@@ -131,7 +131,7 @@ func (s *ImagesServiceOp) GetBySlug(ctx context.Context, slug string) (*Image, *
 		return nil, nil, NewArgError("slug", "cannot be blank")
 	}
 
-	return s.get(ctx, interface{}(slug))
+	return s.get(ctx, any(slug))
 }
 
 // Create a new image
@@ -198,7 +198,7 @@ func (s *ImagesServiceOp) Delete(ctx context.Context, imageID int) (*Response, e
 }
 
 // Helper method for getting an individual image
-func (s *ImagesServiceOp) get(ctx context.Context, ID interface{}) (*Image, *Response, error) {
+func (s *ImagesServiceOp) get(ctx context.Context, ID any) (*Image, *Response, error) {
 	path := fmt.Sprintf("%s/%v", imageBasePath, ID)
 
 	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)

--- a/images_test.go
+++ b/images_test.go
@@ -316,16 +316,16 @@ func TestImages_Create(t *testing.T) {
 	}
 
 	mux.HandleFunc("/v2/images", func(w http.ResponseWriter, r *http.Request) {
-		expected := map[string]interface{}{
+		expected := map[string]any{
 			"name":         "my-new-image",
 			"url":          "http://example.com/distro-amd64.img",
 			"region":       "nyc3",
 			"distribution": "Ubuntu",
 			"description":  "My new custom image",
-			"tags":         []interface{}{"foo", "bar"},
+			"tags":         []any{"foo", "bar"},
 		}
 
-		var v map[string]interface{}
+		var v map[string]any
 		err := json.NewDecoder(r.Body).Decode(&v)
 		if err != nil {
 			t.Fatalf("decode json: %v", err)
@@ -359,13 +359,13 @@ func TestImages_Update(t *testing.T) {
 	}
 
 	mux.HandleFunc("/v2/images/12345", func(w http.ResponseWriter, r *http.Request) {
-		expected := map[string]interface{}{
+		expected := map[string]any{
 			"name":         "name",
 			"distribution": "Fedora",
 			"description":  "Just testing...",
 		}
 
-		var v map[string]interface{}
+		var v map[string]any
 		err := json.NewDecoder(r.Body).Decode(&v)
 		if err != nil {
 			t.Fatalf("decode json: %v", err)

--- a/keys_test.go
+++ b/keys_test.go
@@ -175,11 +175,11 @@ func TestKeys_UpdateByID(t *testing.T) {
 	}
 
 	mux.HandleFunc("/v2/account/keys/12345", func(w http.ResponseWriter, r *http.Request) {
-		expected := map[string]interface{}{
+		expected := map[string]any{
 			"name": "name",
 		}
 
-		var v map[string]interface{}
+		var v map[string]any
 		err := json.NewDecoder(r.Body).Decode(&v)
 		if err != nil {
 			t.Fatalf("decode json: %v", err)
@@ -211,11 +211,11 @@ func TestKeys_UpdateByFingerprint(t *testing.T) {
 	}
 
 	mux.HandleFunc("/v2/account/keys/3b:16:bf:e4:8b:00:8b:b8:59:8c:a9:d3:f0:19:45:fa", func(w http.ResponseWriter, r *http.Request) {
-		expected := map[string]interface{}{
+		expected := map[string]any{
 			"name": "name",
 		}
 
-		var v map[string]interface{}
+		var v map[string]any
 		err := json.NewDecoder(r.Body).Decode(&v)
 		if err != nil {
 			t.Fatalf("decode json: %v", err)

--- a/projects.go
+++ b/projects.go
@@ -27,7 +27,7 @@ type ProjectsService interface {
 	Delete(context.Context, string) (*Response, error)
 
 	ListResources(context.Context, string, *ListOptions) ([]ProjectResource, *Response, error)
-	AssignResources(context.Context, string, ...interface{}) ([]ProjectResource, *Response, error)
+	AssignResources(context.Context, string, ...any) ([]ProjectResource, *Response, error)
 }
 
 // ProjectsServiceOp handles communication with Projects methods of the DigitalOcean API.
@@ -66,11 +66,11 @@ type CreateProjectRequest struct {
 // This type expects certain attribute types, but is built this way to allow
 // nil values as well. See `updateProjectRequest` for the "real" types.
 type UpdateProjectRequest struct {
-	Name        interface{}
-	Description interface{}
-	Purpose     interface{}
-	Environment interface{}
-	IsDefault   interface{}
+	Name        any
+	Description any
+	Purpose     any
+	Environment any
+	IsDefault   any
 }
 
 type updateProjectRequest struct {
@@ -257,7 +257,7 @@ func (p *ProjectsServiceOp) ListResources(ctx context.Context, projectID string,
 //
 // There is no unassign. To move a resource to another project, just assign
 // it to that other project.
-func (p *ProjectsServiceOp) AssignResources(ctx context.Context, projectID string, resources ...interface{}) ([]ProjectResource, *Response, error) {
+func (p *ProjectsServiceOp) AssignResources(ctx context.Context, projectID string, resources ...any) ([]ProjectResource, *Response, error) {
 	path := path.Join(projectsBasePath, projectID, "resources")
 
 	ar := &assignResourcesRequest{

--- a/projects_test.go
+++ b/projects_test.go
@@ -470,7 +470,7 @@ func TestProjects_AssignFleetResourcesWithTypes(t *testing.T) {
 	setup()
 	defer teardown()
 
-	assignableResources := []interface{}{
+	assignableResources := []any{
 		&Droplet{ID: 1234},
 		&FloatingIP{IP: "1.2.3.4"},
 		&ReservedIP{IP: "1.2.3.4"},
@@ -529,7 +529,7 @@ func TestProjects_AssignFleetResourcesWithStrings(t *testing.T) {
 	setup()
 	defer teardown()
 
-	assignableResources := []interface{}{
+	assignableResources := []any{
 		"do:droplet:1234",
 		"do:floatingip:1.2.3.4",
 		"do:reservedip:1.2.3.4",
@@ -588,7 +588,7 @@ func TestProjects_AssignFleetResourcesWithStringsAndTypes(t *testing.T) {
 	setup()
 	defer teardown()
 
-	assignableResources := []interface{}{
+	assignableResources := []any{
 		"do:droplet:1234",
 		&FloatingIP{IP: "1.2.3.4"},
 		&ReservedIP{IP: "1.2.3.4"},
@@ -649,7 +649,7 @@ func TestProjects_AssignFleetResourcesWithTypeWithoutURNReturnsError(t *testing.
 
 	type fakeType struct{}
 
-	assignableResources := []interface{}{
+	assignableResources := []any{
 		fakeType{},
 	}
 

--- a/registry.go
+++ b/registry.go
@@ -469,7 +469,7 @@ func (svc *RegistryServiceOp) DeleteManifest(ctx context.Context, registry, repo
 // registry.
 func (svc *RegistryServiceOp) StartGarbageCollection(ctx context.Context, registry string, request ...*StartGarbageCollectionRequest) (*GarbageCollection, *Response, error) {
 	path := fmt.Sprintf("%s/%s/garbage-collection", registryPath, registry)
-	var requestParams interface{}
+	var requestParams any
 	if len(request) < 1 {
 		// default to only garbage collecting unreferenced blobs for backwards
 		// compatibility
@@ -853,7 +853,7 @@ func (svc *RegistriesServiceOp) DeleteManifest(ctx context.Context, registry, re
 // StartGarbageCollection starts a garbage collection process
 func (svc *RegistriesServiceOp) StartGarbageCollection(ctx context.Context, registry string, request ...*StartGarbageCollectionRequest) (*GarbageCollection, *Response, error) {
 	path := fmt.Sprintf("%s/%s/garbage-collection", registriesPath, registry)
-	var requestParams interface{}
+	var requestParams any
 	if len(request) < 1 {
 		// default to only garbage collecting unreferenced blobs for backwards
 		// compatibility

--- a/registry_test.go
+++ b/registry_test.go
@@ -549,7 +549,7 @@ func TestRegistry_DeleteManifest(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func reifyTemplateStr(t *testing.T, tmplStr string, v interface{}) string {
+func reifyTemplateStr(t *testing.T, tmplStr string, v any) string {
 	tmpl, err := template.New("meow").Parse(tmplStr)
 	require.NoError(t, err)
 

--- a/strings.go
+++ b/strings.go
@@ -18,12 +18,12 @@ type ResourceWithURN interface {
 }
 
 // ToURN converts the resource type and ID to a valid DO API URN.
-func ToURN(resourceType string, id interface{}) string {
+func ToURN(resourceType string, id any) string {
 	return fmt.Sprintf("%s:%s:%v", "do", strings.ToLower(resourceType), id)
 }
 
 // Stringify attempts to create a string representation of DigitalOcean types
-func Stringify(message interface{}) string {
+func Stringify(message any) string {
 	var buf bytes.Buffer
 	v := reflect.ValueOf(message)
 	stringifyValue(&buf, v)

--- a/vpcs.go
+++ b/vpcs.go
@@ -53,7 +53,7 @@ type VPCUpdateRequest struct {
 
 // VPCSetField allows one to set individual fields within a VPC configuration.
 type VPCSetField interface {
-	vpcSetField(map[string]interface{})
+	vpcSetField(map[string]any)
 }
 
 // VPCSetName is used when one want to set the `name` field of a VPC.
@@ -189,22 +189,22 @@ func (v *VPCsServiceOp) Update(ctx context.Context, id string, update *VPCUpdate
 	return root.VPC, resp, nil
 }
 
-func (n VPCSetName) vpcSetField(in map[string]interface{}) {
+func (n VPCSetName) vpcSetField(in map[string]any) {
 	in["name"] = n
 }
 
-func (n VPCSetDescription) vpcSetField(in map[string]interface{}) {
+func (n VPCSetDescription) vpcSetField(in map[string]any) {
 	in["description"] = n
 }
 
-func (*vpcSetDefault) vpcSetField(in map[string]interface{}) {
+func (*vpcSetDefault) vpcSetField(in map[string]any) {
 	in["default"] = true
 }
 
 // Set updates specific properties of a Virtual Private Cloud.
 func (v *VPCsServiceOp) Set(ctx context.Context, id string, fields ...VPCSetField) (*VPC, *Response, error) {
 	path := vpcsBasePath + "/" + id
-	update := make(map[string]interface{}, len(fields))
+	update := make(map[string]any, len(fields))
 	for _, field := range fields {
 		field.vpcSetField(update)
 	}


### PR DESCRIPTION
This pr is a simple update. Changes interface{} type references to any. I noticed the language server gives a warning about interface{} can be replaced by any. The any keyword was introduced in go 1.18 and this project uses 1.23 and above. using any is the idiomatic way in modern go so I figured Id make the change.