### PR TITLE
APPS-12973: Add request based autoscaling changes to app spec

### DIFF
--- a/apps.gen.go
+++ b/apps.gen.go
@@ -124,7 +124,7 @@ const (
 	AppAlertSpecOperator_LessThan            AppAlertSpecOperator = "LESS_THAN"
 )
 
-// AppAlertSpecRule  - CPU_UTILIZATION: Represents CPU for a given container instance. Only applicable at the component level.  - MEM_UTILIZATION: Represents RAM for a given container instance. Only applicable at the component level.  - RESTART_COUNT: Represents restart count for a given container instance. Only applicable at the component level.  - DEPLOYMENT_FAILED: Represents whether a deployment has failed. Only applicable at the app level.  - DEPLOYMENT_LIVE: Represents whether a deployment has succeeded. Only applicable at the app level.  - DEPLOYMENT_STARTED: Represents whether a deployment has started. Only applicable at the app level.  - DEPLOYMENT_CANCELED: Represents whether a deployment has been canceled. Only applicable at the app level.  - DOMAIN_FAILED: Represents whether a domain configuration has failed. Only applicable at the app level.  - DOMAIN_LIVE: Represents whether a domain configuration has succeeded. Only applicable at the app level.  - AUTOSCALE_FAILED: Represents whether autoscaling has failed. Only applicable at the app level.  - AUTOSCALE_SUCCEEDED: Represents whether autoscaling has succeeded. Only applicable at the app level. - FUNCTIONS_ACTIVATION_COUNT: Represents an activation count for a given functions instance. Only applicable to functions components.  - FUNCTIONS_AVERAGE_DURATION_MS: Represents the average duration for function runtimes. Only applicable to functions components.  - FUNCTIONS_ERROR_RATE_PER_MINUTE: Represents an error rate per minute for a given functions instance. Only applicable to functions components.  - FUNCTIONS_AVERAGE_WAIT_TIME_MS: Represents the average wait time for functions. Only applicable to functions components.  - FUNCTIONS_ERROR_COUNT: Represents an error count for a given functions instance. Only applicable to functions components.  - FUNCTIONS_GB_RATE_PER_SECOND: Represents the rate of memory consumption (GB x seconds) for functions. Only applicable to functions components.
+// AppAlertSpecRule  - CPU_UTILIZATION: Represents CPU for a given container instance. Only applicable at the component level.  - MEM_UTILIZATION: Represents RAM for a given container instance. Only applicable at the component level.  - RESTART_COUNT: Represents restart count for a given container instance. Only applicable at the component level.  - DEPLOYMENT_FAILED: Represents whether a deployment has failed. Only applicable at the app level.  - DEPLOYMENT_LIVE: Represents whether a deployment has succeeded. Only applicable at the app level.  - DEPLOYMENT_STARTED: Represents whether a deployment has started. Only applicable at the app level.  - DEPLOYMENT_CANCELED: Represents whether a deployment has been canceled. Only applicable at the app level.  - DOMAIN_FAILED: Represents whether a domain configuration has failed. Only applicable at the app level.  - DOMAIN_LIVE: Represents whether a domain configuration has succeeded. Only applicable at the app level.  - AUTOSCALE_FAILED: Represents whether autoscaling has failed. Only applicable at the app level.  - AUTOSCALE_SUCCEEDED: Represents whether autoscaling has succeeded. Only applicable at the app level.  - JOB_INVOCATION_FAILED: Represents whether a job invocation has failed. Only applicable to scheduled job components.  - FUNCTIONS_ACTIVATION_COUNT: Represents an activation count for a given functions instance. Only applicable to functions components.  - FUNCTIONS_AVERAGE_DURATION_MS: Represents the average duration for function runtimes. Only applicable to functions components.  - FUNCTIONS_ERROR_RATE_PER_MINUTE: Represents an error rate per minute for a given functions instance. Only applicable to functions components.  - FUNCTIONS_AVERAGE_WAIT_TIME_MS: Represents the average wait time for functions. Only applicable to functions components.  - FUNCTIONS_ERROR_COUNT: Represents an error count for a given functions instance. Only applicable to functions components.  - FUNCTIONS_GB_RATE_PER_SECOND: Represents the rate of memory consumption (GB x seconds) for functions. Only applicable to functions components.  - REQUESTS_PER_SECOND: Represents requests per second for a service. Only applicable to service components.  - REQUEST_DURATION_P95_MS: Represents request duration p95 in milliseconds for a service. Only applicable to service components.
 type AppAlertSpecRule string
 
 // List of AppAlertSpecRule
@@ -148,6 +148,8 @@ const (
 	AppAlertSpecRule_FunctionsAverageWaitTimeMs  AppAlertSpecRule = "FUNCTIONS_AVERAGE_WAIT_TIME_MS"
 	AppAlertSpecRule_FunctionsErrorCount         AppAlertSpecRule = "FUNCTIONS_ERROR_COUNT"
 	AppAlertSpecRule_FunctionsGBRatePerSecond    AppAlertSpecRule = "FUNCTIONS_GB_RATE_PER_SECOND"
+	AppAlertSpecRule_RequestsPerSecond           AppAlertSpecRule = "REQUESTS_PER_SECOND"
+	AppAlertSpecRule_RequestDurationP95Ms        AppAlertSpecRule = "REQUEST_DURATION_P95_MS"
 )
 
 // AppAlertSpecWindow the model 'AppAlertSpecWindow'
@@ -177,9 +179,23 @@ type AppAutoscalingSpecMetricCPU struct {
 	Percent int64 `json:"percent,omitempty"`
 }
 
+// AppAutoscalingSpecMetricRequestDuration struct for AppAutoscalingSpecMetricRequestDuration
+type AppAutoscalingSpecMetricRequestDuration struct {
+	// The p95 target request duration in milliseconds for the component.
+	P95Milliseconds int64 `json:"p95_milliseconds,omitempty"`
+}
+
+// AppAutoscalingSpecMetricRequestsPerSecond struct for AppAutoscalingSpecMetricRequestsPerSecond
+type AppAutoscalingSpecMetricRequestsPerSecond struct {
+	// The target number of requests per second per instance for the component.
+	PerInstance int64 `json:"per_instance,omitempty"`
+}
+
 // AppAutoscalingSpecMetrics struct for AppAutoscalingSpecMetrics
 type AppAutoscalingSpecMetrics struct {
-	CPU *AppAutoscalingSpecMetricCPU `json:"cpu,omitempty"`
+	CPU               *AppAutoscalingSpecMetricCPU               `json:"cpu,omitempty"`
+	RequestsPerSecond *AppAutoscalingSpecMetricRequestsPerSecond `json:"requests_per_second,omitempty"`
+	RequestDuration   *AppAutoscalingSpecMetricRequestDuration   `json:"request_duration,omitempty"`
 }
 
 // AppBuildConfig struct for AppBuildConfig
@@ -756,13 +772,15 @@ type AppWorkerSpecTermination struct {
 type AutoscalerActionScaleChange struct {
 	From int64 `json:"from,omitempty"`
 	To   int64 `json:"to,omitempty"`
+	// The metric that triggered the scale change while scaling up. Known values are \"cpu\", \"requests_per_second\", \"request_duration\". For inactivity sleep, \"scale_from_zero\" and \"scale_to_zero\" are used.
+	TriggeringMetric string `json:"triggering_metric,omitempty"`
 }
 
 // AutoscalingEventComponentScaleChange struct for AutoscalingEventComponentScaleChange
 type AutoscalingEventComponentScaleChange struct {
 	From int64 `json:"from,omitempty"`
 	To   int64 `json:"to,omitempty"`
-	// The metric that triggered the scale change while scaling up. Known values are "cpu", "requests_per_second", "request_duration". For inactivity sleep, "scale_from_zero" and "scale_to_zero" are used.
+	// The metric that triggered the scale change while scaling up. Known values are \"cpu\", \"requests_per_second\", \"request_duration\". For inactivity sleep, \"scale_from_zero\" and \"scale_to_zero\" are used.
 	TriggeringMetric string `json:"triggering_metric,omitempty"`
 }
 

--- a/apps_accessors.go
+++ b/apps_accessors.go
@@ -405,12 +405,44 @@ func (a *AppAutoscalingSpecMetricCPU) GetPercent() int64 {
 	return a.Percent
 }
 
+// GetP95Milliseconds returns the P95Milliseconds field.
+func (a *AppAutoscalingSpecMetricRequestDuration) GetP95Milliseconds() int64 {
+	if a == nil {
+		return 0
+	}
+	return a.P95Milliseconds
+}
+
+// GetPerInstance returns the PerInstance field.
+func (a *AppAutoscalingSpecMetricRequestsPerSecond) GetPerInstance() int64 {
+	if a == nil {
+		return 0
+	}
+	return a.PerInstance
+}
+
 // GetCPU returns the CPU field.
 func (a *AppAutoscalingSpecMetrics) GetCPU() *AppAutoscalingSpecMetricCPU {
 	if a == nil {
 		return nil
 	}
 	return a.CPU
+}
+
+// GetRequestDuration returns the RequestDuration field.
+func (a *AppAutoscalingSpecMetrics) GetRequestDuration() *AppAutoscalingSpecMetricRequestDuration {
+	if a == nil {
+		return nil
+	}
+	return a.RequestDuration
+}
+
+// GetRequestsPerSecond returns the RequestsPerSecond field.
+func (a *AppAutoscalingSpecMetrics) GetRequestsPerSecond() *AppAutoscalingSpecMetricRequestsPerSecond {
+	if a == nil {
+		return nil
+	}
+	return a.RequestsPerSecond
 }
 
 // GetCNBVersioning returns the CNBVersioning field.
@@ -2635,6 +2667,14 @@ func (a *AutoscalerActionScaleChange) GetTo() int64 {
 		return 0
 	}
 	return a.To
+}
+
+// GetTriggeringMetric returns the TriggeringMetric field.
+func (a *AutoscalerActionScaleChange) GetTriggeringMetric() string {
+	if a == nil {
+		return ""
+	}
+	return a.TriggeringMetric
 }
 
 // GetFrom returns the From field.

--- a/apps_accessors_test.go
+++ b/apps_accessors_test.go
@@ -356,11 +356,39 @@ func TestAppAutoscalingSpecMetricCPU_GetPercent(tt *testing.T) {
 	a.GetPercent()
 }
 
+func TestAppAutoscalingSpecMetricRequestDuration_GetP95Milliseconds(tt *testing.T) {
+	a := &AppAutoscalingSpecMetricRequestDuration{}
+	a.GetP95Milliseconds()
+	a = nil
+	a.GetP95Milliseconds()
+}
+
+func TestAppAutoscalingSpecMetricRequestsPerSecond_GetPerInstance(tt *testing.T) {
+	a := &AppAutoscalingSpecMetricRequestsPerSecond{}
+	a.GetPerInstance()
+	a = nil
+	a.GetPerInstance()
+}
+
 func TestAppAutoscalingSpecMetrics_GetCPU(tt *testing.T) {
 	a := &AppAutoscalingSpecMetrics{}
 	a.GetCPU()
 	a = nil
 	a.GetCPU()
+}
+
+func TestAppAutoscalingSpecMetrics_GetRequestDuration(tt *testing.T) {
+	a := &AppAutoscalingSpecMetrics{}
+	a.GetRequestDuration()
+	a = nil
+	a.GetRequestDuration()
+}
+
+func TestAppAutoscalingSpecMetrics_GetRequestsPerSecond(tt *testing.T) {
+	a := &AppAutoscalingSpecMetrics{}
+	a.GetRequestsPerSecond()
+	a = nil
+	a.GetRequestsPerSecond()
 }
 
 func TestAppBuildConfig_GetCNBVersioning(tt *testing.T) {
@@ -2309,6 +2337,13 @@ func TestAutoscalerActionScaleChange_GetTo(tt *testing.T) {
 	a.GetTo()
 }
 
+func TestAutoscalerActionScaleChange_GetTriggeringMetric(tt *testing.T) {
+	a := &AutoscalerActionScaleChange{}
+	a.GetTriggeringMetric()
+	a = nil
+	a.GetTriggeringMetric()
+}
+
 func TestAutoscalingEventComponentScaleChange_GetFrom(tt *testing.T) {
 	a := &AutoscalingEventComponentScaleChange{}
 	a.GetFrom()
@@ -3300,7 +3335,10 @@ func TestEvent_GetType(tt *testing.T) {
 }
 
 func TestEventAutoscalingEvent_GetComponents(tt *testing.T) {
-	e := &EventAutoscalingEvent{}
+	zeroValue := map[string]AutoscalingEventComponentScaleChange{}
+	e := &EventAutoscalingEvent{Components: zeroValue}
+	e.GetComponents()
+	e = &EventAutoscalingEvent{}
 	e.GetComponents()
 	e = nil
 	e.GetComponents()


### PR DESCRIPTION
Adds new `requests_per_second` and `request_duration` metric types to autoscaling and their corresponding alerts.