### PR TITLE
Add inference router APIs

### DIFF
--- a/gradientai.go
+++ b/gradientai.go
@@ -9,33 +9,35 @@ import (
 )
 
 const (
-	gradientBasePath             = "/v2/gen-ai/agents"
-	agentModelBasePath           = "/v2/gen-ai/models"
-	datacenterRegionsPath        = "/v2/gen-ai/regions"
-	agentRouteBasePath           = gradientBasePath + "/%s/child_agents/%s"
-	KnowledgeBasePath            = "/v2/gen-ai/knowledge_bases"
-	functionRouteBasePath        = gradientBasePath + "/%s/functions"
-	KnowledgeBaseDataSourcesPath = KnowledgeBasePath + "/%s/data_sources"
-	GetKnowledgeBaseByIDPath     = KnowledgeBasePath + "/%s"
-	UpdateKnowledgeBaseByIDPath  = KnowledgeBasePath + "/%s"
-	DeleteKnowledgeBaseByIDPath  = KnowledgeBasePath + "/%s"
-	AgentKnowledgeBasePath       = "/v2/gen-ai/agents" + "/%s/knowledge_bases/%s"
-	DeleteDataSourcePath         = KnowledgeBasePath + "/%s/data_sources/%s"
-	IndexingJobsPath             = "/v2/gen-ai/indexing_jobs"
-	IndexingJobByIDPath          = IndexingJobsPath + "/%s"
-	IndexingJobCancelPath        = IndexingJobsPath + "/%s/cancel"
-	IndexingJobDataSourcesPath   = IndexingJobsPath + "/%s/data_sources"
-	AnthropicAPIKeysPath         = "/v2/gen-ai/anthropic/keys"
-	AnthropicAPIKeyByIDPath      = AnthropicAPIKeysPath + "/%s"
-	OpenAIAPIKeysPath            = "/v2/gen-ai/openai/keys"
-	UpdateFunctionRoutePath      = functionRouteBasePath + "/%s"
-	DeleteFunctionRoutePath      = functionRouteBasePath + "/%s"
-	customModelsBasePath         = "/v2/gen-ai/custom_models"
-	customModelImportPath        = customModelsBasePath + "/import"
-	customModelByIDPath          = customModelsBasePath + "/%s"
-	customModelMetadataPath      = customModelsBasePath + "/%s/metadata"
-	modelEvaluationRunsBasePath  = "/v2/gen-ai/model_evaluation_runs"
-	modelEvaluationRunByIDPath   = modelEvaluationRunsBasePath + "/%s"
+	gradientBasePath               = "/v2/gen-ai/agents"
+	agentModelBasePath             = "/v2/gen-ai/models"
+	inferenceRoutersBasePath       = agentModelBasePath + "/routers"
+	inferenceRouterTaskPresetsPath = inferenceRoutersBasePath + "/tasks/presets"
+	datacenterRegionsPath          = "/v2/gen-ai/regions"
+	agentRouteBasePath             = gradientBasePath + "/%s/child_agents/%s"
+	KnowledgeBasePath              = "/v2/gen-ai/knowledge_bases"
+	functionRouteBasePath          = gradientBasePath + "/%s/functions"
+	KnowledgeBaseDataSourcesPath   = KnowledgeBasePath + "/%s/data_sources"
+	GetKnowledgeBaseByIDPath       = KnowledgeBasePath + "/%s"
+	UpdateKnowledgeBaseByIDPath    = KnowledgeBasePath + "/%s"
+	DeleteKnowledgeBaseByIDPath    = KnowledgeBasePath + "/%s"
+	AgentKnowledgeBasePath         = "/v2/gen-ai/agents" + "/%s/knowledge_bases/%s"
+	DeleteDataSourcePath           = KnowledgeBasePath + "/%s/data_sources/%s"
+	IndexingJobsPath               = "/v2/gen-ai/indexing_jobs"
+	IndexingJobByIDPath            = IndexingJobsPath + "/%s"
+	IndexingJobCancelPath          = IndexingJobsPath + "/%s/cancel"
+	IndexingJobDataSourcesPath     = IndexingJobsPath + "/%s/data_sources"
+	AnthropicAPIKeysPath           = "/v2/gen-ai/anthropic/keys"
+	AnthropicAPIKeyByIDPath        = AnthropicAPIKeysPath + "/%s"
+	OpenAIAPIKeysPath              = "/v2/gen-ai/openai/keys"
+	UpdateFunctionRoutePath        = functionRouteBasePath + "/%s"
+	DeleteFunctionRoutePath        = functionRouteBasePath + "/%s"
+	customModelsBasePath           = "/v2/gen-ai/custom_models"
+	customModelImportPath          = customModelsBasePath + "/import"
+	customModelByIDPath            = customModelsBasePath + "/%s"
+	customModelMetadataPath        = customModelsBasePath + "/%s/metadata"
+	modelEvaluationRunsBasePath    = "/v2/gen-ai/model_evaluation_runs"
+	modelEvaluationRunByIDPath     = modelEvaluationRunsBasePath + "/%s"
 )
 
 // CustomModelStatus represents the status of a custom model.
@@ -137,6 +139,12 @@ type GradientAIService interface {
 	CreateFunctionRoute(context.Context, string, *FunctionRouteCreateRequest) (*Agent, *Response, error)
 	DeleteFunctionRoute(context.Context, string, string) (*Agent, *Response, error)
 	UpdateFunctionRoute(context.Context, string, string, *FunctionRouteUpdateRequest) (*Agent, *Response, error)
+	ListInferenceRouters(context.Context, *ListOptions) ([]*InferenceRouterSummary, *Response, error)
+	GetInferenceRouter(context.Context, string) (*InferenceRouter, *Response, error)
+	CreateInferenceRouter(context.Context, *InferenceRouterCreateRequest) (*InferenceRouter, *Response, error)
+	UpdateInferenceRouter(context.Context, string, *InferenceRouterUpdateRequest) (*InferenceRouter, *Response, error)
+	DeleteInferenceRouter(context.Context, string) (*InferenceRouterDeleteResponse, *Response, error)
+	ListInferenceRouterTaskPresets(context.Context, *ListOptions) ([]*InferenceRouterTaskPreset, *Response, error)
 	ListAvailableModels(context.Context, *ListOptions) ([]*Model, *Response, error)
 	SearchModels(context.Context, string) ([]string, *Response, error)
 	GetModelByUUID(context.Context, string) (*Model, *Response, error)
@@ -910,6 +918,79 @@ type DatacenterRegions struct {
 
 type datacenterRegionsRoot struct {
 	DatacenterRegions []*DatacenterRegions `json:"regions"`
+}
+
+// InferenceRouterSummary is a compact inference router returned from list operations.
+type InferenceRouterSummary struct {
+	UUID        string `json:"uuid,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// InferenceRouterConfig holds routing configuration for an inference router.
+type InferenceRouterConfig struct {
+	FallbackModels []string        `json:"fallback_models,omitempty"`
+	Policies       json.RawMessage `json:"policies,omitempty"`
+}
+
+// InferenceRouter represents a GenAI inference router resource.
+type InferenceRouter struct {
+	UUID        string                 `json:"uuid,omitempty"`
+	Name        string                 `json:"name,omitempty"`
+	Description string                 `json:"description,omitempty"`
+	CreatedAt   *Timestamp             `json:"created_at,omitempty"`
+	UpdatedAt   *Timestamp             `json:"updated_at,omitempty"`
+	Config      *InferenceRouterConfig `json:"config,omitempty"`
+}
+
+// InferenceRouterCreateRequest defines the body for creating an inference router.
+// Field names match POST /v2/gen-ai/models/routers (see DigitalOcean API / pydo.genai.create_model_router).
+// FallbackModels must contain at least one non-empty model name (enforced by CreateInferenceRouter).
+type InferenceRouterCreateRequest struct {
+	Name           string          `json:"name"`
+	Description    string          `json:"description,omitempty"`
+	Policies       json.RawMessage `json:"policies,omitempty"`
+	FallbackModels []string        `json:"fallback_models"`
+}
+
+// InferenceRouterUpdateRequest defines the body for updating an inference router.
+type InferenceRouterUpdateRequest struct {
+	Name           string           `json:"name,omitempty"`
+	Description    string           `json:"description,omitempty"`
+	Policies       *json.RawMessage `json:"policies,omitempty"`
+	FallbackModels []string         `json:"fallback_models,omitempty"`
+}
+
+// InferenceRouterDeleteResponse is returned when deleting an inference router.
+type InferenceRouterDeleteResponse struct {
+	UUID string `json:"uuid,omitempty"`
+}
+
+// InferenceRouterTaskPreset is a catalog preset task for inference router policies (use TaskSlug in policy JSON).
+// See GET /v2/gen-ai/models/routers/tasks/presets.
+type InferenceRouterTaskPreset struct {
+	TaskSlug    string   `json:"task_slug,omitempty"`
+	Name        string   `json:"name,omitempty"`
+	Category    string   `json:"category,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Models      []string `json:"models,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+}
+
+type inferenceRouterTaskPresetsRoot struct {
+	Tasks []*InferenceRouterTaskPreset `json:"tasks"`
+	Links *Links                       `json:"links,omitempty"`
+	Meta  *Meta                        `json:"meta,omitempty"`
+}
+
+type inferenceRoutersRoot struct {
+	Routers []*InferenceRouterSummary `json:"model_routers"`
+	Links   *Links                    `json:"links,omitempty"`
+	Meta    *Meta                     `json:"meta,omitempty"`
+}
+
+type inferenceRouterRoot struct {
+	Router *InferenceRouter `json:"model_router"`
 }
 
 type gradientAgentKBRoot struct {
@@ -1885,6 +1966,163 @@ func (g *GradientAIServiceOp) UpdateFunctionRoute(ctx context.Context, agent_id 
 	return root.Agent, resp, nil
 }
 
+// ListInferenceRouters returns a page of inference routers.
+func (s *GradientAIServiceOp) ListInferenceRouters(ctx context.Context, opt *ListOptions) ([]*InferenceRouterSummary, *Response, error) {
+	path, err := addOptions(inferenceRoutersBasePath, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(inferenceRoutersRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
+	}
+
+	return root.Routers, resp, nil
+}
+
+// ListInferenceRouterTaskPresets returns a page of preset tasks for building inference router policies.
+func (s *GradientAIServiceOp) ListInferenceRouterTaskPresets(ctx context.Context, opt *ListOptions) ([]*InferenceRouterTaskPreset, *Response, error) {
+	path, err := addOptions(inferenceRouterTaskPresetsPath, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(inferenceRouterTaskPresetsRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
+	}
+
+	return root.Tasks, resp, nil
+}
+
+// GetInferenceRouter retrieves an inference router by UUID.
+func (s *GradientAIServiceOp) GetInferenceRouter(ctx context.Context, uuid string) (*InferenceRouter, *Response, error) {
+	if uuid == "" {
+		return nil, nil, fmt.Errorf("uuid is required")
+	}
+
+	path := fmt.Sprintf("%s/%s", inferenceRoutersBasePath, uuid)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(inferenceRouterRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Router, resp, nil
+}
+
+// CreateInferenceRouter creates a new inference router.
+func (s *GradientAIServiceOp) CreateInferenceRouter(ctx context.Context, create *InferenceRouterCreateRequest) (*InferenceRouter, *Response, error) {
+	if create == nil {
+		return nil, nil, fmt.Errorf("create request is required")
+	}
+	if create.Name == "" {
+		return nil, nil, fmt.Errorf("name is required")
+	}
+	if len(create.FallbackModels) == 0 {
+		return nil, nil, fmt.Errorf("fallback_models is required")
+	}
+	for i, m := range create.FallbackModels {
+		if strings.TrimSpace(m) == "" {
+			return nil, nil, fmt.Errorf("fallback_models[%d] must not be empty", i)
+		}
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, inferenceRoutersBasePath, create)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(inferenceRouterRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Router, resp, nil
+}
+
+// UpdateInferenceRouter updates an inference router. At least one field in the update request must be set.
+func (s *GradientAIServiceOp) UpdateInferenceRouter(ctx context.Context, uuid string, update *InferenceRouterUpdateRequest) (*InferenceRouter, *Response, error) {
+	if uuid == "" {
+		return nil, nil, fmt.Errorf("uuid is required")
+	}
+	if update == nil {
+		return nil, nil, fmt.Errorf("update request is required")
+	}
+	if update.Name == "" && update.Description == "" && update.Policies == nil && len(update.FallbackModels) == 0 {
+		return nil, nil, fmt.Errorf("at least one of name, description, policies, or fallback_models must be set")
+	}
+
+	path := fmt.Sprintf("%s/%s", inferenceRoutersBasePath, uuid)
+	req, err := s.client.NewRequest(ctx, http.MethodPut, path, update)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(inferenceRouterRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Router, resp, nil
+}
+
+// DeleteInferenceRouter deletes an inference router by UUID.
+func (s *GradientAIServiceOp) DeleteInferenceRouter(ctx context.Context, uuid string) (*InferenceRouterDeleteResponse, *Response, error) {
+	if uuid == "" {
+		return nil, nil, fmt.Errorf("uuid is required")
+	}
+
+	path := fmt.Sprintf("%s/%s", inferenceRoutersBasePath, uuid)
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	out := new(InferenceRouterDeleteResponse)
+	resp, err := s.client.Do(ctx, req, out)
+	if err != nil {
+		return nil, resp, err
+	}
+	if out.UUID == "" {
+		out.UUID = uuid
+	}
+
+	return out, resp, nil
+}
+
 // ListAvailableModels returns a list of available Gradient AI models
 func (g *GradientAIServiceOp) ListAvailableModels(ctx context.Context, opt *ListOptions) ([]*Model, *Response, error) {
 	path, err := addOptions(agentModelBasePath, opt)
@@ -2278,4 +2516,20 @@ func (a IndexingJobResponse) String() string {
 
 func (a IndexingJobDataSourcesResponse) String() string {
 	return Stringify(a)
+}
+
+func (r InferenceRouterSummary) String() string {
+	return Stringify(r)
+}
+
+func (r InferenceRouter) String() string {
+	return Stringify(r)
+}
+
+func (r InferenceRouterConfig) String() string {
+	return Stringify(r)
+}
+
+func (r InferenceRouterDeleteResponse) String() string {
+	return Stringify(r)
 }

--- a/gradientai_test.go
+++ b/gradientai_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var listAgentResponse = `
@@ -432,6 +433,70 @@ var listAvailableModelsResponse = `
 	}
 }
 `
+
+var listInferenceRoutersResponse = `
+{
+	"model_routers": [
+		{
+			"uuid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+			"name": "router-one",
+			"description": "Test router for routing prompts."
+		}
+	],
+	"meta": {
+		"total": 1,
+		"page": 1,
+		"pages": 1
+	}
+}
+`
+
+var listInferenceRouterTaskPresetsResponse = `
+{
+	"tasks": [
+		{
+			"task_slug": "translation",
+			"name": "Translation",
+			"category": "general",
+			"description": "Translate text between languages.",
+			"models": ["openai-gpt-oss-120b"],
+			"tags": ["general"]
+		},
+		{
+			"task_slug": "code-generation",
+			"name": "Code Generation",
+			"category": "software-engineering",
+			"description": "Generate code from natural language.",
+			"models": ["openai-gpt-oss-120b", "anthropic-claude-3-5-sonnet"],
+			"tags": ["code"]
+		}
+	],
+	"meta": {
+		"total": 2,
+		"page": 1,
+		"pages": 1
+	}
+}
+`
+
+var getInferenceRouterResponse = `
+{
+	"model_router": {
+		"uuid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+		"name": "router-one",
+		"description": "Router used for unit tests.",
+		"created_at": "2025-06-01T12:00:00Z",
+		"updated_at": "2025-06-02T15:30:00Z",
+		"config": {
+			"fallback_models": ["openai-gpt-4"],
+			"policies": [
+				{"task_slug": "code-generation", "models": ["llama3"], "selection_policy": {"prefer": "fastest"}}
+			]
+		}
+	}
+}
+`
+
 var listAPIKeysResponse = `
 {
     "api_key_infos": [
@@ -2181,6 +2246,162 @@ func TestDeleteFunctionRoute(t *testing.T) {
 	_, resp, err := client.GradientAI.DeleteFunctionRoute(ctx, "00000000-0000-0000-0000-000000000000", "00000000-0000-0000-0000-000000000000")
 	assert.NoError(t, err)
 	assert.Equal(t, 200, resp.Response.StatusCode)
+}
+
+func TestListInferenceRouters(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/gen-ai/models/routers", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		testFormValues(t, r, values{
+			"page":     "1",
+			"per_page": "10",
+		})
+		fmt.Fprint(w, listInferenceRoutersResponse)
+	})
+
+	routers, resp, err := client.GradientAI.ListInferenceRouters(ctx, &ListOptions{Page: 1, PerPage: 10})
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.Response.StatusCode)
+	require.Len(t, routers, 1)
+	assert.Equal(t, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", routers[0].UUID)
+	assert.Equal(t, "router-one", routers[0].Name)
+	assert.Equal(t, "Test router for routing prompts.", routers[0].Description)
+	assert.NotNil(t, resp.Meta)
+	assert.Equal(t, 1, resp.Meta.Total)
+}
+
+func TestListInferenceRouterTaskPresets(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/gen-ai/models/routers/tasks/presets", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		testFormValues(t, r, values{
+			"page":     "1",
+			"per_page": "10",
+		})
+		fmt.Fprint(w, listInferenceRouterTaskPresetsResponse)
+	})
+
+	tasks, resp, err := client.GradientAI.ListInferenceRouterTaskPresets(ctx, &ListOptions{Page: 1, PerPage: 10})
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.Response.StatusCode)
+	require.Len(t, tasks, 2)
+	assert.Equal(t, "translation", tasks[0].TaskSlug)
+	assert.Equal(t, "Translation", tasks[0].Name)
+	assert.Equal(t, "general", tasks[0].Category)
+	assert.Equal(t, "code-generation", tasks[1].TaskSlug)
+	assert.Equal(t, "software-engineering", tasks[1].Category)
+	require.NotNil(t, resp.Meta)
+	assert.Equal(t, 2, resp.Meta.Total)
+}
+
+func TestGetInferenceRouter(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/gen-ai/models/routers/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, getInferenceRouterResponse)
+	})
+
+	router, resp, err := client.GradientAI.GetInferenceRouter(ctx, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.Response.StatusCode)
+	require.NotNil(t, router)
+	assert.Equal(t, "router-one", router.Name)
+	assert.Equal(t, "Router used for unit tests.", router.Description)
+	require.NotNil(t, router.Config)
+	assert.Equal(t, []string{"openai-gpt-4"}, router.Config.FallbackModels)
+	assert.Contains(t, string(router.Config.Policies), "code-generation")
+}
+
+func TestCreateInferenceRouter(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/gen-ai/models/routers", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		fmt.Fprint(w, getInferenceRouterResponse)
+	})
+
+	create := &InferenceRouterCreateRequest{
+		Name:           "router-one",
+		Description:    "Router used for unit tests.",
+		FallbackModels: []string{"openai-gpt-4"},
+	}
+	router, resp, err := client.GradientAI.CreateInferenceRouter(ctx, create)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.Response.StatusCode)
+	require.NotNil(t, router)
+	assert.Equal(t, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", router.UUID)
+}
+
+func TestUpdateInferenceRouter(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/gen-ai/models/routers/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPut)
+		fmt.Fprint(w, getInferenceRouterResponse)
+	})
+
+	name := "router-renamed"
+	update := &InferenceRouterUpdateRequest{Name: name}
+	router, resp, err := client.GradientAI.UpdateInferenceRouter(ctx, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", update)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.Response.StatusCode)
+	require.NotNil(t, router)
+	assert.Equal(t, "router-one", router.Name)
+}
+
+func TestDeleteInferenceRouter(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/gen-ai/models/routers/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+		fmt.Fprint(w, `{"uuid":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}`)
+	})
+
+	out, resp, err := client.GradientAI.DeleteInferenceRouter(ctx, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.Response.StatusCode)
+	require.NotNil(t, out)
+	assert.Equal(t, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", out.UUID)
+}
+
+func TestCreateInferenceRouterValidation(t *testing.T) {
+	setup()
+	defer teardown()
+
+	_, _, err := client.GradientAI.CreateInferenceRouter(ctx, nil)
+	assert.Error(t, err)
+
+	_, _, err = client.GradientAI.CreateInferenceRouter(ctx, &InferenceRouterCreateRequest{Name: "n"})
+	assert.Error(t, err)
+
+	_, _, err = client.GradientAI.CreateInferenceRouter(ctx, &InferenceRouterCreateRequest{
+		Name:           "router",
+		FallbackModels: []string{"a", ""},
+	})
+	assert.Error(t, err)
+}
+
+func TestUpdateInferenceRouterValidation(t *testing.T) {
+	setup()
+	defer teardown()
+
+	_, _, err := client.GradientAI.UpdateInferenceRouter(ctx, "", &InferenceRouterUpdateRequest{Name: "x"})
+	assert.Error(t, err)
+
+	_, _, err = client.GradientAI.UpdateInferenceRouter(ctx, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", nil)
+	assert.Error(t, err)
+
+	_, _, err = client.GradientAI.UpdateInferenceRouter(ctx, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", &InferenceRouterUpdateRequest{})
+	assert.Error(t, err)
 }
 
 func TestListAvailableModels(t *testing.T) {


### PR DESCRIPTION
Adds the following inference router CRUD APIs to the go client:
- `ListInferenceRouters` - GET /v2/gen-ai/models/routers
- `GetInferenceRouter` - GET /v2/gen-ai/models/routers/{uuid}
- `CreateInferenceRouter` - POST /v2/gen-ai/models/routers
- `UpdateInferenceRouter` - PUT /v2/gen-ai/models/routers/{uuid}
- `DeleteInferenceRouter` - DELETE /v2/gen-ai/models/routers/{uuid}
- `ListInferenceRouterTaskPresets` - GET /v2/gen-ai/models/routers/tasks/presets

Tested with `go test`, and also did a sanity check with an API token to check that inference routers were created/deleted correctly using the client

```
create response: status=200 uuid="11f15617-a009-1a1c-9439-ca68c578b04b" name="godo-live-1779479487113357000" description="Temporary godo live test router (safe to delete)." created_at=2026-05-22 19:51:29 +0000 UTC updated_at=2026-05-22 19:51:29 +0000 UTC
```

```
get response: status=200 uuid="11f15617-a009-1a1c-9439-ca68c578b04b" name="godo-live-1779479487113357000" description="Temporary godo live test router (safe to delete)." created_at=2026-05-22 19:51:29 +0000 UTC updated_at=2026-05-22 19:51:29 +0000 UTC
```

```
delete response: status=200 uuid="11f15617-a009-1a1c-9439-ca68c578b04b"
```