### PR TITLE
Add ListEvaluationDatasets API and example

### DIFF
--- a/examples/gradient-ai/list-evaluation-datasets/main.go
+++ b/examples/gradient-ai/list-evaluation-datasets/main.go
@@ -1,0 +1,31 @@
+// Command list-evaluation-datasets lists evaluation datasets via the GradientAI
+// API. Results can optionally be filtered by dataset type.
+//
+// Required env vars:
+//   - DIGITALOCEAN_TOKEN: a DigitalOcean API token.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/digitalocean/godo"
+)
+
+func main() {
+	client := godo.NewFromToken(os.Getenv("DIGITALOCEAN_TOKEN"))
+
+	ctx := context.Background()
+
+	out, _, err := client.GradientAI.ListEvaluationDatasets(ctx, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Found %d evaluation datasets\n", len(out.EvaluationDatasets))
+	for _, dataset := range out.EvaluationDatasets {
+		fmt.Printf("- %s (%s) type=%s rows=%d ground_truth=%t\n",
+			dataset.DatasetUUID, dataset.DatasetName, dataset.DatasetType, dataset.RowCount, dataset.HasGroundTruth)
+	}
+}

--- a/gradientai.go
+++ b/gradientai.go
@@ -44,6 +44,7 @@ const (
 	modelEvaluationPresetByIDPath            = modelEvaluationPresetsBasePath + "/%s"
 	modelEvaluationMetricsBasePath           = "/v2/gen-ai/model_evaluation_metrics"
 	modelEvaluationDatasetUploadURLsPath     = "/v2/gen-ai/model_evaluation/datasets/file_upload_presigned_urls"
+	evaluationDatasetsBasePath               = "/v2/gen-ai/evaluation_datasets"
 )
 
 // CustomModelStatus represents the status of a custom model.
@@ -141,6 +142,16 @@ const (
 	ModelEvaluationRunSortDirectionDesc        ModelEvaluationRunSortDirection = "SORT_DIRECTION_DESC"
 )
 
+// EvaluationDatasetType represents the type of an evaluation dataset.
+type EvaluationDatasetType string
+
+const (
+	EvaluationDatasetTypeUnknown EvaluationDatasetType = "EVALUATION_DATASET_TYPE_UNKNOWN"
+	EvaluationDatasetTypeADK     EvaluationDatasetType = "EVALUATION_DATASET_TYPE_ADK"
+	EvaluationDatasetTypeNonADK  EvaluationDatasetType = "EVALUATION_DATASET_TYPE_NON_ADK"
+	EvaluationDatasetTypeModel   EvaluationDatasetType = "EVALUATION_DATASET_TYPE_MODEL"
+)
+
 // GradientAIService is an interface for interfacing with the Gradient AI Agent endpoints
 // of the DigitalOcean API.
 // See https://docs.digitalocean.com/reference/api/digitalocean/#tag/GradientAI-Platform for more details.
@@ -216,6 +227,7 @@ type GradientAIService interface {
 	ListModelEvaluationRuns(ctx context.Context, opt *ModelEvaluationRunListOptions) (*ModelEvaluationRunListResponse, *Response, error)
 	ListModelEvaluationPresets(ctx context.Context) (*ModelEvaluationPresetListResponse, *Response, error)
 	ListModelEvaluationMetrics(ctx context.Context) (*ModelEvaluationMetricListResponse, *Response, error)
+	ListEvaluationDatasets(ctx context.Context, opt *EvaluationDatasetListOptions) (*EvaluationDatasetListResponse, *Response, error)
 }
 
 var _ GradientAIService = &GradientAIServiceOp{}
@@ -2893,6 +2905,31 @@ type ModelEvaluationMetricListResponse struct {
 	Metrics []*EvaluationMetric `json:"metrics,omitempty"`
 }
 
+// EvaluationDatasetListOptions holds the optional filters for
+// ListEvaluationDatasets.
+type EvaluationDatasetListOptions struct {
+	// DatasetType filters the results by evaluation dataset type.
+	DatasetType EvaluationDatasetType `url:"dataset_type,omitempty"`
+}
+
+// EvaluationDatasetInfo represents an evaluation dataset returned by
+// ListEvaluationDatasets.
+type EvaluationDatasetInfo struct {
+	CreatedAt      *Timestamp            `json:"created_at,omitempty"`
+	DatasetName    string                `json:"dataset_name,omitempty"`
+	DatasetType    EvaluationDatasetType `json:"dataset_type,omitempty"`
+	DatasetUUID    string                `json:"dataset_uuid,omitempty"`
+	FileSize       string                `json:"file_size,omitempty"`
+	HasGroundTruth bool                  `json:"has_ground_truth,omitempty"`
+	RowCount       int64                 `json:"row_count,omitempty"`
+}
+
+// EvaluationDatasetListResponse is the response returned by
+// ListEvaluationDatasets.
+type EvaluationDatasetListResponse struct {
+	EvaluationDatasets []*EvaluationDatasetInfo `json:"evaluation_datasets,omitempty"`
+}
+
 // CreateModelEvaluationRun creates a new model evaluation run.
 func (s *GradientAIServiceOp) CreateModelEvaluationRun(ctx context.Context, createRequest *CreateModelEvaluationRunRequest) (*ModelEvaluationRunCreateResponse, *Response, error) {
 	if createRequest == nil {
@@ -3058,6 +3095,27 @@ func (s *GradientAIServiceOp) ListModelEvaluationMetrics(ctx context.Context) (*
 	}
 
 	root := new(ModelEvaluationMetricListResponse)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root, resp, nil
+}
+
+// ListEvaluationDatasets lists evaluation datasets. Results can be filtered by
+// dataset type using the provided options.
+func (s *GradientAIServiceOp) ListEvaluationDatasets(ctx context.Context, opt *EvaluationDatasetListOptions) (*EvaluationDatasetListResponse, *Response, error) {
+	path, err := addOptions(evaluationDatasetsBasePath, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(EvaluationDatasetListResponse)
 	resp, err := s.client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err

--- a/gradientai_test.go
+++ b/gradientai_test.go
@@ -4075,3 +4075,86 @@ func TestListModelEvaluationMetricsServerError(t *testing.T) {
 	assert.NotNil(t, resp)
 	assert.Equal(t, http.StatusInternalServerError, resp.Response.StatusCode)
 }
+
+var listEvaluationDatasetsResponse = `
+{
+	"evaluation_datasets": [
+		{
+			"created_at": "2023-01-01T00:00:00Z",
+			"dataset_name": "dataset-1",
+			"dataset_type": "EVALUATION_DATASET_TYPE_MODEL",
+			"dataset_uuid": "11111111-1111-1111-1111-111111111111",
+			"file_size": "12345",
+			"has_ground_truth": true,
+			"row_count": 100
+		},
+		{
+			"created_at": "2023-02-01T00:00:00Z",
+			"dataset_name": "dataset-2",
+			"dataset_type": "EVALUATION_DATASET_TYPE_ADK",
+			"dataset_uuid": "22222222-2222-2222-2222-222222222222",
+			"file_size": "67890",
+			"has_ground_truth": false,
+			"row_count": 50
+		}
+	]
+}
+`
+
+func TestListEvaluationDatasets(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/gen-ai/evaluation_datasets", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, listEvaluationDatasetsResponse)
+	})
+
+	out, resp, err := client.GradientAI.ListEvaluationDatasets(ctx, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, out)
+	assert.Equal(t, 200, resp.Response.StatusCode)
+	assert.Len(t, out.EvaluationDatasets, 2)
+	assert.Equal(t, "dataset-1", out.EvaluationDatasets[0].DatasetName)
+	assert.Equal(t, EvaluationDatasetTypeModel, out.EvaluationDatasets[0].DatasetType)
+	assert.Equal(t, "11111111-1111-1111-1111-111111111111", out.EvaluationDatasets[0].DatasetUUID)
+	assert.Equal(t, int64(100), out.EvaluationDatasets[0].RowCount)
+	assert.True(t, out.EvaluationDatasets[0].HasGroundTruth)
+	assert.Equal(t, "dataset-2", out.EvaluationDatasets[1].DatasetName)
+	assert.Equal(t, EvaluationDatasetTypeADK, out.EvaluationDatasets[1].DatasetType)
+}
+
+func TestListEvaluationDatasetsWithOptions(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/gen-ai/evaluation_datasets", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		assert.Equal(t, string(EvaluationDatasetTypeADK), r.URL.Query().Get("dataset_type"))
+		fmt.Fprint(w, listEvaluationDatasetsResponse)
+	})
+
+	out, resp, err := client.GradientAI.ListEvaluationDatasets(ctx, &EvaluationDatasetListOptions{
+		DatasetType: EvaluationDatasetTypeADK,
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, out)
+	assert.Equal(t, 200, resp.Response.StatusCode)
+	assert.Len(t, out.EvaluationDatasets, 2)
+}
+
+func TestListEvaluationDatasetsServerError(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/gen-ai/evaluation_datasets", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		http.Error(w, `{"id":"server_error","message":"boom"}`, http.StatusInternalServerError)
+	})
+
+	out, resp, err := client.GradientAI.ListEvaluationDatasets(ctx, nil)
+	assert.Error(t, err)
+	assert.Nil(t, out)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusInternalServerError, resp.Response.StatusCode)
+}


### PR DESCRIPTION
Implements listing of Gradient AI evaluation datasets: adds evaluation_datasets API path, EvaluationDatasetType enum, request options (EvaluationDatasetListOptions), response types (EvaluationDatasetInfo, EvaluationDatasetListResponse), and the ListEvaluationDatasets method on the service interface and implementation. Includes unit tests covering success, filtering via dataset_type, and server error handling, plus a new example CLI (examples/gradient-ai/list-evaluation-datasets/main.go) demonstrating usage (requires DIGITALOCEAN_TOKEN).