### PR TITLE
prepv1.169.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [1.169.0] - 2025-11-13
+
+- #928 - @do-joe - Fix GetLogsink API Response Parsing to Match Actual API Behavior
+
 ## [1.168.0] - 2025-11-06
 
 - #926 - @niket-dujari - added provision for attach and detach share

--- a/godo.go
+++ b/godo.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.168.0"
+	libraryVersion = "1.169.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"


### PR DESCRIPTION
## [1.169.0] - 2025-11-13

- #928 - @do-joe - Fix GetLogsink API Response Parsing to Match Actual API Behavior