### PR TITLE
action: use int64 for action IDs to fix overflow on 32-bit platforms

### DIFF
--- a/action.go
+++ b/action.go
@@ -20,7 +20,7 @@ const (
 // DigitalOcean API: https://docs.digitalocean.com/reference/api/api-reference/#tag/Actions
 type ActionsService interface {
 	List(context.Context, *ListOptions) ([]Action, *Response, error)
-	Get(context.Context, int) (*Action, *Response, error)
+	Get(context.Context, int64) (*Action, *Response, error)
 }
 
 // ActionsServiceOp handles communication with the image action related methods of the
@@ -43,7 +43,7 @@ type actionRoot struct {
 
 // Action represents a DigitalOcean Action
 type Action struct {
-	ID           int        `json:"id"`
+	ID           int64      `json:"id"`
 	Status       string     `json:"status"`
 	Type         string     `json:"type"`
 	StartedAt    *Timestamp `json:"started_at"`
@@ -83,7 +83,7 @@ func (s *ActionsServiceOp) List(ctx context.Context, opt *ListOptions) ([]Action
 }
 
 // Get an action by ID.
-func (s *ActionsServiceOp) Get(ctx context.Context, id int) (*Action, *Response, error) {
+func (s *ActionsServiceOp) Get(ctx context.Context, id int64) (*Action, *Response, error) {
 	if id < 1 {
 		return nil, nil, NewArgError("id", "cannot be less than 1")
 	}

--- a/action_test.go
+++ b/action_test.go
@@ -1,6 +1,7 @@
 package godo
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -125,6 +126,39 @@ func TestAction_Get(t *testing.T) {
 
 	if action.RegionSlug != "slug" {
 		t.Fatalf("unexpected response, invalid region slug")
+	}
+}
+
+func TestAction_UnmarshalLargeID(t *testing.T) {
+	jsonBlob := `{"action":{"id":3169590176,"status":"completed","type":"create","resource_id":12345,"resource_type":"droplet"}}`
+
+	var root actionRoot
+	err := json.Unmarshal([]byte(jsonBlob), &root)
+	if err != nil {
+		t.Fatalf("failed to unmarshal Action with large ID: %v", err)
+	}
+
+	if root.Event.ID != 3169590176 {
+		t.Errorf("expected ID 3169590176, got %d", root.Event.ID)
+	}
+}
+
+func TestAction_GetLargeID(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/actions/3169590176", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{"action":{"id":3169590176,"status":"completed","type":"create"}}`)
+	})
+
+	action, _, err := client.Actions.Get(ctx, 3169590176)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if action.ID != 3169590176 {
+		t.Errorf("expected ID 3169590176, got %d", action.ID)
 	}
 }
 

--- a/droplet_actions.go
+++ b/droplet_actions.go
@@ -42,7 +42,7 @@ type DropletActionsService interface {
 	EnableIPv6ByTag(context.Context, string) ([]Action, *Response, error)
 	EnablePrivateNetworking(context.Context, int) (*Action, *Response, error)
 	EnablePrivateNetworkingByTag(context.Context, string) ([]Action, *Response, error)
-	Get(context.Context, int, int) (*Action, *Response, error)
+	Get(context.Context, int, int64) (*Action, *Response, error)
 	GetByURI(context.Context, string) (*Action, *Response, error)
 }
 
@@ -318,7 +318,7 @@ func (s *DropletActionsServiceOp) doActionByTag(ctx context.Context, tag string,
 }
 
 // Get an action for a particular Droplet by id.
-func (s *DropletActionsServiceOp) Get(ctx context.Context, dropletID, actionID int) (*Action, *Response, error) {
+func (s *DropletActionsServiceOp) Get(ctx context.Context, dropletID int, actionID int64) (*Action, *Response, error) {
 	if dropletID < 1 {
 		return nil, nil, NewArgError("dropletID", "cannot be less than 1")
 	}

--- a/droplets_test.go
+++ b/droplets_test.go
@@ -398,6 +398,44 @@ func TestDroplets_Create(t *testing.T) {
 	}
 }
 
+func TestDroplets_CreateWithLargeActionID(t *testing.T) {
+	setup()
+	defer teardown()
+
+	createRequest := &DropletCreateRequest{
+		Name:   "name",
+		Region: "region",
+		Size:   "size",
+		Image:  DropletCreateImage{Slug: "ubuntu-22-04-x64"},
+	}
+
+	mux.HandleFunc("/v2/droplets", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		fmt.Fprint(w, `{
+			"droplet": {"id": 12345},
+			"links": {
+				"actions": [{"id": 3169590176, "href": "http://example.com", "rel": "create"}]
+			}
+		}`)
+	})
+
+	droplet, resp, err := client.Droplets.Create(ctx, createRequest)
+	if err != nil {
+		t.Fatalf("Droplets.Create returned error: %v", err)
+	}
+
+	if droplet.ID != 12345 {
+		t.Errorf("expected droplet ID 12345, got %d", droplet.ID)
+	}
+
+	if len(resp.Links.Actions) != 1 {
+		t.Fatalf("expected 1 link action, got %d", len(resp.Links.Actions))
+	}
+	if resp.Links.Actions[0].ID != 3169590176 {
+		t.Errorf("expected link action ID 3169590176, got %d", resp.Links.Actions[0].ID)
+	}
+}
+
 func TestDroplets_CreateWithoutDropletAgent(t *testing.T) {
 	setup()
 	defer teardown()

--- a/floating_ips_actions.go
+++ b/floating_ips_actions.go
@@ -12,7 +12,7 @@ import (
 type FloatingIPActionsService interface {
 	Assign(ctx context.Context, ip string, dropletID int) (*Action, *Response, error)
 	Unassign(ctx context.Context, ip string) (*Action, *Response, error)
-	Get(ctx context.Context, ip string, actionID int) (*Action, *Response, error)
+	Get(ctx context.Context, ip string, actionID int64) (*Action, *Response, error)
 	List(ctx context.Context, ip string, opt *ListOptions) ([]Action, *Response, error)
 }
 
@@ -38,7 +38,7 @@ func (s *FloatingIPActionsServiceOp) Unassign(ctx context.Context, ip string) (*
 }
 
 // Get an action for a particular floating IP by id.
-func (s *FloatingIPActionsServiceOp) Get(ctx context.Context, ip string, actionID int) (*Action, *Response, error) {
+func (s *FloatingIPActionsServiceOp) Get(ctx context.Context, ip string, actionID int64) (*Action, *Response, error) {
 	path := fmt.Sprintf("%s/%d", floatingIPActionPath(ip), actionID)
 	return s.get(ctx, path)
 }

--- a/image_actions.go
+++ b/image_actions.go
@@ -11,7 +11,7 @@ import (
 // endpoints of the DigitalOcean API
 // See: https://docs.digitalocean.com/reference/api/api-reference/#tag/Image-Actions
 type ImageActionsService interface {
-	Get(context.Context, int, int) (*Action, *Response, error)
+	Get(context.Context, int, int64) (*Action, *Response, error)
 	GetByURI(context.Context, string) (*Action, *Response, error)
 	Transfer(context.Context, int, *ActionRequest) (*Action, *Response, error)
 	Convert(context.Context, int) (*Action, *Response, error)
@@ -78,7 +78,7 @@ func (i *ImageActionsServiceOp) Convert(ctx context.Context, imageID int) (*Acti
 }
 
 // Get an action for a particular image by id.
-func (i *ImageActionsServiceOp) Get(ctx context.Context, imageID, actionID int) (*Action, *Response, error) {
+func (i *ImageActionsServiceOp) Get(ctx context.Context, imageID int, actionID int64) (*Action, *Response, error) {
 	if imageID < 1 {
 		return nil, nil, NewArgError("imageID", "cannot be less than 1")
 	}

--- a/links.go
+++ b/links.go
@@ -22,7 +22,7 @@ type Pages struct {
 
 // LinkAction is a pointer to an action
 type LinkAction struct {
-	ID   int    `json:"id,omitempty"`
+	ID   int64  `json:"id,omitempty"`
 	Rel  string `json:"rel,omitempty"`
 	HREF string `json:"href,omitempty"`
 }

--- a/links_test.go
+++ b/links_test.go
@@ -214,6 +214,48 @@ func TestLinks_ParseEmptyString(t *testing.T) {
 	}
 }
 
+func TestLinkAction_UnmarshalLargeID(t *testing.T) {
+	largeIDs := []struct {
+		name string
+		json string
+		id   int64
+	}{
+		{
+			name: "exceeds int32 max",
+			json: `{"links":{"actions":[{"id":3169590176,"rel":"create","href":"http://example.com"}]}}`,
+			id:   3169590176,
+		},
+		{
+			name: "at int32 max",
+			json: `{"links":{"actions":[{"id":2147483647,"rel":"create","href":"http://example.com"}]}}`,
+			id:   2147483647,
+		},
+		{
+			name: "above int32 max",
+			json: `{"links":{"actions":[{"id":2147483648,"rel":"create","href":"http://example.com"}]}}`,
+			id:   2147483648,
+		},
+	}
+
+	for _, tc := range largeIDs {
+		t.Run(tc.name, func(t *testing.T) {
+			var root struct {
+				Links Links `json:"links"`
+			}
+			err := json.Unmarshal([]byte(tc.json), &root)
+			if err != nil {
+				t.Fatalf("failed to unmarshal LinkAction with large ID: %v", err)
+			}
+			if len(root.Links.Actions) != 1 {
+				t.Fatalf("expected 1 action, got %d", len(root.Links.Actions))
+			}
+			if root.Links.Actions[0].ID != tc.id {
+				t.Errorf("expected ID %d, got %d", tc.id, root.Links.Actions[0].ID)
+			}
+		})
+	}
+}
+
 func TestLinks_NextPageToken(t *testing.T) {
 	t.Run("happy token", func(t *testing.T) {
 		checkNextPageToken(t, &Response{Links: &Links{

--- a/reserved_ips_actions.go
+++ b/reserved_ips_actions.go
@@ -12,7 +12,7 @@ import (
 type ReservedIPActionsService interface {
 	Assign(ctx context.Context, ip string, dropletID int) (*Action, *Response, error)
 	Unassign(ctx context.Context, ip string) (*Action, *Response, error)
-	Get(ctx context.Context, ip string, actionID int) (*Action, *Response, error)
+	Get(ctx context.Context, ip string, actionID int64) (*Action, *Response, error)
 	List(ctx context.Context, ip string, opt *ListOptions) ([]Action, *Response, error)
 }
 
@@ -38,7 +38,7 @@ func (s *ReservedIPActionsServiceOp) Unassign(ctx context.Context, ip string) (*
 }
 
 // Get an action for a particular reserved IP by id.
-func (s *ReservedIPActionsServiceOp) Get(ctx context.Context, ip string, actionID int) (*Action, *Response, error) {
+func (s *ReservedIPActionsServiceOp) Get(ctx context.Context, ip string, actionID int64) (*Action, *Response, error) {
 	path := fmt.Sprintf("%s/%d", reservedIPActionPath(ip), actionID)
 	return s.get(ctx, path)
 }

--- a/storage_actions.go
+++ b/storage_actions.go
@@ -12,7 +12,7 @@ import (
 type StorageActionsService interface {
 	Attach(ctx context.Context, volumeID string, dropletID int) (*Action, *Response, error)
 	DetachByDropletID(ctx context.Context, volumeID string, dropletID int) (*Action, *Response, error)
-	Get(ctx context.Context, volumeID string, actionID int) (*Action, *Response, error)
+	Get(ctx context.Context, volumeID string, actionID int64) (*Action, *Response, error)
 	List(ctx context.Context, volumeID string, opt *ListOptions) ([]Action, *Response, error)
 	Resize(ctx context.Context, volumeID string, sizeGigabytes int, regionSlug string) (*Action, *Response, error)
 }
@@ -48,7 +48,7 @@ func (s *StorageActionsServiceOp) DetachByDropletID(ctx context.Context, volumeI
 }
 
 // Get an action for a particular storage volume by id.
-func (s *StorageActionsServiceOp) Get(ctx context.Context, volumeID string, actionID int) (*Action, *Response, error) {
+func (s *StorageActionsServiceOp) Get(ctx context.Context, volumeID string, actionID int64) (*Action, *Response, error) {
 	path := fmt.Sprintf("%s/%d", storageAllocationActionPath(volumeID), actionID)
 	return s.get(ctx, path)
 }


### PR DESCRIPTION
## Summary

Fixes [digitalocean/terraform-provider-digitalocean#1532](https://github.com/digitalocean/terraform-provider-digitalocean/issues/1532)

DigitalOcean action IDs have exceeded `math.MaxInt32` (2,147,483,647). On 32-bit platforms (e.g. `linux/arm`), Go's `int` type is 32 bits, causing `json.Unmarshal` to fail when decoding API responses containing these action IDs:

```
json: cannot unmarshal number 3169590176 into Go struct field LinkAction.links.actions.id of type int
```

This breaks any API call whose response includes `links.actions` (e.g. `Droplets.Create`), even though the server-side operation succeeds. In the Terraform provider, this causes the resource to be created but never recorded in state, leading to duplicate resources on retry.

## Changes

Change `Action.ID` and `LinkAction.ID` from `int` to `int64`, along with all `actionID` parameters in service interfaces and implementations:

- `action.go` — `Action.ID int` → `int64`, `ActionsService.Get` and `ActionsServiceOp.Get` parameter `int` → `int64`
- `links.go` — `LinkAction.ID int` → `int64`
- `droplet_actions.go` — `DropletActionsService.Get` and impl actionID `int` → `int64`
- `image_actions.go` — `ImageActionsService.Get` and impl actionID `int` → `int64`
- `floating_ips_actions.go` — `FloatingIPActionsService.Get` and impl actionID `int` → `int64`
- `storage_actions.go` — `StorageActionsService.Get` and impl actionID `int` → `int64`
- `reserved_ips_actions.go` — `ReservedIPActionsService.Get` and impl actionID `int` → `int64`

## Breaking change

This is a breaking change. Consumers that assign `Action.ID` or `LinkAction.ID` to an `int` variable, pass `int` values to any `Get` method accepting an action ID, or implement the affected service interfaces will need to update to `int64`. The fix is mechanical.

## Tests

Added tests that verify correct unmarshalling of action IDs exceeding `math.MaxInt32`:

- `TestLinkAction_UnmarshalLargeID` — verifies `LinkAction.ID` handles values at, above, and well beyond int32 max
- `TestAction_UnmarshalLargeID` — verifies `Action` struct unmarshals the reported ID (`3169590176`)
- `TestAction_GetLargeID` — HTTP round-trip test for `Actions.Get` with a large ID
- `TestDroplets_CreateWithLargeActionID` — end-to-end test mirroring the exact bug: `Droplets.Create` response with `links.actions[].id: 3169590176`

Made with [Cursor](https://cursor.com)