### PR TITLE
CON-12804 - add GPU related DOKS cluster plugin options

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -89,6 +89,8 @@ type KubernetesClusterCreateRequest struct {
 	RoutingAgent                      *KubernetesRoutingAgent                      `json:"routing_agent,omitempty"`
 	AmdGpuDevicePlugin                *KubernetesAmdGpuDevicePlugin                `json:"amd_gpu_device_plugin,omitempty"`
 	AmdGpuDeviceMetricsExporterPlugin *KubernetesAmdGpuDeviceMetricsExporterPlugin `json:"amd_gpu_device_metrics_exporter_plugin,omitempty"`
+	NvidiaGpuDevicePlugin             *KubernetesNvidiaGpuDevicePlugin             `json:"nvidia_gpu_device_plugin,omitempty"`
+	RdmaSharedDevicePlugin            *KubernetesRdmaSharedDevicePlugin            `json:"rdma_shared_dev_plugin,omitempty"`
 }
 
 // KubernetesClusterUpdateRequest represents a request to update a Kubernetes cluster.
@@ -103,6 +105,8 @@ type KubernetesClusterUpdateRequest struct {
 	RoutingAgent                      *KubernetesRoutingAgent                      `json:"routing_agent,omitempty"`
 	AmdGpuDevicePlugin                *KubernetesAmdGpuDevicePlugin                `json:"amd_gpu_device_plugin,omitempty"`
 	AmdGpuDeviceMetricsExporterPlugin *KubernetesAmdGpuDeviceMetricsExporterPlugin `json:"amd_gpu_device_metrics_exporter_plugin,omitempty"`
+	NvidiaGpuDevicePlugin             *KubernetesNvidiaGpuDevicePlugin             `json:"nvidia_gpu_device_plugin,omitempty"`
+	RdmaSharedDevicePlugin            *KubernetesRdmaSharedDevicePlugin            `json:"rdma_shared_dev_plugin,omitempty"`
 
 	// Convert cluster to run highly available control plane
 	HA *bool `json:"ha,omitempty"`
@@ -238,6 +242,8 @@ type KubernetesCluster struct {
 	RoutingAgent                      *KubernetesRoutingAgent                      `json:"routing_agent,omitempty"`
 	AmdGpuDevicePlugin                *KubernetesAmdGpuDevicePlugin                `json:"amd_gpu_device_plugin,omitempty"`
 	AmdGpuDeviceMetricsExporterPlugin *KubernetesAmdGpuDeviceMetricsExporterPlugin `json:"amd_gpu_device_metrics_exporter_plugin,omitempty"`
+	NvidiaGpuDevicePlugin             *KubernetesNvidiaGpuDevicePlugin             `json:"nvidia_gpu_device_plugin,omitempty"`
+	RdmaSharedDevicePlugin            *KubernetesRdmaSharedDevicePlugin            `json:"rdma_shared_dev_plugin,omitempty"`
 
 	Status    *KubernetesClusterStatus `json:"status,omitempty"`
 	CreatedAt time.Time                `json:"created_at,omitempty"`
@@ -280,6 +286,13 @@ type KubernetesControlPlaneFirewall struct {
 	AllowedAddresses []string `json:"allowed_addresses"`
 }
 
+// KubernetesClusterAutoscalerConfiguration represents Kubernetes cluster autoscaler configuration.
+type KubernetesClusterAutoscalerConfiguration struct {
+	ScaleDownUtilizationThreshold *float64 `json:"scale_down_utilization_threshold"`
+	ScaleDownUnneededTime         *string  `json:"scale_down_unneeded_time"`
+	Expanders                     []string `json:"expanders"`
+}
+
 // KubernetesRoutingAgent represents information about the routing-agent cluster plugin.
 type KubernetesRoutingAgent struct {
 	Enabled *bool `json:"enabled"`
@@ -296,11 +309,16 @@ type KubernetesAmdGpuDeviceMetricsExporterPlugin struct {
 	Enabled *bool `json:"enabled"`
 }
 
-// KubernetesClusterAutoscalerConfiguration represents Kubernetes cluster autoscaler configuration.
-type KubernetesClusterAutoscalerConfiguration struct {
-	ScaleDownUtilizationThreshold *float64 `json:"scale_down_utilization_threshold"`
-	ScaleDownUnneededTime         *string  `json:"scale_down_unneeded_time"`
-	Expanders                     []string `json:"expanders"`
+// KubernetesNvidiaGpuDevicePlugin represents information about the NVIDIA GPU Device Plugin cluster plugin.
+// If a cluster has a node pool with an NVIDIA GPU it will be enabled by default.
+type KubernetesNvidiaGpuDevicePlugin struct {
+	Enabled *bool `json:"enabled"`
+}
+
+// KubernetesRdmaSharedDevicePlugin represents information about the rdma-shared-dev cluster plugin.
+// If a cluster has a multi-node GPU ready slug it will be enabled by default.
+type KubernetesRdmaSharedDevicePlugin struct {
+	Enabled *bool `json:"enabled"`
 }
 
 // KubernetesMaintenancePolicyDay represents the possible days of a maintenance

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -42,6 +42,12 @@ func TestKubernetesClusters_ListClusters(t *testing.T) {
 			AmdGpuDeviceMetricsExporterPlugin: &KubernetesAmdGpuDeviceMetricsExporterPlugin{
 				Enabled: PtrTo(true),
 			},
+			NvidiaGpuDevicePlugin: &KubernetesNvidiaGpuDevicePlugin{
+				Enabled: PtrTo(true),
+			},
+			RdmaSharedDevicePlugin: &KubernetesRdmaSharedDevicePlugin{
+				Enabled: PtrTo(true),
+			},
 			NodePools: []*KubernetesNodePool{
 				{
 					ID:    "1a17a012-cb31-4886-a787-deadbeef1191",
@@ -139,6 +145,12 @@ func TestKubernetesClusters_ListClusters(t *testing.T) {
 				"enabled": true
 			},
 			"amd_gpu_device_metrics_exporter_plugin": {
+				"enabled": true
+			},
+			"nvidia_gpu_device_plugin": {
+				"enabled": true
+			},
+			"rdma_shared_dev_plugin": {
 				"enabled": true
 			},
 			"node_pools": [
@@ -291,6 +303,12 @@ func TestKubernetesClusters_Get(t *testing.T) {
 		AmdGpuDeviceMetricsExporterPlugin: &KubernetesAmdGpuDeviceMetricsExporterPlugin{
 			Enabled: PtrTo(true),
 		},
+		NvidiaGpuDevicePlugin: &KubernetesNvidiaGpuDevicePlugin{
+			Enabled: PtrTo(true),
+		},
+		RdmaSharedDevicePlugin: &KubernetesRdmaSharedDevicePlugin{
+			Enabled: PtrTo(true),
+		},
 		NodePools: []*KubernetesNodePool{
 			{
 				ID:    "deadbeef-dead-beef-dead-deadbeefb4b3",
@@ -349,6 +367,12 @@ func TestKubernetesClusters_Get(t *testing.T) {
 			"enabled": true
 		},
 		"amd_gpu_device_metrics_exporter_plugin": {
+			"enabled": true
+		},
+		"nvidia_gpu_device_plugin": {
+			"enabled": true
+		},
+		"rdma_shared_dev_plugin": {
 			"enabled": true
 		},
 		"node_pools": [
@@ -605,6 +629,12 @@ func TestKubernetesClusters_Create(t *testing.T) {
 		AmdGpuDeviceMetricsExporterPlugin: &KubernetesAmdGpuDeviceMetricsExporterPlugin{
 			Enabled: PtrTo(true),
 		},
+		NvidiaGpuDevicePlugin: &KubernetesNvidiaGpuDevicePlugin{
+			Enabled: PtrTo(true),
+		},
+		RdmaSharedDevicePlugin: &KubernetesRdmaSharedDevicePlugin{
+			Enabled: PtrTo(true),
+		},
 		NodePools: []*KubernetesNodePool{
 			{
 				ID:     "8d91899c-0739-4a1a-acc5-deadbeefbb8a",
@@ -642,6 +672,18 @@ func TestKubernetesClusters_Create(t *testing.T) {
 		SurgeUpgrade:  true,
 		HA:            true,
 		RoutingAgent: &KubernetesRoutingAgent{
+			Enabled: PtrTo(true),
+		},
+		AmdGpuDevicePlugin: &KubernetesAmdGpuDevicePlugin{
+			Enabled: PtrTo(true),
+		},
+		AmdGpuDeviceMetricsExporterPlugin: &KubernetesAmdGpuDeviceMetricsExporterPlugin{
+			Enabled: PtrTo(true),
+		},
+		NvidiaGpuDevicePlugin: &KubernetesNvidiaGpuDevicePlugin{
+			Enabled: PtrTo(true),
+		},
+		RdmaSharedDevicePlugin: &KubernetesRdmaSharedDevicePlugin{
 			Enabled: PtrTo(true),
 		},
 		NodePools: []*KubernetesNodePoolCreateRequest{
@@ -683,6 +725,12 @@ func TestKubernetesClusters_Create(t *testing.T) {
 			"enabled": true
 		},
 		"amd_gpu_device_metrics_exporter_plugin": {
+			"enabled": true
+		},
+		"nvidia_gpu_device_plugin": {
+			"enabled": true
+		},
+		"rdma_shared_dev_plugin": {
 			"enabled": true
 		},
 		"node_pools": [
@@ -893,6 +941,12 @@ func TestKubernetesClusters_Update(t *testing.T) {
 		AmdGpuDeviceMetricsExporterPlugin: &KubernetesAmdGpuDeviceMetricsExporterPlugin{
 			Enabled: PtrTo(true),
 		},
+		NvidiaGpuDevicePlugin: &KubernetesNvidiaGpuDevicePlugin{
+			Enabled: PtrTo(true),
+		},
+		RdmaSharedDevicePlugin: &KubernetesRdmaSharedDevicePlugin{
+			Enabled: PtrTo(true),
+		},
 	}
 	updateRequest := &KubernetesClusterUpdateRequest{
 		Name:              want.Name,
@@ -917,6 +971,12 @@ func TestKubernetesClusters_Update(t *testing.T) {
 			Enabled: PtrTo(true),
 		},
 		AmdGpuDeviceMetricsExporterPlugin: &KubernetesAmdGpuDeviceMetricsExporterPlugin{
+			Enabled: PtrTo(true),
+		},
+		NvidiaGpuDevicePlugin: &KubernetesNvidiaGpuDevicePlugin{
+			Enabled: PtrTo(true),
+		},
+		RdmaSharedDevicePlugin: &KubernetesRdmaSharedDevicePlugin{
 			Enabled: PtrTo(true),
 		},
 	}
@@ -973,11 +1033,17 @@ func TestKubernetesClusters_Update(t *testing.T) {
 		},
 		"amd_gpu_device_metrics_exporter_plugin": {
 			"enabled": true
+		},
+		"nvidia_gpu_device_plugin": {
+			"enabled": true
+		},
+		"rdma_shared_dev_plugin": {
+			"enabled": true
 		}
 	}
 }`
 
-	expectedReqJSON := `{"name":"antoine-test-cluster","tags":["cluster-tag-1","cluster-tag-2"],"maintenance_policy":{"start_time":"00:00","duration":"","day":"monday"},"surge_upgrade":true,"control_plane_firewall":{"enabled":true,"allowed_addresses":["1.2.3.4/32"]},"cluster_autoscaler_configuration":{"scale_down_utilization_threshold":0.2,"scale_down_unneeded_time":"1m27s","expanders":[]},"routing_agent":{"enabled":true},"amd_gpu_device_plugin":{"enabled":true},"amd_gpu_device_metrics_exporter_plugin":{"enabled":true}}
+	expectedReqJSON := `{"name":"antoine-test-cluster","tags":["cluster-tag-1","cluster-tag-2"],"maintenance_policy":{"start_time":"00:00","duration":"","day":"monday"},"surge_upgrade":true,"control_plane_firewall":{"enabled":true,"allowed_addresses":["1.2.3.4/32"]},"cluster_autoscaler_configuration":{"scale_down_utilization_threshold":0.2,"scale_down_unneeded_time":"1m27s","expanders":[]},"routing_agent":{"enabled":true},"amd_gpu_device_plugin":{"enabled":true},"amd_gpu_device_metrics_exporter_plugin":{"enabled":true},"nvidia_gpu_device_plugin":{"enabled":true},"rdma_shared_dev_plugin":{"enabled":true}}
 `
 
 	mux.HandleFunc("/v2/kubernetes/clusters/8d91899c-0739-4a1a-acc5-deadbeefbb8f", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Being:
- `nvidia_gpu_device_plugin`
- `rdma_shared_dev_plugin`

It's a bit inconsistent, however, already like that in the k8saas API..