### PR TITLE
Add BatchInferenceService for the inference proxy batch API

### DIFF
--- a/batch_inference.go
+++ b/batch_inference.go
@@ -1,0 +1,271 @@
+package godo
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+const (
+	defaultBatchInferenceBaseURL = "https://inference.do-ai.run/"
+	batchInferenceBasePath       = "v1/batches"
+	batchInferenceFilePath       = batchInferenceBasePath + "/files"
+	batchInferenceByIDPath       = batchInferenceBasePath + "/%s"
+	batchInferenceResultsPath    = batchInferenceBasePath + "/%s/results"
+	batchInferenceCancelPath     = batchInferenceBasePath + "/%s/cancel"
+)
+
+// BatchInferenceService is an interface for managing batch inference jobs
+// via the inference proxy at inference.do-ai.run.
+type BatchInferenceService interface {
+	CreatePresignedUploadURL(context.Context, *CreateBatchFileRequest) (*CreateBatchFileResponse, *Response, error)
+	UploadInputFile(ctx context.Context, uploadURL string, content io.Reader) (*Response, error)
+	CreateJob(context.Context, *CreateBatchRequest) (*Batch, *Response, error)
+	ListJobs(context.Context, *ListBatchesOptions) (*ListBatchesResponse, *Response, error)
+	GetJob(context.Context, string) (*Batch, *Response, error)
+	CancelJob(context.Context, string) (*Batch, *Response, error)
+	GetJobResult(context.Context, string) (*BatchResultsResponse, *Response, error)
+}
+
+// BatchInferenceServiceOp handles communication with the batch inference
+// endpoints on the inference proxy (inference.do-ai.run).
+type BatchInferenceServiceOp struct {
+	client  *Client
+	baseURL *url.URL
+}
+
+var _ BatchInferenceService = &BatchInferenceServiceOp{}
+
+// -- Request types --
+
+// CreateBatchFileRequest represents a request to create a presigned URL for
+// uploading a batch JSONL input file.
+type CreateBatchFileRequest struct {
+	FileName string `json:"file_name"`
+}
+
+// CreateBatchRequest represents a request to create a batch inference job.
+// Provider is always required. Endpoint is required only when Provider is "openai".
+type CreateBatchRequest struct {
+	Provider         string `json:"provider"`
+	FileID           string `json:"file_id"`
+	CompletionWindow string `json:"completion_window"`
+	RequestID        string `json:"request_id,omitempty"`
+	Endpoint         string `json:"endpoint,omitempty"`
+}
+
+// ListBatchesOptions specifies optional query parameters for listing batch jobs.
+type ListBatchesOptions struct {
+	After  string `url:"after,omitempty"`
+	Limit  int    `url:"limit,omitempty"`
+	Status string `url:"status,omitempty"`
+}
+
+// -- Response types --
+
+// CreateBatchFileResponse is returned when creating a presigned file upload URL.
+type CreateBatchFileResponse struct {
+	FileID    string `json:"file_id"`
+	UploadURL string `json:"upload_url"`
+	ExpiresAt string `json:"expires_at"`
+}
+
+// BatchRequestCounts holds per-request completion counts for a batch job.
+type BatchRequestCounts struct {
+	Total     int `json:"total"`
+	Completed int `json:"completed"`
+	Failed    int `json:"failed"`
+}
+
+// Batch represents a batch inference job returned by the inference proxy.
+// Timestamps are ISO 8601 strings. Nullable fields use *string.
+type Batch struct {
+	BatchID           string              `json:"batch_id"`
+	Provider          string              `json:"provider"`
+	FileID            string              `json:"file_id"`
+	CompletionWindow  string              `json:"completion_window"`
+	Status            string              `json:"status"`
+	RequestID         string              `json:"request_id"`
+	RequestCounts     *BatchRequestCounts `json:"request_counts,omitempty"`
+	ResultAvailable   bool                `json:"result_available"`
+	CancelRequestedAt *string             `json:"cancel_requested_at"`
+	CreatedAt         string              `json:"created_at"`
+	UpdatedAt         string              `json:"updated_at"`
+	ExpiresAt         *string             `json:"expires_at"`
+}
+
+// BatchEdge is a single edge in the Relay-style batch list response.
+type BatchEdge struct {
+	Cursor string `json:"cursor"`
+	Node   Batch  `json:"node"`
+}
+
+// BatchPageInfo holds forward-only pagination info for batch listing.
+type BatchPageInfo struct {
+	EndCursor   string `json:"endCursor"`
+	HasNextPage bool   `json:"hasNextPage"`
+}
+
+// ListBatchesResponse is returned by GET /v1/batches.
+// Uses Relay-style cursor pagination.
+type ListBatchesResponse struct {
+	Edges    []BatchEdge   `json:"edges"`
+	PageInfo BatchPageInfo `json:"page_info"`
+}
+
+// BatchResultsDownload holds the presigned download URL and its expiry.
+type BatchResultsDownload struct {
+	PresignedURL string `json:"presigned_url"`
+	ExpiresAt    string `json:"expires_at"`
+}
+
+// BatchResultsResponse is returned by GET /v1/batches/{batch_id}/results.
+type BatchResultsResponse struct {
+	Download     BatchResultsDownload `json:"download"`
+	OutputFileID string               `json:"output_file_id"`
+}
+
+// -- helpers --
+
+// newRequest builds an HTTP request resolved against the inference proxy base URL
+// rather than the default api.digitalocean.com. The resulting absolute URL is
+// passed to Client.NewRequest so that standard headers and auth are applied.
+func (s *BatchInferenceServiceOp) newRequest(ctx context.Context, method, path string, body interface{}) (*http.Request, error) {
+	rel, err := url.Parse(path)
+	if err != nil {
+		return nil, err
+	}
+	u := s.baseURL.ResolveReference(rel)
+	return s.client.NewRequest(ctx, method, u.String(), body)
+}
+
+// -- Service methods --
+
+// CreatePresignedUploadURL creates a presigned URL for uploading a batch JSONL input file.
+func (s *BatchInferenceServiceOp) CreatePresignedUploadURL(ctx context.Context, createReq *CreateBatchFileRequest) (*CreateBatchFileResponse, *Response, error) {
+	req, err := s.newRequest(ctx, http.MethodPost, batchInferenceFilePath, createReq)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(CreateBatchFileResponse)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root, resp, nil
+}
+
+// UploadInputFile uploads batch JSONL content to a presigned S3 URL returned by
+// CreatePresignedUploadURL. A plain HTTP client is used (no Authorization header)
+// because the presigned URL already embeds authentication in its query parameters.
+func (s *BatchInferenceServiceOp) UploadInputFile(ctx context.Context, uploadURL string, content io.Reader) (*Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, uploadURL, content)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-ndjson")
+
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
+
+	response := newResponse(resp)
+	if err := CheckResponse(resp); err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+// CreateJob creates a new batch inference job.
+func (s *BatchInferenceServiceOp) CreateJob(ctx context.Context, createReq *CreateBatchRequest) (*Batch, *Response, error) {
+	req, err := s.newRequest(ctx, http.MethodPost, batchInferenceBasePath, createReq)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(Batch)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root, resp, nil
+}
+
+// ListJobs returns a list of batch inference jobs with optional filtering and pagination.
+func (s *BatchInferenceServiceOp) ListJobs(ctx context.Context, opts *ListBatchesOptions) (*ListBatchesResponse, *Response, error) {
+	path, err := addOptions(batchInferenceBasePath, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.newRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(ListBatchesResponse)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root, resp, nil
+}
+
+// GetJob retrieves a batch inference job by ID.
+func (s *BatchInferenceServiceOp) GetJob(ctx context.Context, batchID string) (*Batch, *Response, error) {
+	path := fmt.Sprintf(batchInferenceByIDPath, batchID)
+
+	req, err := s.newRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(Batch)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root, resp, nil
+}
+
+// CancelJob requests cancellation of a batch inference job.
+func (s *BatchInferenceServiceOp) CancelJob(ctx context.Context, batchID string) (*Batch, *Response, error) {
+	path := fmt.Sprintf(batchInferenceCancelPath, batchID)
+
+	req, err := s.newRequest(ctx, http.MethodPost, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(Batch)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root, resp, nil
+}
+
+// GetJobResult retrieves the result download URLs for a completed batch inference job.
+func (s *BatchInferenceServiceOp) GetJobResult(ctx context.Context, batchID string) (*BatchResultsResponse, *Response, error) {
+	path := fmt.Sprintf(batchInferenceResultsPath, batchID)
+
+	req, err := s.newRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(BatchResultsResponse)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root, resp, nil
+}

--- a/batch_inference_test.go
+++ b/batch_inference_test.go
@@ -1,0 +1,465 @@
+package godo
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// batchInferenceSetup creates a test server and configures the client so that
+// BatchInferenceServiceOp routes requests to the local mock server.
+func batchInferenceSetup() func() {
+	setup()
+
+	// Point the batch-inference service's base URL at the test server.
+	u, _ := url.Parse(server.URL + "/")
+	client.BatchInference.(*BatchInferenceServiceOp).baseURL = u
+
+	return teardown
+}
+
+var (
+	batchFileUploadResponse = `{
+  "file_id": "b7d562e0-49ae-43f7-820d-6a37a2f05435",
+  "upload_url": "https://spaces.example.com/batch-inputs/1/b7d562e0.jsonl?token=xyz",
+  "expires_at": "2026-04-21T17:49:27.536939587Z"
+}`
+
+	batchCreateResponse = `{
+  "batch_id": "11f13da9-64a4-fe5b-8567-a23ae3abd3e2",
+  "cancel_requested_at": null,
+  "completion_window": "24h",
+  "created_at": "2026-04-21T17:41:57Z",
+  "expires_at": "2026-04-21T17:49:28Z",
+  "file_id": "b7d562e0-49ae-43f7-820d-6a37a2f05435",
+  "provider": "anthropic",
+  "request_counts": {
+    "total": 0,
+    "completed": 0,
+    "failed": 0
+  },
+  "request_id": "postman-1776793316",
+  "result_available": false,
+  "status": "queued",
+  "updated_at": "2026-04-21T17:41:57Z"
+}`
+
+	batchGetResponse = `{
+  "batch_id": "11f13da9-64a4-fe5b-8567-a23ae3abd3e2",
+  "cancel_requested_at": null,
+  "completion_window": "24h",
+  "created_at": "2026-04-21T17:41:57Z",
+  "expires_at": "2026-04-21T17:49:28Z",
+  "file_id": "b7d562e0-49ae-43f7-820d-6a37a2f05435",
+  "provider": "anthropic",
+  "request_counts": {
+    "total": 2,
+    "completed": 2,
+    "failed": 0
+  },
+  "request_id": "postman-1776793316",
+  "result_available": true,
+  "status": "completed",
+  "updated_at": "2026-04-21T17:44:26Z"
+}`
+
+	batchCancelResponse = `{
+  "batch_id": "11f13dad-0b91-104b-8567-a23ae3abd3e2",
+  "cancel_requested_at": "2026-04-21T18:10:00Z",
+  "completion_window": "24h",
+  "created_at": "2026-04-21T18:05:00Z",
+  "expires_at": null,
+  "file_id": "b7d562e0-49ae-43f7-820d-6a37a2f05435",
+  "provider": "anthropic",
+  "request_counts": {
+    "total": 2,
+    "completed": 0,
+    "failed": 0
+  },
+  "request_id": "postman-cancel-test",
+  "result_available": false,
+  "status": "cancelled",
+  "updated_at": "2026-04-21T18:10:00Z"
+}`
+
+	batchListResponse = `{
+  "edges": [
+    {
+      "cursor": "eyJjIjoiMjAyNi0wNC0yMVQxNzo0MTo1N1oiLCJpIjoyMH0=",
+      "node": {
+        "batch_id": "11f13da9-64a4-fe5b-8567-a23ae3abd3e2",
+        "cancel_requested_at": null,
+        "completion_window": "24h",
+        "created_at": "2026-04-21T17:41:57Z",
+        "expires_at": null,
+        "provider": "anthropic",
+        "request_counts": {
+          "total": 2,
+          "completed": 2,
+          "failed": 0
+        },
+        "request_id": "postman-1776793316",
+        "result_available": true,
+        "status": "completed",
+        "updated_at": "2026-04-21T17:44:26Z"
+      }
+    },
+    {
+      "cursor": "eyJjIjoiMjAyNi0wNC0yMFQwNToyMjo1MVoiLCJpIjoxM30=",
+      "node": {
+        "batch_id": "11f13c78-fa24-cbfc-8567-a23ae3abd3e2",
+        "cancel_requested_at": null,
+        "completion_window": "24h",
+        "created_at": "2026-04-20T05:22:51Z",
+        "expires_at": null,
+        "provider": "openai",
+        "request_counts": {
+          "total": 2,
+          "completed": 2,
+          "failed": 0
+        },
+        "request_id": "postman-1776662571",
+        "result_available": true,
+        "status": "completed",
+        "updated_at": "2026-04-20T05:25:12Z"
+      }
+    }
+  ],
+  "page_info": {
+    "endCursor": "eyJjIjoiMjAyNi0wNC0yMFQwNToyMjo1MVoiLCJpIjoxM30=",
+    "hasNextPage": true
+  }
+}`
+
+	batchResultsResponse = `{
+  "download": {
+    "presigned_url": "https://spaces.example.com/batch-results/1/output.jsonl?token=abc",
+    "expires_at": "2026-04-21T18:07:47.228188268Z"
+  },
+  "output_file_id": "msgbatch_015UytMT8cCLD8332Hb3BhNe"
+}`
+)
+
+func TestBatchInference_CreatePresignedUploadURL(t *testing.T) {
+	cleanup := batchInferenceSetup()
+	defer cleanup()
+
+	mux.HandleFunc("/v1/batches/files", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+
+		var req CreateBatchFileRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if req.FileName != "input.jsonl" {
+			t.Errorf("expected FileName 'input.jsonl', got '%s'", req.FileName)
+		}
+		fmt.Fprint(w, batchFileUploadResponse)
+	})
+
+	upload, _, err := client.BatchInference.CreatePresignedUploadURL(ctx, &CreateBatchFileRequest{
+		FileName: "input.jsonl",
+	})
+	if err != nil {
+		t.Fatalf("CreatePresignedUploadURL: %v", err)
+	}
+	if upload.FileID != "b7d562e0-49ae-43f7-820d-6a37a2f05435" {
+		t.Errorf("expected FileID 'b7d562e0-49ae-43f7-820d-6a37a2f05435', got '%s'", upload.FileID)
+	}
+	if upload.UploadURL != "https://spaces.example.com/batch-inputs/1/b7d562e0.jsonl?token=xyz" {
+		t.Errorf("unexpected UploadURL: %s", upload.UploadURL)
+	}
+	if upload.ExpiresAt != "2026-04-21T17:49:27.536939587Z" {
+		t.Errorf("expected ExpiresAt '2026-04-21T17:49:27.536939587Z', got '%s'", upload.ExpiresAt)
+	}
+}
+
+func TestBatchInference_UploadInputFile(t *testing.T) {
+	cleanup := batchInferenceSetup()
+	defer cleanup()
+
+	body := `{"custom_id":"req-1","method":"POST","url":"/v1/messages","body":{"model":"claude-sonnet-4-20250514","max_tokens":1024,"messages":[{"role":"user","content":"Hello"}]}}` + "\n"
+
+	mux.HandleFunc("/upload/test.jsonl", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPut)
+
+		if ct := r.Header.Get("Content-Type"); ct != "application/x-ndjson" {
+			t.Errorf("expected Content-Type 'application/x-ndjson', got '%s'", ct)
+		}
+		if auth := r.Header.Get("Authorization"); auth != "" {
+			t.Errorf("expected no Authorization header, got '%s'", auth)
+		}
+
+		got, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if string(got) != body {
+			t.Errorf("unexpected body: %s", string(got))
+		}
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	uploadURL := server.URL + "/upload/test.jsonl"
+	resp, err := client.BatchInference.UploadInputFile(ctx, uploadURL, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("UploadInputFile: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestBatchInference_CreateJob(t *testing.T) {
+	cleanup := batchInferenceSetup()
+	defer cleanup()
+
+	mux.HandleFunc("/v1/batches", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			return
+		}
+		testMethod(t, r, http.MethodPost)
+
+		var req CreateBatchRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if req.Provider != "anthropic" {
+			t.Errorf("expected Provider 'anthropic', got '%s'", req.Provider)
+		}
+		if req.FileID != "b7d562e0-49ae-43f7-820d-6a37a2f05435" {
+			t.Errorf("expected FileID 'b7d562e0-49ae-43f7-820d-6a37a2f05435', got '%s'", req.FileID)
+		}
+		if req.CompletionWindow != "24h" {
+			t.Errorf("expected CompletionWindow '24h', got '%s'", req.CompletionWindow)
+		}
+		fmt.Fprint(w, batchCreateResponse)
+	})
+
+	batch, _, err := client.BatchInference.CreateJob(ctx, &CreateBatchRequest{
+		Provider:         "anthropic",
+		FileID:           "b7d562e0-49ae-43f7-820d-6a37a2f05435",
+		CompletionWindow: "24h",
+		RequestID:        "postman-1776793316",
+	})
+	if err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	if batch.BatchID != "11f13da9-64a4-fe5b-8567-a23ae3abd3e2" {
+		t.Errorf("expected BatchID '11f13da9-64a4-fe5b-8567-a23ae3abd3e2', got '%s'", batch.BatchID)
+	}
+	if batch.Provider != "anthropic" {
+		t.Errorf("expected Provider 'anthropic', got '%s'", batch.Provider)
+	}
+	if batch.Status != "queued" {
+		t.Errorf("expected Status 'queued', got '%s'", batch.Status)
+	}
+	if batch.CreatedAt != "2026-04-21T17:41:57Z" {
+		t.Errorf("expected CreatedAt '2026-04-21T17:41:57Z', got '%s'", batch.CreatedAt)
+	}
+	if batch.RequestCounts == nil {
+		t.Fatal("expected RequestCounts to be non-nil")
+	}
+	if batch.RequestCounts.Total != 0 {
+		t.Errorf("expected RequestCounts.Total 0, got %d", batch.RequestCounts.Total)
+	}
+	if batch.ResultAvailable {
+		t.Error("expected ResultAvailable to be false")
+	}
+}
+
+func TestBatchInference_CreateJobOpenAI(t *testing.T) {
+	cleanup := batchInferenceSetup()
+	defer cleanup()
+
+	mux.HandleFunc("/v1/batches", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			return
+		}
+		testMethod(t, r, http.MethodPost)
+
+		var req CreateBatchRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if req.Provider != "openai" {
+			t.Errorf("expected Provider 'openai', got '%s'", req.Provider)
+		}
+		if req.Endpoint != "/v1/chat/completions" {
+			t.Errorf("expected Endpoint '/v1/chat/completions', got '%s'", req.Endpoint)
+		}
+
+		resp := `{
+  "batch_id": "11f13c78-fa24-cbfc-8567-a23ae3abd3e2",
+  "cancel_requested_at": null,
+  "completion_window": "24h",
+  "created_at": "2026-04-20T05:22:51Z",
+  "expires_at": null,
+  "file_id": "b7d562e0-49ae-43f7-820d-6a37a2f05435",
+  "provider": "openai",
+  "request_counts": {"total": 0, "completed": 0, "failed": 0},
+  "request_id": "openai-test",
+  "result_available": false,
+  "status": "queued",
+  "updated_at": "2026-04-20T05:22:51Z"
+}`
+		fmt.Fprint(w, resp)
+	})
+
+	batch, _, err := client.BatchInference.CreateJob(ctx, &CreateBatchRequest{
+		Provider:         "openai",
+		FileID:           "b7d562e0-49ae-43f7-820d-6a37a2f05435",
+		CompletionWindow: "24h",
+		Endpoint:         "/v1/chat/completions",
+		RequestID:        "openai-test",
+	})
+	if err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	if batch.Provider != "openai" {
+		t.Errorf("expected Provider 'openai', got '%s'", batch.Provider)
+	}
+}
+
+func TestBatchInference_GetJob(t *testing.T) {
+	cleanup := batchInferenceSetup()
+	defer cleanup()
+
+	mux.HandleFunc("/v1/batches/11f13da9-64a4-fe5b-8567-a23ae3abd3e2", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, batchGetResponse)
+	})
+
+	batch, _, err := client.BatchInference.GetJob(ctx, "11f13da9-64a4-fe5b-8567-a23ae3abd3e2")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if batch.BatchID != "11f13da9-64a4-fe5b-8567-a23ae3abd3e2" {
+		t.Errorf("expected BatchID '11f13da9-64a4-fe5b-8567-a23ae3abd3e2', got '%s'", batch.BatchID)
+	}
+	if batch.Status != "completed" {
+		t.Errorf("expected Status 'completed', got '%s'", batch.Status)
+	}
+	if batch.Provider != "anthropic" {
+		t.Errorf("expected Provider 'anthropic', got '%s'", batch.Provider)
+	}
+	if batch.RequestCounts == nil {
+		t.Fatal("expected RequestCounts to be non-nil")
+	}
+	if batch.RequestCounts.Completed != 2 {
+		t.Errorf("expected RequestCounts.Completed 2, got %d", batch.RequestCounts.Completed)
+	}
+	if batch.RequestCounts.Total != 2 {
+		t.Errorf("expected RequestCounts.Total 2, got %d", batch.RequestCounts.Total)
+	}
+	if !batch.ResultAvailable {
+		t.Error("expected ResultAvailable to be true")
+	}
+}
+
+func TestBatchInference_CancelJob(t *testing.T) {
+	cleanup := batchInferenceSetup()
+	defer cleanup()
+
+	mux.HandleFunc("/v1/batches/11f13dad-0b91-104b-8567-a23ae3abd3e2/cancel", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		fmt.Fprint(w, batchCancelResponse)
+	})
+
+	batch, _, err := client.BatchInference.CancelJob(ctx, "11f13dad-0b91-104b-8567-a23ae3abd3e2")
+	if err != nil {
+		t.Fatalf("CancelJob: %v", err)
+	}
+	if batch.BatchID != "11f13dad-0b91-104b-8567-a23ae3abd3e2" {
+		t.Errorf("expected BatchID '11f13dad-0b91-104b-8567-a23ae3abd3e2', got '%s'", batch.BatchID)
+	}
+	if batch.Status != "cancelled" {
+		t.Errorf("expected Status 'cancelled', got '%s'", batch.Status)
+	}
+	if batch.CancelRequestedAt == nil || *batch.CancelRequestedAt != "2026-04-21T18:10:00Z" {
+		t.Errorf("expected CancelRequestedAt '2026-04-21T18:10:00Z', got %v", batch.CancelRequestedAt)
+	}
+}
+
+func TestBatchInference_ListJobs(t *testing.T) {
+	cleanup := batchInferenceSetup()
+	defer cleanup()
+
+	mux.HandleFunc("/v1/batches", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+
+		status := r.URL.Query().Get("status")
+		if status != "completed" {
+			t.Errorf("expected query status=completed, got '%s'", status)
+		}
+		limit := r.URL.Query().Get("limit")
+		if limit != "10" {
+			t.Errorf("expected query limit=10, got '%s'", limit)
+		}
+		fmt.Fprint(w, batchListResponse)
+	})
+
+	list, _, err := client.BatchInference.ListJobs(ctx, &ListBatchesOptions{
+		Status: "completed",
+		Limit:  10,
+	})
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	if len(list.Edges) != 2 {
+		t.Fatalf("expected 2 edges, got %d", len(list.Edges))
+	}
+	if list.Edges[0].Node.BatchID != "11f13da9-64a4-fe5b-8567-a23ae3abd3e2" {
+		t.Errorf("expected first batch BatchID '11f13da9-64a4-fe5b-8567-a23ae3abd3e2', got '%s'", list.Edges[0].Node.BatchID)
+	}
+	if list.Edges[0].Node.Provider != "anthropic" {
+		t.Errorf("expected first batch Provider 'anthropic', got '%s'", list.Edges[0].Node.Provider)
+	}
+	if list.Edges[0].Node.Status != "completed" {
+		t.Errorf("expected first batch Status 'completed', got '%s'", list.Edges[0].Node.Status)
+	}
+	if list.Edges[0].Cursor != "eyJjIjoiMjAyNi0wNC0yMVQxNzo0MTo1N1oiLCJpIjoyMH0=" {
+		t.Errorf("unexpected first edge cursor: %s", list.Edges[0].Cursor)
+	}
+	if list.Edges[1].Node.BatchID != "11f13c78-fa24-cbfc-8567-a23ae3abd3e2" {
+		t.Errorf("expected second batch BatchID '11f13c78-fa24-cbfc-8567-a23ae3abd3e2', got '%s'", list.Edges[1].Node.BatchID)
+	}
+	if list.Edges[1].Node.Provider != "openai" {
+		t.Errorf("expected second batch Provider 'openai', got '%s'", list.Edges[1].Node.Provider)
+	}
+	if !list.PageInfo.HasNextPage {
+		t.Error("expected HasNextPage to be true")
+	}
+	if list.PageInfo.EndCursor != "eyJjIjoiMjAyNi0wNC0yMFQwNToyMjo1MVoiLCJpIjoxM30=" {
+		t.Errorf("unexpected EndCursor: %s", list.PageInfo.EndCursor)
+	}
+}
+
+func TestBatchInference_GetJobResult(t *testing.T) {
+	cleanup := batchInferenceSetup()
+	defer cleanup()
+
+	mux.HandleFunc("/v1/batches/11f13da9-64a4-fe5b-8567-a23ae3abd3e2/results", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, batchResultsResponse)
+	})
+
+	results, _, err := client.BatchInference.GetJobResult(ctx, "11f13da9-64a4-fe5b-8567-a23ae3abd3e2")
+	if err != nil {
+		t.Fatalf("GetJobResult: %v", err)
+	}
+	if results.Download.PresignedURL != "https://spaces.example.com/batch-results/1/output.jsonl?token=abc" {
+		t.Errorf("unexpected PresignedURL: %s", results.Download.PresignedURL)
+	}
+	if results.Download.ExpiresAt != "2026-04-21T18:07:47.228188268Z" {
+		t.Errorf("unexpected Download.ExpiresAt: %s", results.Download.ExpiresAt)
+	}
+	if results.OutputFileID != "msgbatch_015UytMT8cCLD8332Hb3BhNe" {
+		t.Errorf("unexpected OutputFileID: %s", results.OutputFileID)
+	}
+}

--- a/godo.go
+++ b/godo.go
@@ -101,6 +101,7 @@ type Client struct {
 	PartnerAttachment   PartnerAttachmentService
 	GradientAI          GradientAIService
 	DedicatedInference  DedicatedInferenceService
+	BatchInference      BatchInferenceService
 	BYOIPPrefixes       BYOIPPrefixesService
 	// Optional function called after every successful request made to the DO APIs
 	onRequestCompleted RequestCompletionCallback
@@ -333,6 +334,8 @@ func NewClient(httpClient *http.Client) *Client {
 	c.PartnerAttachment = &PartnerAttachmentServiceOp{client: c}
 	c.GradientAI = &GradientAIServiceOp{client: c}
 	c.DedicatedInference = &DedicatedInferenceServiceOp{client: c}
+	batchInferenceURL, _ := url.Parse(defaultBatchInferenceBaseURL)
+	c.BatchInference = &BatchInferenceServiceOp{client: c, baseURL: batchInferenceURL}
 
 	c.headers = make(map[string]string)
 

--- a/godo_test.go
+++ b/godo_test.go
@@ -99,6 +99,7 @@ func testClientServices(t *testing.T, c *Client) {
 		"ReservedIPs",
 		"ReservedIPActions",
 		"Tags",
+		"BatchInference",
 	}
 
 	cp := reflect.ValueOf(c)


### PR DESCRIPTION
## Summary

Add `BatchInferenceService` to godo for managing batch inference jobs against the inference proxy data plane at `inference.do-ai.run/v1/batches`.

This service is distinct from other godo services in two ways:
- **Custom base URL:** Routes to `inference.do-ai.run` instead of `api.digitalocean.com`, using a per-service `baseURL` field on `BatchInferenceServiceOp`
- **Custom DO schema:** Types match the actual inference proxy response format (not OpenAI-compatible) — Relay-style cursor pagination (`edges`/`page_info`), ISO 8601 timestamp strings, `provider` field, and nested `download.presigned_url` structures

### New `BatchInferenceService` interface (7 methods)

| Method | HTTP | Path | Description |
|---|---|---|---|
| `CreatePresignedUploadURL` | `POST` | `/v1/batches/files` | Get a presigned S3 URL for `.jsonl` input file upload |
| `UploadInputFile` | `PUT` | `{presigned_url}` | Upload `.jsonl` content to the presigned URL (no Authorization header — auth is embedded in the URL's query parameters) |
| `CreateJob` | `POST` | `/v1/batches` | Create a batch inference job (`provider` required: `"openai"` or `"anthropic"`) |
| `ListJobs` | `GET` | `/v1/batches` | List jobs with optional status filter and Relay cursor pagination (`after`/`limit`) |
| `GetJob` | `GET` | `/v1/batches/{batch_id}` | Retrieve a single batch job by ID |
| `CancelJob` | `POST` | `/v1/batches/{batch_id}/cancel` | Request cancellation of a batch job |
| `GetJobResult` | `GET` | `/v1/batches/{batch_id}/results` | Get presigned download URL for completed job results |

### Files changed

- **`batch_inference.go`** (new) — Service interface, request/response types, and implementation
- **`batch_inference_test.go`** (new) — Unit tests for all 7 methods (8 test functions including OpenAI-specific create)
- **`godo.go`** — Add `BatchInference BatchInferenceService` field to `Client`; wire `BatchInferenceServiceOp` with custom base URL in `NewClient`
- **`godo_test.go`** — Add `"BatchInference"` to service reflection test

### Design notes

- **`UploadInputFile`** uses a plain `http.Client{}` (bypassing the godo client's `oauth2.Transport`) because the presigned S3 URL already contains authentication in its query parameters. Adding a DO `Authorization` header would be incorrect.
- **`newRequest` helper** resolves paths against the inference proxy base URL (`inference.do-ai.run`), then passes the absolute URL to `Client.NewRequest` so standard headers (User-Agent, Accept, custom headers) are still applied.
- Test fixtures are based on actual production API responses (2026-04-21).

## Test plan

- [x] `go test -race ./...` passes (all existing + 8 new tests)
- [x] `gofmt` check clean
- [x] CI: `go test -race ./...` on Go 1.23.x/1.24.x
- [x] CI: `gofmt` check
- [x] Review from godo maintainers