### PR TITLE
KBAAS-341: Add ProjectID to VectorDBCreateRequest

### DIFF
--- a/vector_databases.go
+++ b/vector_databases.go
@@ -80,10 +80,11 @@ type VectorDBBackup struct {
 
 // VectorDBCreateRequest represents a request to create a vector database.
 type VectorDBCreateRequest struct {
-	Name   string   `json:"name,omitempty"`
-	Region string   `json:"region,omitempty"`
-	Size   string   `json:"size,omitempty"`
-	Tags   []string `json:"tags,omitempty"`
+	Name      string   `json:"name,omitempty"`
+	Region    string   `json:"region,omitempty"`
+	Size      string   `json:"size,omitempty"`
+	Tags      []string `json:"tags,omitempty"`
+	ProjectID string   `json:"project_id,omitempty"`
 }
 
 // VectorDBUpdateRequest represents a request to update a vector database.

--- a/vector_databases_test.go
+++ b/vector_databases_test.go
@@ -118,10 +118,11 @@ func TestVectorDBs_Create(t *testing.T) {
 	})
 
 	createRequest := &VectorDBCreateRequest{
-		Name:   "vectortest",
-		Region: "nyc3",
-		Size:   "small",
-		Tags:   []string{"production", "ml"},
+		Name:      "vectortest",
+		Region:    "nyc3",
+		Size:      "small",
+		Tags:      []string{"production", "ml"},
+		ProjectID: "49c369ee-c6a7-4c13-b8b4-ba0ac8d4180b",
 	}
 
 	got, _, err := client.VectorDBs.Create(ctx, createRequest)


### PR DESCRIPTION
**Summary**
Adds ProjectID field to VectorDBCreateRequest. The vector database API requires project_id on create requests, but it was missing from the original implementation.

**Changes**

vector_databases.go — added ProjectID string \json:"project_id,omitempty"`toVectorDBCreateRequest`

Testing
Built a comprehensive integration test against stage2 (https://api.s2r1.internal.digitalocean.com) that exercises all 11 VectorDB operations end-to-end:
=== CREATE ===
Created: 51e6f20c-0c9b-46ba-9d02-a0a5ed2b3358 nilay-test-vdb pending
(waited ~3 min for active)

=== LIST ===                  ✅ total=1 count=1
=== GET ===                   ✅ returned endpoints, config, status
=== UPDATE ===                ✅ auto_schema=true
=== UPDATE TAGS ===           ✅ tags=[test nilay]
=== GET CREDENTIALS ===       ✅ UserID=do-admin, Token returned
=== LIST BACKUPS ===      ✅   
=== RESIZE (small → medium) ===  ✅ completed after ~3 min
=== DELETE ===                ✅ deleted successfully
Notes

project_id is confirmed required by the API. This field also needs to be added to the Swagger spec in Cthulhu

Related

Original PR: #1015 (merged, released as v1.193.0)
Ticket: [KBAAS-265](https://do-internal.atlassian.net/browse/KBAAS-265)

[KBAAS-265]: https://do-internal.atlassian.net/browse/KBAAS-265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ