### PR TITLE
NfsAction - type inconsistency bug fix

### DIFF
--- a/nfs_actions.go
+++ b/nfs_actions.go
@@ -28,7 +28,7 @@ var _ NfsActionsService = &NfsActionsServiceOp{}
 
 // NfsAction represents an NFS action
 type NfsAction struct {
-	ID           int        `json:"id"`
+	ID           string     `json:"id"`
 	Status       string     `json:"status"`
 	Type         string     `json:"type"`
 	StartedAt    *Timestamp `json:"started_at"`

--- a/nfs_actions_test.go
+++ b/nfs_actions_test.go
@@ -16,12 +16,13 @@ func TestNfsResize(t *testing.T) {
 	mux.HandleFunc("/v2/nfs/my-nfs-id/actions", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprint(w, `{"action": {"id": 1, "status": "in-progress", "type": "resize", "resource_type": "network_file_share", "resource_id": "my-nfs-id", "region_slug": "atl1", "started_at": "2025-10-14T11:55:31.615157397Z"}}`)
+		fmt.Fprint(w, `{"action": {"id": "1", "status": "in-progress", "type": "resize", "resource_type": "network_file_share", "resource_id": "my-nfs-id", "region_slug": "atl1", "started_at": "2025-10-14T11:55:31.615157397Z"}}`)
 	})
 
 	action, resp, err := client.NfsActions.Resize(context.Background(), "my-nfs-id", 1024, "atl1")
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
+	assert.Equal(t, "1", action.ID)
 	assert.Equal(t, "my-nfs-id", action.ResourceID)
 	assert.Equal(t, "atl1", action.RegionSlug)
 	assert.Equal(t, "network_file_share", action.ResourceType)
@@ -36,12 +37,13 @@ func TestNfsSnapshot(t *testing.T) {
 	mux.HandleFunc("/v2/nfs/my-nfs-id/actions", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprint(w, `{"action": {"id": 1, "status": "in-progress", "type": "snapshot", "resource_type": "network_file_share", "resource_id": "my-nfs-id", "region_slug": "atl1", "started_at": "2025-10-14T11:55:31.615157397Z"}}`)
+		fmt.Fprint(w, `{"action": {"id": "1", "status": "in-progress", "type": "snapshot", "resource_type": "network_file_share", "resource_id": "my-nfs-id", "region_slug": "atl1", "started_at": "2025-10-14T11:55:31.615157397Z"}}`)
 	})
 
 	action, resp, err := client.NfsActions.Snapshot(context.Background(), "my-nfs-id", "my-snapshot", "atl1")
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
+	assert.Equal(t, "1", action.ID)
 	assert.Equal(t, "my-nfs-id", action.ResourceID)
 	assert.Equal(t, "atl1", action.RegionSlug)
 	assert.Equal(t, "network_file_share", action.ResourceType)
@@ -56,12 +58,13 @@ func TestNfsAttach(t *testing.T) {
 	mux.HandleFunc("/v2/nfs/my-nfs-id/actions", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprint(w, `{"action": {"id": 1, "status": "in-progress", "type": "attach", "resource_type": "network_file_share", "resource_id": "my-nfs-id", "region_slug": "atl1", "started_at": "2025-10-14T11:55:31.615157397Z"}}`)
+		fmt.Fprint(w, `{"action": {"id": "1", "status": "in-progress", "type": "attach", "resource_type": "network_file_share", "resource_id": "my-nfs-id", "region_slug": "atl1", "started_at": "2025-10-14T11:55:31.615157397Z"}}`)
 	})
 
 	action, resp, err := client.NfsActions.Attach(context.Background(), "my-nfs-id", "my-vpc-id", "atl1")
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
+	assert.Equal(t, "1", action.ID)
 	assert.Equal(t, "my-nfs-id", action.ResourceID)
 	assert.Equal(t, "atl1", action.RegionSlug)
 	assert.Equal(t, "network_file_share", action.ResourceType)
@@ -76,12 +79,13 @@ func TestNfsDetach(t *testing.T) {
 	mux.HandleFunc("/v2/nfs/my-nfs-id/actions", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprint(w, `{"action": {"id": 1, "status": "in-progress", "type": "detach", "resource_type": "network_file_share", "resource_id": "my-nfs-id", "region_slug": "atl1", "started_at": "2025-10-14T11:55:31.615157397Z"}}`)
+		fmt.Fprint(w, `{"action": {"id": "1", "status": "in-progress", "type": "detach", "resource_type": "network_file_share", "resource_id": "my-nfs-id", "region_slug": "atl1", "started_at": "2025-10-14T11:55:31.615157397Z"}}`)
 	})
 
 	action, resp, err := client.NfsActions.Detach(context.Background(), "my-nfs-id", "my-vpc-id", "atl1")
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
+	assert.Equal(t, "1", action.ID)
 	assert.Equal(t, "my-nfs-id", action.ResourceID)
 	assert.Equal(t, "atl1", action.RegionSlug)
 	assert.Equal(t, "network_file_share", action.ResourceType)
@@ -96,12 +100,13 @@ func TestNfsReassign(t *testing.T) {
 	mux.HandleFunc("/v2/nfs/my-nfs-id/actions", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprint(w, `{"action": {"id": 1, "status": "in-progress", "type": "reassign", "resource_type": "network_file_share", "resource_id": "my-nfs-id", "region_slug": "atl1", "started_at": "2025-10-14T11:55:31.615157397Z"}}`)
+		fmt.Fprint(w, `{"action": {"id": "1", "status": "in-progress", "type": "reassign", "resource_type": "network_file_share", "resource_id": "my-nfs-id", "region_slug": "atl1", "started_at": "2025-10-14T11:55:31.615157397Z"}}`)
 	})
 
 	action, resp, err := client.NfsActions.Reassign(context.Background(), "my-nfs-id", "old-vpc-id", "new-vpc-id")
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
+	assert.Equal(t, "1", action.ID)
 	assert.Equal(t, "my-nfs-id", action.ResourceID)
 	assert.Equal(t, "network_file_share", action.ResourceType)
 	assert.Equal(t, "in-progress", action.Status)
@@ -115,12 +120,13 @@ func TestNfsSwitchPerformanceTier(t *testing.T) {
 	mux.HandleFunc("/v2/nfs/my-nfs-id/actions", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprint(w, `{"action": {"id": 1, "status": "in-progress", "type": "switch_performance_tier", "resource_type": "network_file_share", "resource_id": "my-nfs-id", "region_slug": "atl1", "started_at": "2025-10-14T11:55:31.615157397Z"}}`)
+		fmt.Fprint(w, `{"action": {"id": "1", "status": "in-progress", "type": "switch_performance_tier", "resource_type": "network_file_share", "resource_id": "my-nfs-id", "region_slug": "atl1", "started_at": "2025-10-14T11:55:31.615157397Z"}}`)
 	})
 
 	action, resp, err := client.NfsActions.SwitchPerformanceTier(context.Background(), "my-nfs-id", "standard")
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
+	assert.Equal(t, "1", action.ID)
 	assert.Equal(t, "my-nfs-id", action.ResourceID)
 	assert.Equal(t, "atl1", action.RegionSlug)
 	assert.Equal(t, "network_file_share", action.ResourceType)


### PR DESCRIPTION
The nfs actions public api returns action ID as a string. Updating the godo client to match string type instead of int type.