### PR TITLE
DOKS: per cluster sso config

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -27,7 +27,7 @@ type KubernetesService interface {
 	Get(context.Context, string) (*KubernetesCluster, *Response, error)
 	GetUser(context.Context, string) (*KubernetesClusterUser, *Response, error)
 	GetUpgrades(context.Context, string) ([]*KubernetesVersion, *Response, error)
-	GetKubeConfig(context.Context, string) (*KubernetesClusterConfig, *Response, error)
+	GetKubeConfig(context.Context, string, *KubernetesClusterKubeconfigGetRequest) (*KubernetesClusterConfig, *Response, error)
 	GetKubeConfigWithExpiry(context.Context, string, int64) (*KubernetesClusterConfig, *Response, error)
 	GetCredentials(context.Context, string, *KubernetesClusterCredentialsGetRequest) (*KubernetesClusterCredentials, *Response, error)
 	List(context.Context, *ListOptions) ([]*KubernetesCluster, *Response, error)
@@ -186,6 +186,11 @@ type KubernetesNodeDeleteRequest struct {
 // KubernetesClusterCredentialsGetRequest is a request to get cluster credentials.
 type KubernetesClusterCredentialsGetRequest struct {
 	ExpirySeconds *int `json:"expiry_seconds,omitempty"`
+}
+
+// KubernetesClusterKubeconfigGetRequest is a request to get cluster kubeconfig.
+type KubernetesClusterKubeconfigGetRequest struct {
+	Type string `json:"type,omitempty"`
 }
 
 // KubernetesClusterRegistryRequest represents clusters to integrate with docr registry
@@ -793,12 +798,17 @@ type KubernetesClusterConfig struct {
 }
 
 // GetKubeConfig returns a Kubernetes config file for the specified cluster.
-func (svc *KubernetesServiceOp) GetKubeConfig(ctx context.Context, clusterID string) (*KubernetesClusterConfig, *Response, error) {
+func (svc *KubernetesServiceOp) GetKubeConfig(ctx context.Context, clusterID string, get *KubernetesClusterKubeconfigGetRequest) (*KubernetesClusterConfig, *Response, error) {
 	path := fmt.Sprintf("%s/%s/kubeconfig", kubernetesClustersPath, clusterID)
 	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	q := req.URL.Query()
+	if get.Type != "" {
+		q.Add("type", get.Type)
+	}
+	req.URL.RawQuery = q.Encode()
 	configBytes := bytes.NewBuffer(nil)
 	resp, err := svc.client.Do(ctx, req, configBytes)
 	if err != nil {
@@ -811,6 +821,7 @@ func (svc *KubernetesServiceOp) GetKubeConfig(ctx context.Context, clusterID str
 }
 
 // GetKubeConfigWithExpiry returns a Kubernetes config file for the specified cluster with expiry_seconds.
+// Expiry only makes sense for token-based kubeconfigs.
 func (svc *KubernetesServiceOp) GetKubeConfigWithExpiry(ctx context.Context, clusterID string, expirySeconds int64) (*KubernetesClusterConfig, *Response, error) {
 	path := fmt.Sprintf("%s/%s/kubeconfig", kubernetesClustersPath, clusterID)
 	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -325,11 +325,11 @@ type KubernetesRdmaSharedDevicePlugin struct {
 }
 
 // KubernetesClusterSSO configures Single Sign-On (SSO) for a Kubernetes cluster.
-// Identity Provider (IDP) settings for SSO are set up on the team level,
-// whereas on a per-cluster level, users can enable or require SSO for the cluster.
 type KubernetesClusterSSO struct {
-	Enabled  *bool `json:"enabled,omitempty"`
-	Required *bool `json:"required,omitempty"`
+	Enabled   bool   `json:"enabled"`
+	Required  bool   `json:"required"`
+	IssuerURL string `json:"issuer_url,omitempty"`
+	ClientID  string `json:"client_id,omitempty"`
 }
 
 // KubernetesMaintenancePolicyDay represents the possible days of a maintenance

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -499,9 +499,30 @@ func TestKubernetesClusters_GetKubeConfig(t *testing.T) {
 	blob := []byte(want)
 	mux.HandleFunc("/v2/kubernetes/clusters/deadbeef-dead-4aa5-beef-deadbeef347d/kubeconfig", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
+		_, isTypeQueryParamSet := r.URL.Query()["type"]
+		assert.False(t, isTypeQueryParamSet)
 		fmt.Fprint(w, want)
 	})
-	got, _, err := kubeSvc.GetKubeConfig(ctx, "deadbeef-dead-4aa5-beef-deadbeef347d")
+	got, _, err := kubeSvc.GetKubeConfig(ctx, "deadbeef-dead-4aa5-beef-deadbeef347d", &KubernetesClusterKubeconfigGetRequest{})
+	require.NoError(t, err)
+	require.Equal(t, blob, got.KubeconfigYAML)
+}
+
+func TestKubernetesClusters_GetKubeConfig_WithType(t *testing.T) {
+	setup()
+	defer teardown()
+
+	kubeSvc := client.Kubernetes
+	want := "some YAML"
+	blob := []byte(want)
+	mux.HandleFunc("/v2/kubernetes/clusters/deadbeef-dead-4aa5-beef-deadbeef347d/kubeconfig", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		assert.Equal(t, "token", r.URL.Query().Get("type"))
+		fmt.Fprint(w, want)
+	})
+	got, _, err := kubeSvc.GetKubeConfig(ctx, "deadbeef-dead-4aa5-beef-deadbeef347d", &KubernetesClusterKubeconfigGetRequest{
+		Type: "token",
+	})
 	require.NoError(t, err)
 	require.Equal(t, blob, got.KubeconfigYAML)
 }

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -49,7 +49,9 @@ func TestKubernetesClusters_ListClusters(t *testing.T) {
 				Enabled: PtrTo(true),
 			},
 			SSO: &KubernetesClusterSSO{
-				Enabled: PtrTo(true),
+				Enabled:   true,
+				IssuerURL: "https://example.com/issuer",
+				ClientID:  "client-id",
 			},
 			NodePools: []*KubernetesNodePool{
 				{
@@ -157,7 +159,10 @@ func TestKubernetesClusters_ListClusters(t *testing.T) {
 				"enabled": true
 			},
 			"sso": {
-			    "enabled": true
+			    "enabled": true,
+				"required": false,
+				"issuer_url": "https://example.com/issuer",
+				"client_id": "client-id"
 			},
 			"node_pools": [
 				{
@@ -316,8 +321,9 @@ func TestKubernetesClusters_Get(t *testing.T) {
 			Enabled: PtrTo(true),
 		},
 		SSO: &KubernetesClusterSSO{
-			Enabled:  PtrTo(true),
-			Required: PtrTo(false),
+			Enabled:   true,
+			IssuerURL: "https://example.com/issuer",
+			ClientID:  "client-id",
 		},
 		NodePools: []*KubernetesNodePool{
 			{
@@ -387,7 +393,9 @@ func TestKubernetesClusters_Get(t *testing.T) {
 		},
 		"sso": {
 			"enabled": true,
-			"required": false
+			"required": false,
+			"issuer_url": "https://example.com/issuer",
+			"client_id": "client-id"
 		},
 		"node_pools": [
 			{
@@ -650,8 +658,10 @@ func TestKubernetesClusters_Create(t *testing.T) {
 			Enabled: PtrTo(true),
 		},
 		SSO: &KubernetesClusterSSO{
-			Enabled:  PtrTo(true),
-			Required: PtrTo(false),
+			Enabled:   true,
+			Required:  false,
+			IssuerURL: "https://example.com/issuer",
+			ClientID:  "client-id",
 		},
 		NodePools: []*KubernetesNodePool{
 			{
@@ -705,7 +715,9 @@ func TestKubernetesClusters_Create(t *testing.T) {
 			Enabled: PtrTo(true),
 		},
 		SSO: &KubernetesClusterSSO{
-			Enabled: PtrTo(true),
+			Enabled:   true,
+			IssuerURL: "https://example.com/issuer",
+			ClientID:  "client-id",
 		},
 		NodePools: []*KubernetesNodePoolCreateRequest{
 			{
@@ -756,7 +768,9 @@ func TestKubernetesClusters_Create(t *testing.T) {
 		},
 		"sso": {
 			"enabled": true,
-			"required": false
+			"required": false,
+			"issuer_url": "https://example.com/issuer",
+			"client_id": "client-id"
 		},
 		"node_pools": [
 			{
@@ -973,7 +987,7 @@ func TestKubernetesClusters_Update(t *testing.T) {
 			Enabled: PtrTo(true),
 		},
 		SSO: &KubernetesClusterSSO{
-			Enabled: PtrTo(false),
+			Enabled: false,
 		},
 	}
 	updateRequest := &KubernetesClusterUpdateRequest{
@@ -1008,7 +1022,7 @@ func TestKubernetesClusters_Update(t *testing.T) {
 			Enabled: PtrTo(true),
 		},
 		SSO: &KubernetesClusterSSO{
-			Enabled: PtrTo(false),
+			Enabled: false,
 		},
 	}
 
@@ -1072,12 +1086,13 @@ func TestKubernetesClusters_Update(t *testing.T) {
 			"enabled": true
 		},
 		"sso": {
-			"enabled": false
+			"enabled": false,
+			"required": false
 		}
 	}
 }`
 
-	expectedReqJSON := `{"name":"antoine-test-cluster","tags":["cluster-tag-1","cluster-tag-2"],"maintenance_policy":{"start_time":"00:00","duration":"","day":"monday"},"surge_upgrade":true,"control_plane_firewall":{"enabled":true,"allowed_addresses":["1.2.3.4/32"]},"cluster_autoscaler_configuration":{"scale_down_utilization_threshold":0.2,"scale_down_unneeded_time":"1m27s","expanders":[]},"routing_agent":{"enabled":true},"amd_gpu_device_plugin":{"enabled":true},"amd_gpu_device_metrics_exporter_plugin":{"enabled":true},"nvidia_gpu_device_plugin":{"enabled":true},"rdma_shared_dev_plugin":{"enabled":true},"sso":{"enabled":false}}
+	expectedReqJSON := `{"name":"antoine-test-cluster","tags":["cluster-tag-1","cluster-tag-2"],"maintenance_policy":{"start_time":"00:00","duration":"","day":"monday"},"surge_upgrade":true,"control_plane_firewall":{"enabled":true,"allowed_addresses":["1.2.3.4/32"]},"cluster_autoscaler_configuration":{"scale_down_utilization_threshold":0.2,"scale_down_unneeded_time":"1m27s","expanders":[]},"routing_agent":{"enabled":true},"amd_gpu_device_plugin":{"enabled":true},"amd_gpu_device_metrics_exporter_plugin":{"enabled":true},"nvidia_gpu_device_plugin":{"enabled":true},"rdma_shared_dev_plugin":{"enabled":true},"sso":{"enabled":false,"required":false}}
 `
 
 	mux.HandleFunc("/v2/kubernetes/clusters/8d91899c-0739-4a1a-acc5-deadbeefbb8f", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Pivoting DOKS SSO to per-cluster SSO apps (rather than using the SSO app configured on the team level).
And preparing the methods that downloading kubeconfigs to be able to download them for SSO-enabled clusters.
The feature is currently not available to the users, so I'm not worried about making breaking changes.