### PR TITLE
fix(changelog): standardize version headers to [vX.Y.Z] format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## [1.165.1] - 2025-09-24
+## [v1.165.1] - 2025-09-24
 
 - #906 - @do-joe - Fix Database Logsink API Response Parsing and TLS Field Marshaling
 - #904 - @SSharma-10 - Godo automate release
@@ -8,24 +8,24 @@
 - #905 - @harshmaru7 - new release test
 - #902 - @SSharma-10 - added comment for ListAgentVersions
 
-## [1.164.0] - 2025-09-10
+## [v1.164.0] - 2025-09-10
 
 - #897 - @DO-rrao - List remote route | removed id field from remote route
 - #894 - @DO-rrao - GenAI : Implement Indexing Jobs Operations
 - #893 - @DO-rrao - GenAI - added changes for ListIndexingJobs for a Knowledge Base
 - #891 - @imaskm - Added prefix update method
 
-## [1.163.0] - 2025-08-14
+## [v1.163.0] - 2025-08-14
 
 - #889 - @bhardwajRahul - Enable Support for Kafka Schema Registry in Godo
 
-## [1.162.0] - 2025-08-07
+## [v1.162.0] - 2025-08-07
 
 - #875 - @dependabot[bot] - Bump golang.org/x/oauth2 from 0.23.0 to 0.27.0
 - #885 - @SSharma-10 - Added support for Valkey Configuration
 - #876 - @SSharma-10 - Added GenAI Additional Operations
 
-## [1.161.0] - 2025-07-28
+## [v1.161.0] - 2025-07-28
 
 - #883 - @ElanHasson - Add GitHub Actions workflow to generate CHANGELOG.md and update godo version
 - #879 - @ElanHasson - APPS - Add Autoscale succeeded alert support


### PR DESCRIPTION
## Summary
Standardized all version headers in `CHANGELOG.md` to use `[vX.Y.Z]` format.

## Motivation
Improves consistency and aligns with semantic versioning used in recent entries.

### Notes
Pure formatting change—no content edits.


### Checklist
- [x] All version headers use `[vX.Y.Z]` format
- [x] No semantic changes to changelog content
- [x] Verified against recent tagging conventions
