### PR TITLE
[CON-13686] Make HA flag optional in Kubernetes cluster create request for version-based API defaults

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -77,7 +77,7 @@ type KubernetesClusterCreateRequest struct {
 	ServiceSubnet string   `json:"service_subnet,omitempty"`
 
 	// HA enables a highly available control plane. When omitted, the API applies
-	// version-based defaults: false for versions <= 1.36, true for versions > 1.36.
+	// version-based defaults: false for versions < 1.36, true for versions >= 1.36.
 	HA *bool `json:"ha,omitempty"`
 
 	NodePools []*KubernetesNodePoolCreateRequest `json:"node_pools,omitempty"`

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -76,8 +76,9 @@ type KubernetesClusterCreateRequest struct {
 	ClusterSubnet string   `json:"cluster_subnet,omitempty"`
 	ServiceSubnet string   `json:"service_subnet,omitempty"`
 
-	// Create cluster with highly available control plane
-	HA bool `json:"ha"`
+	// HA enables a highly available control plane. When omitted, the API applies
+	// version-based defaults: false for versions <= 1.36, true for versions > 1.36.
+	HA *bool `json:"ha,omitempty"`
 
 	NodePools []*KubernetesNodePoolCreateRequest `json:"node_pools,omitempty"`
 

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -614,6 +614,43 @@ func TestKubernetesClusters_GetUpgrades(t *testing.T) {
 	require.Equal(t, want, got)
 }
 
+func TestKubernetesClusterCreateRequest_HA_JsonMarshal(t *testing.T) {
+	tests := []struct {
+		name     string
+		req      *KubernetesClusterCreateRequest
+		contains string // substring that must be in JSON
+		omits    string // substring that must NOT be in JSON
+	}{
+		{
+			name:  "HA nil - field omitted",
+			req:   &KubernetesClusterCreateRequest{Name: "test", VersionSlug: "1.36"},
+			omits: `"ha"`,
+		},
+		{
+			name:     "HA true - field present",
+			req:      &KubernetesClusterCreateRequest{Name: "test", VersionSlug: "1.36", HA: PtrTo(true)},
+			contains: `"ha":true`,
+		},
+		{
+			name:     "HA false - field present",
+			req:      &KubernetesClusterCreateRequest{Name: "test", VersionSlug: "1.36", HA: PtrTo(false)},
+			contains: `"ha":false`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.req)
+			require.NoError(t, err)
+			if tt.contains != "" {
+				require.Contains(t, string(data), tt.contains)
+			}
+			if tt.omits != "" {
+				require.NotContains(t, string(data), tt.omits)
+			}
+		})
+	}
+}
+
 func TestKubernetesClusters_Create(t *testing.T) {
 	setup()
 	defer teardown()
@@ -688,7 +725,7 @@ func TestKubernetesClusters_Create(t *testing.T) {
 		ClusterSubnet: want.ClusterSubnet,
 		ServiceSubnet: want.ServiceSubnet,
 		SurgeUpgrade:  true,
-		HA:            true,
+		HA:            PtrTo(true),
 		RoutingAgent: &KubernetesRoutingAgent{
 			Enabled: PtrTo(true),
 		},


### PR DESCRIPTION
## Summary
Makes the `HA` field optional (`*bool` with `omitempty`) in `KubernetesClusterCreateRequest` so the API can apply version-based defaults when omitted:
- **Versions < 1.36**: default `false`
- **Versions >= 1.36**: default `true`

## Changes
- `KubernetesClusterCreateRequest.HA`: `bool` → `*bool` with `omitempty`
- Added `TestKubernetesClusterCreateRequest_HA_JsonMarshal` to verify JSON marshaling

## Jira
https://do-internal.atlassian.net/browse/CON-13686