### PR TITLE
App Ingress authority routing only supports exact matching #937

### DIFF
--- a/apps.gen.go
+++ b/apps.gen.go
@@ -389,8 +389,8 @@ type AppIngressSpecRuleRoutingRedirect struct {
 // AppIngressSpecRuleStringMatch The string match configuration.
 type AppIngressSpecRuleStringMatch struct {
 	// Prefix-based match. For example, `/api` will match `/api`, `/api/`, and any nested paths such as `/api/v1/endpoint`.
-	Prefix string `json:"prefix,omitempty"`
-	Exact  string `json:"exact,omitempty"`
+	Prefix *string `json:"prefix,omitempty"`
+	Exact  *string `json:"exact,omitempty"`
 }
 
 type AppSecureHeaderSpec struct {

--- a/apps_accessors.go
+++ b/apps_accessors.go
@@ -1079,18 +1079,18 @@ func (a *AppIngressSpecRuleRoutingRedirect) GetUri() string {
 
 // GetExact returns the Exact field.
 func (a *AppIngressSpecRuleStringMatch) GetExact() string {
-	if a == nil {
+	if a == nil || a.Exact == nil {
 		return ""
 	}
-	return a.Exact
+	return *a.Exact
 }
 
 // GetPrefix returns the Prefix field.
 func (a *AppIngressSpecRuleStringMatch) GetPrefix() string {
-	if a == nil {
+	if a == nil || a.Prefix == nil {
 		return ""
 	}
-	return a.Prefix
+	return *a.Prefix
 }
 
 // GetComponentName returns the ComponentName field.

--- a/apps_accessors_test.go
+++ b/apps_accessors_test.go
@@ -945,14 +945,20 @@ func TestAppIngressSpecRuleRoutingRedirect_GetUri(tt *testing.T) {
 }
 
 func TestAppIngressSpecRuleStringMatch_GetExact(tt *testing.T) {
-	a := &AppIngressSpecRuleStringMatch{}
+	var zeroValue string
+	a := &AppIngressSpecRuleStringMatch{Exact: &zeroValue}
+	a.GetExact()
+	a = &AppIngressSpecRuleStringMatch{}
 	a.GetExact()
 	a = nil
 	a.GetExact()
 }
 
 func TestAppIngressSpecRuleStringMatch_GetPrefix(tt *testing.T) {
-	a := &AppIngressSpecRuleStringMatch{}
+	var zeroValue string
+	a := &AppIngressSpecRuleStringMatch{Prefix: &zeroValue}
+	a.GetPrefix()
+	a = &AppIngressSpecRuleStringMatch{}
 	a.GetPrefix()
 	a = nil
 	a.GetPrefix()

--- a/apps_test.go
+++ b/apps_test.go
@@ -730,7 +730,62 @@ func TestApps_GetLogs_component(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, logs.LiveURL)
 }
+// TestAppIngressSpecRuleMatchAuthorityJSON ensures ingress rule match JSON from the API
+// decodes authority and path prefix fields as expected, including empty strings.
+func TestAppIngressSpecRuleMatchAuthorityJSON(t *testing.T) {
+	exactEmpty := ""
+	exactDomain := "example.com"
+	pathSlash := "/"
+	pathEmpty := ""
 
+	tests := []struct {
+		name  string
+		input string
+		want  AppIngressSpecRuleMatch
+	}{
+		{
+			name:  "authority with empty exact string",
+			input: `{"path":{"prefix":"/"},"authority":{"exact":""}}`,
+			want: AppIngressSpecRuleMatch{
+				Path:      &AppIngressSpecRuleStringMatch{Prefix: &pathSlash},
+				Authority: &AppIngressSpecRuleStringMatch{Exact: &exactEmpty},
+			},
+		},
+		{
+			name:  "authority with non-empty exact string",
+			input: `{"path":{"prefix":"/"},"authority":{"exact":"example.com"}}`,
+			want: AppIngressSpecRuleMatch{
+				Path:      &AppIngressSpecRuleStringMatch{Prefix: &pathSlash},
+				Authority: &AppIngressSpecRuleStringMatch{Exact: &exactDomain},
+			},
+		},
+		{
+			name:  "no authority set",
+			input: `{"path":{"prefix":"/"}}`,
+			want: AppIngressSpecRuleMatch{
+				Path:      &AppIngressSpecRuleStringMatch{Prefix: &pathSlash},
+				Authority: nil,
+			},
+		},
+		{
+			name:  "authority with empty exact string and empty path prefix",
+			input: `{"path":{"prefix":""},"authority":{"exact":""}}`,
+			want: AppIngressSpecRuleMatch{
+				Path:      &AppIngressSpecRuleStringMatch{Prefix: &pathEmpty},
+				Authority: &AppIngressSpecRuleStringMatch{Exact: &exactEmpty},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var got AppIngressSpecRuleMatch
+			err := json.Unmarshal([]byte(tc.input), &got)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
 func TestApps_ListRegions(t *testing.T) {
 	setup()
 	defer teardown()

--- a/apps_test.go
+++ b/apps_test.go
@@ -730,6 +730,7 @@ func TestApps_GetLogs_component(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, logs.LiveURL)
 }
+
 // TestAppIngressSpecRuleMatchAuthorityJSON ensures ingress rule match JSON from the API
 // decodes authority and path prefix fields as expected, including empty strings.
 func TestAppIngressSpecRuleMatchAuthorityJSON(t *testing.T) {


### PR DESCRIPTION
Issue - https://github.com/digitalocean/godo/issues/937

Root Cause
The bug is in 
https://github.com/aupadhyay-shark/godo/blob/e9ef74c396061df3c575c27b8d5f44c789424139/apps.gen.go

type AppIngressSpecRuleStringMatch struct {
Prefix string json:"prefix,omitempty"
Exact string json:"exact,omitempty"
}

Fix
Changed Prefix and Exact from string to *string in AppIngressSpecRuleStringMatch