### PR TITLE
added support for ADVANCED PG configuration

### DIFF
--- a/databases.go
+++ b/databases.go
@@ -167,6 +167,7 @@ type DatabasesService interface {
 	GetMongoDBConfig(context.Context, string) (*MongoDBConfig, *Response, error)
 	GetOpensearchConfig(context.Context, string) (*OpensearchConfig, *Response, error)
 	GetKafkaConfig(context.Context, string) (*KafkaConfig, *Response, error)
+	GetAdvancedPostgresSQLConfig(context.Context, string) (*AdvancedPostgresConfig, *Response, error)
 	UpdatePostgreSQLConfig(context.Context, string, *PostgreSQLConfig) (*Response, error)
 	UpdateRedisConfig(context.Context, string, *RedisConfig) (*Response, error)
 	UpdateValkeyConfig(context.Context, string, *ValkeyConfig) (*Response, error)
@@ -174,6 +175,7 @@ type DatabasesService interface {
 	UpdateMongoDBConfig(context.Context, string, *MongoDBConfig) (*Response, error)
 	UpdateOpensearchConfig(context.Context, string, *OpensearchConfig) (*Response, error)
 	UpdateKafkaConfig(context.Context, string, *KafkaConfig) (*Response, error)
+	UpdateAdvancedPostgresSQLConfig(context.Context, string, *AdvancedPostgresConfigUpdate) (*Response, error)
 	ListOptions(todo context.Context) (*DatabaseOptions, *Response, error)
 	UpgradeMajorVersion(context.Context, string, *UpgradeVersionRequest) (*Response, error)
 	ListTopics(context.Context, string, *ListOptions) ([]DatabaseTopic, *Response, error)
@@ -726,6 +728,25 @@ type PostgreSQLConfig struct {
 	MaxFailoverReplicationTimeLag   *int64                       `json:"max_failover_replication_time_lag,omitempty"`
 }
 
+// AdvancedPostgresPGParameter is one GUC parameter returned by GET /config for advanced_pg clusters.
+type AdvancedPostgresPGParameter struct {
+	Name            string `json:"name,omitempty"`
+	Value           string `json:"value,omitempty"`
+	Description     string `json:"description,omitempty"`
+	RequiresRestart bool   `json:"requires_restart,omitempty"`
+	DefaultValue    string `json:"default_value,omitempty"`
+}
+
+// AdvancedPostgresConfig holds advanced configurations for advanced_pg database clusters.
+type AdvancedPostgresConfig struct {
+	PGParameters []AdvancedPostgresPGParameter `json:"pg_parameters,omitempty"`
+}
+
+// AdvancedPostgresConfigUpdate is the PATCH payload for advanced_pg database clusters.
+type AdvancedPostgresConfigUpdate struct {
+	PGParameters map[string]string `json:"pg_parameters,omitempty"`
+}
+
 // PostgreSQLBouncerConfig configuration
 type PostgreSQLBouncerConfig struct {
 	ServerResetQueryAlways  *bool     `json:"server_reset_query_always,omitempty"`
@@ -940,6 +961,14 @@ type databaseOpensearchConfigRoot struct {
 
 type databaseKafkaConfigRoot struct {
 	Config *KafkaConfig `json:"config"`
+}
+
+type databaseAdvancedPostgresConfigRoot struct {
+	Config *AdvancedPostgresConfig `json:"config"`
+}
+
+type databaseAdvancedPostgresConfigUpdateRoot struct {
+	Config *AdvancedPostgresConfigUpdate `json:"config"`
 }
 
 type databaseBackupsRoot struct {
@@ -1905,6 +1934,38 @@ func (svc *DatabasesServiceOp) GetKafkaConfig(ctx context.Context, databaseID st
 func (svc *DatabasesServiceOp) UpdateKafkaConfig(ctx context.Context, databaseID string, config *KafkaConfig) (*Response, error) {
 	path := fmt.Sprintf(databaseConfigPath, databaseID)
 	root := &databaseKafkaConfigRoot{
+		Config: config,
+	}
+	req, err := svc.client.NewRequest(ctx, http.MethodPatch, path, root)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := svc.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}
+
+// GetAdvancedPostgresSQLConfig retrieves the config for an advanced_pg database cluster.
+func (svc *DatabasesServiceOp) GetAdvancedPostgresSQLConfig(ctx context.Context, databaseID string) (*AdvancedPostgresConfig, *Response, error) {
+	path := fmt.Sprintf(databaseConfigPath, databaseID)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(databaseAdvancedPostgresConfigRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Config, resp, nil
+}
+
+// UpdateAdvancedPostgresSQLConfig updates the config for an advanced_pg database cluster.
+func (svc *DatabasesServiceOp) UpdateAdvancedPostgresSQLConfig(ctx context.Context, databaseID string, config *AdvancedPostgresConfigUpdate) (*Response, error) {
+	path := fmt.Sprintf(databaseConfigPath, databaseID)
+	root := &databaseAdvancedPostgresConfigUpdateRoot{
 		Config: config,
 	}
 	req, err := svc.client.NewRequest(ctx, http.MethodPatch, path, root)

--- a/databases_test.go
+++ b/databases_test.go
@@ -3109,6 +3109,84 @@ func TestDatabases_UpdateConfigPostgres(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestDatabases_GetConfigAdvancedPostgres(t *testing.T) {
+	setup()
+	defer teardown()
+
+	var (
+		dbSvc = client.Databases
+		dbID  = "da4e0206-d019-41d7-b51f-deadbeefbb8f"
+		path  = fmt.Sprintf("/v2/databases/%s/config", dbID)
+
+		advancedPostgresConfigJSON = `{
+  "config": {
+    "pg_parameters": [
+      {
+        "name": "work_mem",
+        "value": "1024",
+        "description": "Sets the maximum memory to be used for query workspaces.",
+        "requires_restart": false,
+        "default_value": "1024"
+      }
+    ]
+  }
+}`
+
+		advancedPostgresConfig = AdvancedPostgresConfig{
+			PGParameters: []AdvancedPostgresPGParameter{
+				{
+					Name:            "work_mem",
+					Value:           "1024",
+					Description:     "Sets the maximum memory to be used for query workspaces.",
+					RequiresRestart: false,
+					DefaultValue:    "1024",
+				},
+			},
+		}
+	)
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, advancedPostgresConfigJSON)
+	})
+
+	got, _, err := dbSvc.GetAdvancedPostgresSQLConfig(ctx, dbID)
+	require.NoError(t, err)
+	require.Equal(t, &advancedPostgresConfig, got)
+}
+
+func TestDatabases_UpdateConfigAdvancedPostgres(t *testing.T) {
+	setup()
+	defer teardown()
+
+	var (
+		dbID = "deadbeef-dead-4aa5-beef-deadbeef347d"
+		path = fmt.Sprintf("/v2/databases/%s/config", dbID)
+
+		advancedPostgresConfig = &AdvancedPostgresConfigUpdate{
+			PGParameters: map[string]string{
+				"work_mem": "4096",
+			},
+		}
+	)
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+
+		var b databaseAdvancedPostgresConfigUpdateRoot
+		decoder := json.NewDecoder(r.Body)
+		err := decoder.Decode(&b)
+		require.NoError(t, err)
+
+		assert.Equal(t, b.Config, advancedPostgresConfig)
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	_, err := client.Databases.UpdateAdvancedPostgresSQLConfig(ctx, dbID, advancedPostgresConfig)
+	require.NoError(t, err)
+}
+
 func TestDatabases_GetConfigRedis(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
The aim of this PR is to add support for configuration `get` and `update` calls to `ADVANCED_PG` engine type

the code is tested using the example below

```
package main

import (
	"context"
	"fmt"
	"os"

	"github.com/digitalocean/godo"
)

func main() {
	token := os.Getenv("DIGITALOCEAN_TOKEN")
	if token == "" {
		fmt.Fprintln(os.Stderr, "DIGITALOCEAN_TOKEN environment variable is required")
		os.Exit(1)
	}

	databaseID := os.Getenv("DATABASE_ID")
	if databaseID == "" {
		fmt.Fprintln(os.Stderr, "DATABASE_ID environment variable is required")
		os.Exit(1)
	}

	client := godo.NewFromToken(token)
	ctx := context.Background()

	fmt.Printf("Getting advanced_pg config for database %s...\n", databaseID)
	config, resp, err := client.Databases.GetAdvancedPostgresSQLConfig(ctx, databaseID)
	if err != nil {
		fmt.Fprintf(os.Stderr, "Error getting advanced_pg config: %v\n", err)
		if resp != nil {
			fmt.Fprintf(os.Stderr, "HTTP Status: %s\n", resp.Status)
		}
		os.Exit(1)
	}

	printConfig("Current config", config)

	paramName := os.Getenv("PG_PARAM_NAME")
	if paramName == "" {
		paramName = "work_mem"
	}

	paramValue := os.Getenv("PG_PARAM_VALUE")
	if paramValue == "" {
		paramValue = "5120"
	}

	fmt.Printf("\nUpdating parameter %q to %q...\n", paramName, paramValue)
	update := &godo.AdvancedPostgresConfigUpdate{
		PGParameters: map[string]string{
			paramName: paramValue,
		},
	}

	resp, err = client.Databases.UpdateAdvancedPostgresSQLConfig(ctx, databaseID, update)
	if err != nil {
		fmt.Fprintf(os.Stderr, "Error updating advanced_pg config: %v\n", err)
		if resp != nil {
			fmt.Fprintf(os.Stderr, "HTTP Status: %s\n", resp.Status)
		}
		os.Exit(1)
	}

	fmt.Printf("Update successful! HTTP Status: %s\n", resp.Status)

	fmt.Printf("\nVerifying updated config...\n")
	updated, _, err := client.Databases.GetAdvancedPostgresSQLConfig(ctx, databaseID)
	if err != nil {
		fmt.Fprintf(os.Stderr, "Error verifying advanced_pg config: %v\n", err)
		os.Exit(1)
	}

	printConfig("Updated config", updated)
}

func printConfig(label string, config *godo.AdvancedPostgresConfig) {
	if config == nil {
		fmt.Printf("%s: (nil)\n", label)
		return
	}

	fmt.Printf("%s:\n", label)
	if len(config.PGParameters) == 0 {
		fmt.Println("  (no pg_parameters returned)")
		return
	}

	for _, param := range config.PGParameters {
		fmt.Printf("  - name: %s\n", param.Name)
		fmt.Printf("    value: %s\n", param.Value)
		if param.DefaultValue != "" {
			fmt.Printf("    default_value: %s\n", param.DefaultValue)
		}
		if param.Description != "" {
			fmt.Printf("    description: %s\n", param.Description)
		}
		if param.RequiresRestart {
			fmt.Printf("    requires_restart: true\n")
		}
	}
}

```