### PR TITLE
Adding in secrets API support

### DIFF
--- a/godo.go
+++ b/godo.go
@@ -79,6 +79,7 @@ type Client struct {
 	LoadBalancers       LoadBalancersService
 	Monitoring          MonitoringService
 	Security            SecurityService
+	Secrets             SecretsService
 	Nfs                 NfsService
 	NfsActions          NfsActionsService
 	OneClick            OneClickService
@@ -320,6 +321,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.LoadBalancers = &LoadBalancersServiceOp{client: c}
 	c.Monitoring = &MonitoringServiceOp{client: c}
 	c.Security = &SecurityServiceOp{client: c}
+	c.Secrets = &SecretsServiceOp{client: c}
 	c.Nfs = &NfsServiceOp{client: c}
 	c.NfsActions = &NfsActionsServiceOp{client: c}
 	c.VPCNATGateways = &VPCNATGatewaysServiceOp{client: c}

--- a/godo_test.go
+++ b/godo_test.go
@@ -92,6 +92,7 @@ func testClientServices(t *testing.T, c *Client) {
 		"Keys",
 		"Monitoring",
 		"Security",
+		"Secrets",
 		"Regions",
 		"Sizes",
 		"FloatingIPs",

--- a/secrets.go
+++ b/secrets.go
@@ -1,0 +1,310 @@
+package godo
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const secretsBasePath = "v2/security/secrets"
+
+// SecretsService is an interface for interacting with the Secrets endpoints of
+// the DigitalOcean API.
+type SecretsService interface {
+	List(context.Context, *ListOptions) ([]*Secret, *Response, error)
+	Get(context.Context, string, string) (*Secret, *Response, error)
+	ListVersions(context.Context, string, string) ([]*SecretVersion, *Response, error)
+	Create(context.Context, *SecretCreateRequest) (*SecretWriteResult, *Response, error)
+	Update(context.Context, string, *SecretUpdateRequest) (*SecretWriteResult, *Response, error)
+	Delete(context.Context, string, string) (*Response, error)
+	Restore(context.Context, string, string) (*Response, error)
+}
+
+// SecretsServiceOp handles communication with Secrets related methods of the
+// DigitalOcean API.
+type SecretsServiceOp struct {
+	client *Client
+}
+
+var _ SecretsService = &SecretsServiceOp{}
+
+// Secret represents a DigitalOcean secret.
+type Secret struct {
+	Name              string            `json:"secret"`
+	Region            string            `json:"region,omitempty"`
+	Version           int               `json:"version"`
+	Values            map[string]string `json:"values,omitempty"`
+	CreatedAt         string            `json:"created_at"`
+	UpdatedAt         string            `json:"updated_at,omitempty"`
+	DeleteRequestedAt *string           `json:"delete_requested_at,omitempty"`
+}
+
+// SecretVersion represents a version of a secret.
+type SecretVersion struct {
+	Version   int    `json:"version"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at,omitempty"`
+}
+
+// SecretCreateRequest represents a request to create a secret.
+type SecretCreateRequest struct {
+	Name   string            `json:"name"`
+	Region string            `json:"region"`
+	Values map[string]string `json:"values"`
+}
+
+// SecretUpdateRequest represents a request to update a secret.
+type SecretUpdateRequest struct {
+	Region  string            `json:"region"`
+	Version int               `json:"version"`
+	Values  map[string]string `json:"values"`
+}
+
+// SecretWriteResult represents the response from creating or updating a secret.
+type SecretWriteResult struct {
+	Name    string `json:"name"`
+	Region  string `json:"region"`
+	Version int    `json:"version"`
+}
+
+type secretRegionOptions struct {
+	Region string `url:"region"`
+}
+
+type secretsListRoot struct {
+	Secrets            []*Secret `json:"secrets"`
+	Links              *Links    `json:"links"`
+	Meta               *Meta     `json:"meta"`
+	UnavailableRegions []string  `json:"unavailable_regions,omitempty"`
+}
+
+type secretVersionsRoot struct {
+	Versions []*SecretVersion `json:"versions"`
+}
+
+// List returns a paginated list of secrets across all regions.
+func (s *SecretsServiceOp) List(ctx context.Context, opts *ListOptions) ([]*Secret, *Response, error) {
+	path, err := addOptions(secretsBasePath, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(secretsListRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
+	}
+
+	return root.Secrets, resp, nil
+}
+
+// Get retrieves a secret by name and region.
+func (s *SecretsServiceOp) Get(ctx context.Context, name, region string) (*Secret, *Response, error) {
+	if name == "" {
+		return nil, nil, NewArgError("name", "cannot be empty")
+	}
+	if region == "" {
+		return nil, nil, NewArgError("region", "cannot be empty")
+	}
+
+	path := fmt.Sprintf("%s/%s", secretsBasePath, name)
+	path, err := addOptions(path, &secretRegionOptions{Region: region})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	secret := new(Secret)
+	resp, err := s.client.Do(ctx, req, secret)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return secret, resp, nil
+}
+
+// ListVersions returns all versions of a secret.
+func (s *SecretsServiceOp) ListVersions(ctx context.Context, name, region string) ([]*SecretVersion, *Response, error) {
+	if name == "" {
+		return nil, nil, NewArgError("name", "cannot be empty")
+	}
+	if region == "" {
+		return nil, nil, NewArgError("region", "cannot be empty")
+	}
+
+	path := fmt.Sprintf("%s/%s/versions", secretsBasePath, name)
+	path, err := addOptions(path, &secretRegionOptions{Region: region})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(secretVersionsRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Versions, resp, nil
+}
+
+// Create creates a new secret.
+func (s *SecretsServiceOp) Create(ctx context.Context, createRequest *SecretCreateRequest) (*SecretWriteResult, *Response, error) {
+	if createRequest == nil {
+		return nil, nil, NewArgError("createRequest", "cannot be nil")
+	}
+	if createRequest.Region == "" {
+		return nil, nil, NewArgError("region", "cannot be empty")
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, secretsBasePath, createRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result := new(SecretWriteResult)
+	resp, err := s.doDecodeJSON(ctx, req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// Update updates an existing secret.
+func (s *SecretsServiceOp) Update(ctx context.Context, name string, updateRequest *SecretUpdateRequest) (*SecretWriteResult, *Response, error) {
+	if name == "" {
+		return nil, nil, NewArgError("name", "cannot be empty")
+	}
+	if updateRequest == nil {
+		return nil, nil, NewArgError("updateRequest", "cannot be nil")
+	}
+	if updateRequest.Region == "" {
+		return nil, nil, NewArgError("region", "cannot be empty")
+	}
+
+	path := fmt.Sprintf("%s/%s", secretsBasePath, name)
+	req, err := s.client.NewRequest(ctx, http.MethodPut, path, updateRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result := new(SecretWriteResult)
+	resp, err := s.doDecodeJSON(ctx, req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// Delete schedules a secret for soft deletion.
+func (s *SecretsServiceOp) Delete(ctx context.Context, name, region string) (*Response, error) {
+	if name == "" {
+		return nil, NewArgError("name", "cannot be empty")
+	}
+	if region == "" {
+		return nil, NewArgError("region", "cannot be empty")
+	}
+
+	path := fmt.Sprintf("%s/%s", secretsBasePath, name)
+	path, err := addOptions(path, &secretRegionOptions{Region: region})
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}
+
+// Restore restores a secret that was scheduled for deletion.
+func (s *SecretsServiceOp) Restore(ctx context.Context, name, region string) (*Response, error) {
+	if name == "" {
+		return nil, NewArgError("name", "cannot be empty")
+	}
+	if region == "" {
+		return nil, NewArgError("region", "cannot be empty")
+	}
+
+	path := fmt.Sprintf("%s/%s/restore", secretsBasePath, name)
+	path, err := addOptions(path, &secretRegionOptions{Region: region})
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}
+
+// doDecodeJSON sends a request and decodes the JSON response body even when
+// the API returns 204 No Content with a body.
+func (s *SecretsServiceOp) doDecodeJSON(ctx context.Context, req *http.Request, v interface{}) (*Response, error) {
+	c := s.client
+	if c.rateLimiter != nil {
+		if err := c.rateLimiter.Wait(ctx); err != nil {
+			return nil, err
+		}
+	}
+
+	resp, err := DoRequestWithClient(ctx, c.HTTPClient, req)
+	if err != nil {
+		return nil, err
+	}
+	if c.onRequestCompleted != nil {
+		c.onRequestCompleted(req, resp)
+	}
+
+	defer func() {
+		const maxBodySlurpSize = 2 << 10
+		if resp.ContentLength == -1 || resp.ContentLength <= maxBodySlurpSize {
+			io.CopyN(io.Discard, resp.Body, maxBodySlurpSize)
+		}
+		resp.Body.Close()
+	}()
+
+	response := newResponse(resp)
+	c.ratemtx.Lock()
+	c.Rate = response.Rate
+	c.ratemtx.Unlock()
+
+	if err = CheckResponse(resp); err != nil {
+		return response, err
+	}
+
+	if v != nil {
+		if err = json.NewDecoder(resp.Body).Decode(v); err != nil {
+			return response, err
+		}
+	}
+
+	return response, nil
+}

--- a/secrets.go
+++ b/secrets.go
@@ -13,7 +13,7 @@ const secretsBasePath = "v2/security/secrets"
 // SecretsService is an interface for interacting with the Secrets endpoints of
 // the DigitalOcean API.
 type SecretsService interface {
-	List(context.Context, *ListOptions) ([]*Secret, *Response, error)
+	List(context.Context, *ListOptions) (*SecretsList, *Response, error)
 	Get(context.Context, string, string) (*Secret, *Response, error)
 	ListVersions(context.Context, string, string) ([]*SecretVersion, *Response, error)
 	Create(context.Context, *SecretCreateRequest) (*SecretWriteResult, *Response, error)
@@ -69,6 +69,12 @@ type SecretWriteResult struct {
 	Version int    `json:"version"`
 }
 
+// SecretsList holds the result of a list secrets request.
+type SecretsList struct {
+	Secrets            []*Secret
+	UnavailableRegions []string
+}
+
 type secretRegionOptions struct {
 	Region string `url:"region"`
 }
@@ -85,7 +91,7 @@ type secretVersionsRoot struct {
 }
 
 // List returns a paginated list of secrets across all regions.
-func (s *SecretsServiceOp) List(ctx context.Context, opts *ListOptions) ([]*Secret, *Response, error) {
+func (s *SecretsServiceOp) List(ctx context.Context, opts *ListOptions) (*SecretsList, *Response, error) {
 	path, err := addOptions(secretsBasePath, opts)
 	if err != nil {
 		return nil, nil, err
@@ -108,7 +114,10 @@ func (s *SecretsServiceOp) List(ctx context.Context, opts *ListOptions) ([]*Secr
 		resp.Meta = m
 	}
 
-	return root.Secrets, resp, nil
+	return &SecretsList{
+		Secrets:            root.Secrets,
+		UnavailableRegions: root.UnavailableRegions,
+	}, resp, nil
 }
 
 // Get retrieves a secret by name and region.

--- a/secrets_test.go
+++ b/secrets_test.go
@@ -45,13 +45,14 @@ func TestSecretsList(t *testing.T) {
 		}`)
 	})
 
-	secrets, resp, err := client.Secrets.List(context.Background(), &ListOptions{Page: 1, PerPage: 20})
+	list, resp, err := client.Secrets.List(context.Background(), &ListOptions{Page: 1, PerPage: 20})
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
-	assert.Len(t, secrets, 1)
-	assert.Equal(t, secretName, secrets[0].Name)
-	assert.Equal(t, secretRegion, secrets[0].Region)
-	assert.Equal(t, 1, secrets[0].Version)
+	assert.Len(t, list.Secrets, 1)
+	assert.Equal(t, secretName, list.Secrets[0].Name)
+	assert.Equal(t, secretRegion, list.Secrets[0].Region)
+	assert.Equal(t, 1, list.Secrets[0].Version)
+	assert.Equal(t, []string{"sfo3"}, list.UnavailableRegions)
 }
 
 func TestSecretsGet(t *testing.T) {

--- a/secrets_test.go
+++ b/secrets_test.go
@@ -1,0 +1,224 @@
+package godo
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+const (
+	secretName   = "my-secret"
+	secretRegion = "nyc3"
+)
+
+func TestSecretsList(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/security/secrets", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "1", r.URL.Query().Get("page"))
+		assert.Equal(t, "20", r.URL.Query().Get("per_page"))
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"secrets": [{
+				"secret": "`+secretName+`",
+				"region": "`+secretRegion+`",
+				"version": 1,
+				"created_at": "2026-06-08T12:00:00Z",
+				"updated_at": "2026-06-08T12:00:00Z"
+			}],
+			"meta": {"page": 1, "pages": 1, "total": 1},
+			"unavailable_regions": ["sfo3"]
+		}`)
+	})
+
+	secrets, resp, err := client.Secrets.List(context.Background(), &ListOptions{Page: 1, PerPage: 20})
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Len(t, secrets, 1)
+	assert.Equal(t, secretName, secrets[0].Name)
+	assert.Equal(t, secretRegion, secrets[0].Region)
+	assert.Equal(t, 1, secrets[0].Version)
+}
+
+func TestSecretsGet(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/security/secrets/"+secretName, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, secretRegion, r.URL.Query().Get("region"))
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"secret": "`+secretName+`",
+			"version": 1,
+			"values": {"key": "val"},
+			"created_at": "2026-06-08T12:00:00Z",
+			"updated_at": "2026-06-08T12:00:00Z"
+		}`)
+	})
+
+	secret, resp, err := client.Secrets.Get(context.Background(), secretName, secretRegion)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, secretName, secret.Name)
+	assert.Equal(t, 1, secret.Version)
+	assert.Equal(t, "val", secret.Values["key"])
+}
+
+func TestSecretsListVersions(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/security/secrets/"+secretName+"/versions", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, secretRegion, r.URL.Query().Get("region"))
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"versions": [{
+				"version": 1,
+				"created_at": "2026-06-08T11:00:00Z",
+				"updated_at": "2026-06-08T11:00:00Z"
+			}]
+		}`)
+	})
+
+	versions, resp, err := client.Secrets.ListVersions(context.Background(), secretName, secretRegion)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Len(t, versions, 1)
+	assert.Equal(t, 1, versions[0].Version)
+}
+
+func TestSecretsCreate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	createRequest := &SecretCreateRequest{
+		Name:   secretName,
+		Region: secretRegion,
+		Values: map[string]string{"key": "val"},
+	}
+
+	mux.HandleFunc("/v2/security/secrets", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		var body SecretCreateRequest
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, createRequest.Name, body.Name)
+		assert.Equal(t, createRequest.Region, body.Region)
+		assert.Equal(t, createRequest.Values, body.Values)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"name": "`+secretName+`", "region": "`+secretRegion+`", "version": 1}`)
+	})
+
+	result, resp, err := client.Secrets.Create(context.Background(), createRequest)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, secretName, result.Name)
+	assert.Equal(t, secretRegion, result.Region)
+	assert.Equal(t, 1, result.Version)
+}
+
+func TestSecretsCreateNoContentWithBody(t *testing.T) {
+	setup()
+	defer teardown()
+
+	client.HTTPClient = &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			assert.Equal(t, http.MethodPost, req.Method)
+			return &http.Response{
+				StatusCode: http.StatusNoContent,
+				Body:       io.NopCloser(strings.NewReader(`{"name": "` + secretName + `", "region": "` + secretRegion + `", "version": 1}`)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+
+	createRequest := &SecretCreateRequest{
+		Name:   secretName,
+		Region: secretRegion,
+		Values: map[string]string{"key": "val"},
+	}
+
+	result, resp, err := client.Secrets.Create(context.Background(), createRequest)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, secretName, result.Name)
+	assert.Equal(t, secretRegion, result.Region)
+	assert.Equal(t, 1, result.Version)
+}
+
+func TestSecretsUpdate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	updateRequest := &SecretUpdateRequest{
+		Region:  secretRegion,
+		Version: 1,
+		Values:  map[string]string{"key": "new-val"},
+	}
+
+	mux.HandleFunc("/v2/security/secrets/"+secretName, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		var body SecretUpdateRequest
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, updateRequest.Region, body.Region)
+		assert.Equal(t, updateRequest.Version, body.Version)
+		assert.Equal(t, updateRequest.Values, body.Values)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"name": "`+secretName+`", "region": "`+secretRegion+`", "version": 2}`)
+	})
+
+	result, resp, err := client.Secrets.Update(context.Background(), secretName, updateRequest)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, secretName, result.Name)
+	assert.Equal(t, secretRegion, result.Region)
+	assert.Equal(t, 2, result.Version)
+}
+
+func TestSecretsDelete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/security/secrets/"+secretName, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, secretRegion, r.URL.Query().Get("region"))
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	resp, err := client.Secrets.Delete(context.Background(), secretName, secretRegion)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestSecretsRestore(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/security/secrets/"+secretName+"/restore", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, secretRegion, r.URL.Query().Get("region"))
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	resp, err := client.Secrets.Restore(context.Background(), secretName, secretRegion)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}


### PR DESCRIPTION
1. secrets.go — SecretsService with all 7 endpoints at v2/security/secrets:

2. List, Get, ListVersions, Create, Update, Delete, Restore

3. Types: Secret, SecretVersion, SecretCreateRequest, SecretUpdateRequest, SecretWriteResult