### PR TITLE
CON-13397 - Add coredns_autoscaler plugin to Kubernetes cluster types

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -335,7 +335,7 @@ type KubernetesRdmaSharedDevicePlugin struct {
 	Enabled *bool `json:"enabled"`
 }
 
-// KubernetesCorednsAutoscaler represents information about the CoreDNS Cluster Proportional Autoscaler plugin.
+// KubernetesCorednsAutoscaler represents information about the CoreDNS Cluster Proportional Autoscaler cluster plugin.
 type KubernetesCorednsAutoscaler struct {
 	Enabled *bool `json:"enabled"`
 }

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -93,6 +93,7 @@ type KubernetesClusterCreateRequest struct {
 	AmdGpuDeviceMetricsExporterPlugin *KubernetesAmdGpuDeviceMetricsExporterPlugin `json:"amd_gpu_device_metrics_exporter_plugin,omitempty"`
 	NvidiaGpuDevicePlugin             *KubernetesNvidiaGpuDevicePlugin             `json:"nvidia_gpu_device_plugin,omitempty"`
 	RdmaSharedDevicePlugin            *KubernetesRdmaSharedDevicePlugin            `json:"rdma_shared_dev_plugin,omitempty"`
+	CorednsAutoscaler                 *KubernetesCorednsAutoscaler                 `json:"coredns_autoscaler,omitempty"`
 	SSO                               *KubernetesClusterSSO                        `json:"sso,omitempty"`
 }
 
@@ -110,6 +111,7 @@ type KubernetesClusterUpdateRequest struct {
 	AmdGpuDeviceMetricsExporterPlugin *KubernetesAmdGpuDeviceMetricsExporterPlugin `json:"amd_gpu_device_metrics_exporter_plugin,omitempty"`
 	NvidiaGpuDevicePlugin             *KubernetesNvidiaGpuDevicePlugin             `json:"nvidia_gpu_device_plugin,omitempty"`
 	RdmaSharedDevicePlugin            *KubernetesRdmaSharedDevicePlugin            `json:"rdma_shared_dev_plugin,omitempty"`
+	CorednsAutoscaler                 *KubernetesCorednsAutoscaler                 `json:"coredns_autoscaler,omitempty"`
 	SSO                               *KubernetesClusterSSO                        `json:"sso,omitempty"`
 
 	// Convert cluster to run highly available control plane
@@ -254,6 +256,7 @@ type KubernetesCluster struct {
 	AmdGpuDeviceMetricsExporterPlugin *KubernetesAmdGpuDeviceMetricsExporterPlugin `json:"amd_gpu_device_metrics_exporter_plugin,omitempty"`
 	NvidiaGpuDevicePlugin             *KubernetesNvidiaGpuDevicePlugin             `json:"nvidia_gpu_device_plugin,omitempty"`
 	RdmaSharedDevicePlugin            *KubernetesRdmaSharedDevicePlugin            `json:"rdma_shared_dev_plugin,omitempty"`
+	CorednsAutoscaler                 *KubernetesCorednsAutoscaler                 `json:"coredns_autoscaler,omitempty"`
 	SSO                               *KubernetesClusterSSO                        `json:"sso,omitempty"`
 
 	Status    *KubernetesClusterStatus `json:"status,omitempty"`
@@ -329,6 +332,11 @@ type KubernetesNvidiaGpuDevicePlugin struct {
 // KubernetesRdmaSharedDevicePlugin represents information about the rdma-shared-dev cluster plugin.
 // If a cluster has a multi-node GPU ready slug it will be enabled by default.
 type KubernetesRdmaSharedDevicePlugin struct {
+	Enabled *bool `json:"enabled"`
+}
+
+// KubernetesCorednsAutoscaler represents information about the CoreDNS Cluster Proportional Autoscaler plugin.
+type KubernetesCorednsAutoscaler struct {
 	Enabled *bool `json:"enabled"`
 }
 

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -49,6 +49,9 @@ func TestKubernetesClusters_ListClusters(t *testing.T) {
 			RdmaSharedDevicePlugin: &KubernetesRdmaSharedDevicePlugin{
 				Enabled: PtrTo(true),
 			},
+			CorednsAutoscaler: &KubernetesCorednsAutoscaler{
+				Enabled: PtrTo(true),
+			},
 			SSO: &KubernetesClusterSSO{
 				Enabled:   true,
 				IssuerURL: "https://example.com/issuer",
@@ -159,6 +162,9 @@ func TestKubernetesClusters_ListClusters(t *testing.T) {
 				"enabled": true
 			},
 			"rdma_shared_dev_plugin": {
+				"enabled": true
+			},
+			"coredns_autoscaler": {
 				"enabled": true
 			},
 			"sso": {
@@ -325,6 +331,9 @@ func TestKubernetesClusters_Get(t *testing.T) {
 		RdmaSharedDevicePlugin: &KubernetesRdmaSharedDevicePlugin{
 			Enabled: PtrTo(true),
 		},
+		CorednsAutoscaler: &KubernetesCorednsAutoscaler{
+			Enabled: PtrTo(true),
+		},
 		SSO: &KubernetesClusterSSO{
 			Enabled:   true,
 			IssuerURL: "https://example.com/issuer",
@@ -395,6 +404,9 @@ func TestKubernetesClusters_Get(t *testing.T) {
 			"enabled": true
 		},
 		"rdma_shared_dev_plugin": {
+			"enabled": true
+		},
+		"coredns_autoscaler": {
 			"enabled": true
 		},
 		"sso": {
@@ -767,6 +779,9 @@ func TestKubernetesClusters_Create(t *testing.T) {
 		RdmaSharedDevicePlugin: &KubernetesRdmaSharedDevicePlugin{
 			Enabled: PtrTo(true),
 		},
+		CorednsAutoscaler: &KubernetesCorednsAutoscaler{
+			Enabled: PtrTo(true),
+		},
 		SSO: &KubernetesClusterSSO{
 			Enabled:   true,
 			Required:  false,
@@ -825,6 +840,9 @@ func TestKubernetesClusters_Create(t *testing.T) {
 		RdmaSharedDevicePlugin: &KubernetesRdmaSharedDevicePlugin{
 			Enabled: PtrTo(true),
 		},
+		CorednsAutoscaler: &KubernetesCorednsAutoscaler{
+			Enabled: PtrTo(true),
+		},
 		SSO: &KubernetesClusterSSO{
 			Enabled:   true,
 			IssuerURL: "https://example.com/issuer",
@@ -876,6 +894,9 @@ func TestKubernetesClusters_Create(t *testing.T) {
 			"enabled": true
 		},
 		"rdma_shared_dev_plugin": {
+			"enabled": true
+		},
+		"coredns_autoscaler": {
 			"enabled": true
 		},
 		"sso": {
@@ -1101,6 +1122,9 @@ func TestKubernetesClusters_Update(t *testing.T) {
 		RdmaSharedDevicePlugin: &KubernetesRdmaSharedDevicePlugin{
 			Enabled: PtrTo(true),
 		},
+		CorednsAutoscaler: &KubernetesCorednsAutoscaler{
+			Enabled: PtrTo(true),
+		},
 		SSO: &KubernetesClusterSSO{
 			Enabled: false,
 		},
@@ -1134,6 +1158,9 @@ func TestKubernetesClusters_Update(t *testing.T) {
 			Enabled: PtrTo(true),
 		},
 		RdmaSharedDevicePlugin: &KubernetesRdmaSharedDevicePlugin{
+			Enabled: PtrTo(true),
+		},
+		CorednsAutoscaler: &KubernetesCorednsAutoscaler{
 			Enabled: PtrTo(true),
 		},
 		SSO: &KubernetesClusterSSO{
@@ -1201,6 +1228,9 @@ func TestKubernetesClusters_Update(t *testing.T) {
 		"rdma_shared_dev_plugin": {
 			"enabled": true
 		},
+		"coredns_autoscaler": {
+			"enabled": true
+		},
 		"sso": {
 			"enabled": false,
 			"required": false
@@ -1208,7 +1238,7 @@ func TestKubernetesClusters_Update(t *testing.T) {
 	}
 }`
 
-	expectedReqJSON := `{"name":"antoine-test-cluster","tags":["cluster-tag-1","cluster-tag-2"],"maintenance_policy":{"start_time":"00:00","duration":"","day":"monday"},"surge_upgrade":true,"control_plane_firewall":{"enabled":true,"allowed_addresses":["1.2.3.4/32"]},"cluster_autoscaler_configuration":{"scale_down_utilization_threshold":0.2,"scale_down_unneeded_time":"1m27s","expanders":[]},"routing_agent":{"enabled":true},"amd_gpu_device_plugin":{"enabled":true},"amd_gpu_device_metrics_exporter_plugin":{"enabled":true},"nvidia_gpu_device_plugin":{"enabled":true},"rdma_shared_dev_plugin":{"enabled":true},"sso":{"enabled":false,"required":false}}
+	expectedReqJSON := `{"name":"antoine-test-cluster","tags":["cluster-tag-1","cluster-tag-2"],"maintenance_policy":{"start_time":"00:00","duration":"","day":"monday"},"surge_upgrade":true,"control_plane_firewall":{"enabled":true,"allowed_addresses":["1.2.3.4/32"]},"cluster_autoscaler_configuration":{"scale_down_utilization_threshold":0.2,"scale_down_unneeded_time":"1m27s","expanders":[]},"routing_agent":{"enabled":true},"amd_gpu_device_plugin":{"enabled":true},"amd_gpu_device_metrics_exporter_plugin":{"enabled":true},"nvidia_gpu_device_plugin":{"enabled":true},"rdma_shared_dev_plugin":{"enabled":true},"coredns_autoscaler":{"enabled":true},"sso":{"enabled":false,"required":false}}
 `
 
 	mux.HandleFunc("/v2/kubernetes/clusters/8d91899c-0739-4a1a-acc5-deadbeefbb8f", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Adds support for the field coredns_autoscaler on DOKS cluster create, update, get, and list responses, aligned with OpenAPI

Related PR - https://github.com/digitalocean/openapi/pull/1153