### PR TITLE
Add DOSettings with ServiceCnames support for database clusters

### DIFF
--- a/databases.go
+++ b/databases.go
@@ -535,13 +535,13 @@ type DatabaseCreateDBRequest struct {
 
 // DatabaseCreateReplicaRequest is used to create a new read-only replica
 type DatabaseCreateReplicaRequest struct {
-	Name               string   `json:"name"`
-	Region             string   `json:"region"`
-	Size               string   `json:"size"`
-	PrivateNetworkUUID string       `json:"private_network_uuid"`
-	Tags               []string     `json:"tags,omitempty"`
-	StorageSizeMib     uint64       `json:"storage_size_mib,omitempty"`
-	DOSettings         *DOSettings  `json:"do_settings,omitempty"`
+	Name               string      `json:"name"`
+	Region             string      `json:"region"`
+	Size               string      `json:"size"`
+	PrivateNetworkUUID string      `json:"private_network_uuid"`
+	Tags               []string    `json:"tags,omitempty"`
+	StorageSizeMib     uint64      `json:"storage_size_mib,omitempty"`
+	DOSettings         *DOSettings `json:"do_settings,omitempty"`
 }
 
 // DatabaseUpdateFirewallRulesRequest is used to set the firewall rules for a database

--- a/databases_test.go
+++ b/databases_test.go
@@ -758,14 +758,14 @@ func TestDatabases_Create(t *testing.T) {
 		{
 			title: "create with do_settings",
 			createRequest: &DatabaseCreateRequest{
-				Name:       "backend-cname-test",
-				EngineSlug: "pg",
-				Version:    "14",
-				Region:     "nyc3",
-				SizeSlug:   "db-s-2vcpu-4gb",
-				NumNodes:   2,
-				Tags:       []string{"production"},
-				ProjectID:  "05d84f74-db8c-4de5-ae72-2fd4823fb1c8",
+				Name:           "backend-cname-test",
+				EngineSlug:     "pg",
+				Version:        "14",
+				Region:         "nyc3",
+				SizeSlug:       "db-s-2vcpu-4gb",
+				NumNodes:       2,
+				Tags:           []string{"production"},
+				ProjectID:      "05d84f74-db8c-4de5-ae72-2fd4823fb1c8",
 				StorageSizeMib: 61440,
 				DOSettings: &DOSettings{
 					ServiceCnames: []string{"db.example.com", "database.myapp.io"},


### PR DESCRIPTION
This adds the `do_settings` field with `service_cnames` support to:
- DatabaseCreateRequest (for cluster creation)
- DatabaseCreateReplicaRequest (for replica creation)
- Database (response struct)
- DatabaseReplica (response struct)

The `service_cnames` field allows users to configure custom CNAMEs for their database clusters and replicas.