### PR TITLE
Add UpdateModelEvaluationRun to GradientAI service

### DIFF
--- a/gradientai.go
+++ b/gradientai.go
@@ -45,6 +45,7 @@ const (
 	modelEvaluationMetricsBasePath           = "/v2/gen-ai/model_evaluation_metrics"
 	modelEvaluationDatasetUploadURLsPath     = "/v2/gen-ai/model_evaluation/datasets/file_upload_presigned_urls"
 	evaluationDatasetsBasePath               = "/v2/gen-ai/evaluation_datasets"
+	UpdateModelEvaluationRunPath             = modelEvaluationRunsBasePath + "/%s"
 )
 
 // CustomModelStatus represents the status of a custom model.
@@ -220,6 +221,7 @@ type GradientAIService interface {
 	DeleteModelEvaluationPreset(ctx context.Context, evalPresetUUID string) (*ModelEvaluationPresetDeleteResponse, *Response, error)
 	CancelModelEvaluationRun(ctx context.Context, evalRunUUID string) (*ModelEvaluationRunCancelResponse, *Response, error)
 	CreateModelEvaluationRun(ctx context.Context, createRequest *CreateModelEvaluationRunRequest) (*ModelEvaluationRunCreateResponse, *Response, error)
+	UpdateModelEvaluationRun(ctx context.Context, evalRunUUID string, updateRequest *UpdateModelEvaluationRunRequest) (*ModelEvaluationRunUpdateResponse, *Response, error)
 	CreateModelEvalDatasetUploadPresignedURLs(ctx context.Context, createRequest *CreateModelEvalDatasetUploadPresignedURLsRequest) (*CreateModelEvalDatasetUploadPresignedURLsResponse, *Response, error)
 	GetModelEvaluationRun(ctx context.Context, evalRunUUID string, opt *ModelEvaluationRunGetOptions) (*ModelEvaluationRunGetResponse, *Response, error)
 	GetModelEvaluationPreset(ctx context.Context, evalPresetUUID string) (*ModelEvaluationPresetGetResponse, *Response, error)
@@ -2540,6 +2542,17 @@ type ModelEvaluationRunCancelResponse struct {
 	Run *ModelEvaluationRunSummary `json:"run,omitempty"`
 }
 
+// UpdateModelEvaluationRunRequest represents the request payload for updating a
+// model evaluation run. Currently only the run's display name can be updated.
+type UpdateModelEvaluationRunRequest struct {
+	Name string `json:"name,omitempty"`
+}
+
+// ModelEvaluationRunUpdateResponse is the response returned by UpdateModelEvaluationRun.
+type ModelEvaluationRunUpdateResponse struct {
+	Run *ModelEvaluationRunSummary `json:"run,omitempty"`
+}
+
 // ModelEvaluationPresetDeleteResponse is the response returned by
 // DeleteModelEvaluationPreset. The underlying API returns an empty object on
 // success; this struct exists for forward compatibility and to keep the SDK
@@ -2611,6 +2624,31 @@ func (s *GradientAIServiceOp) CancelModelEvaluationRun(ctx context.Context, eval
 	}
 
 	root := new(ModelEvaluationRunCancelResponse)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root, resp, nil
+}
+
+// UpdateModelEvaluationRun updates mutable fields on an existing model
+// evaluation run identified by its UUID. Currently only the run's display name
+// can be updated.
+func (s *GradientAIServiceOp) UpdateModelEvaluationRun(ctx context.Context, evalRunUUID string, updateRequest *UpdateModelEvaluationRunRequest) (*ModelEvaluationRunUpdateResponse, *Response, error) {
+	if evalRunUUID == "" {
+		return nil, nil, fmt.Errorf("eval run uuid is required")
+	}
+	if updateRequest == nil {
+		return nil, nil, fmt.Errorf("update request is required")
+	}
+	path := fmt.Sprintf(UpdateModelEvaluationRunPath, evalRunUUID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPut, path, updateRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(ModelEvaluationRunUpdateResponse)
 	resp, err := s.client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err

--- a/gradientai.go
+++ b/gradientai.go
@@ -2643,7 +2643,7 @@ func (s *GradientAIServiceOp) UpdateModelEvaluationRun(ctx context.Context, eval
 	}
 	path := fmt.Sprintf(UpdateModelEvaluationRunPath, evalRunUUID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPut, path, updateRequest)
+	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/gradientai_test.go
+++ b/gradientai_test.go
@@ -3439,6 +3439,110 @@ func TestCancelModelEvaluationRunInvalidURL(t *testing.T) {
 	assert.Nil(t, resp)
 }
 
+var updateModelEvaluationRunResponse = `
+{
+	"run": {
+		"eval_run_uuid": "33c32a9b-aa48-4577-b513-0a0257dd00f2",
+		"name": "Updated run",
+		"candidate_model_name": "OpenAI GPT-oss-20b",
+		"dataset_name": "political_reasoning_safety_NGT.jsonl",
+		"status": "MODEL_EVALUATION_RUN_PARTIALLY_SUCCESSFUL",
+		"created_at": "2026-06-05T12:17:08Z",
+		"candidate_model_uuid": "c60da0be-73c4-11f0-b074-4e013e2ddde4",
+		"judge_model_uuid": "3568b895-f2ca-11ef-bf8f-4e013e2ddde4",
+		"judge_model_name": "OpenAI GPT-4o",
+		"dataset_uuid": "11f15429-ff86-d769-9439-ca68c578b04b"
+	}
+}
+`
+
+func TestUpdateModelEvaluationRun(t *testing.T) {
+	setup()
+	defer teardown()
+
+	evalRunUUID := "33c32a9b-aa48-4577-b513-0a0257dd00f2"
+
+	mux.HandleFunc(fmt.Sprintf("/v2/gen-ai/model_evaluation_runs/%s", evalRunUUID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPut)
+
+		v := new(UpdateModelEvaluationRunRequest)
+		if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+			t.Errorf("Error decoding request body: %v", err)
+		}
+		assert.Equal(t, "Updated run", v.Name)
+
+		fmt.Fprint(w, updateModelEvaluationRunResponse)
+	})
+
+	updateReq := &UpdateModelEvaluationRunRequest{
+		Name: "Updated run",
+	}
+
+	out, resp, err := client.GradientAI.UpdateModelEvaluationRun(ctx, evalRunUUID, updateReq)
+	assert.NoError(t, err)
+	assert.NotNil(t, out)
+	assert.NotNil(t, out.Run)
+	assert.Equal(t, 200, resp.Response.StatusCode)
+
+	run := out.Run
+	assert.Equal(t, evalRunUUID, run.EvalRunUuid)
+	assert.Equal(t, "Updated run", run.Name)
+	assert.Equal(t, ModelEvaluationRunPartiallySuccessful, run.Status)
+	assert.Equal(t, "OpenAI GPT-oss-20b", run.CandidateModelName)
+	assert.Equal(t, "c60da0be-73c4-11f0-b074-4e013e2ddde4", run.CandidateModelUuid)
+	assert.Equal(t, "OpenAI GPT-4o", run.JudgeModelName)
+	assert.Equal(t, "3568b895-f2ca-11ef-bf8f-4e013e2ddde4", run.JudgeModelUuid)
+	assert.Equal(t, "political_reasoning_safety_NGT.jsonl", run.DatasetName)
+	assert.Equal(t, "11f15429-ff86-d769-9439-ca68c578b04b", run.DatasetUuid)
+	assert.NotNil(t, run.CreatedAt)
+}
+
+func TestUpdateModelEvaluationRunMissingUUID(t *testing.T) {
+	setup()
+	defer teardown()
+
+	out, resp, err := client.GradientAI.UpdateModelEvaluationRun(ctx, "", &UpdateModelEvaluationRunRequest{Name: "x"})
+	assert.Error(t, err)
+	assert.Nil(t, out)
+	assert.Nil(t, resp)
+}
+
+func TestUpdateModelEvaluationRunMissingRequest(t *testing.T) {
+	setup()
+	defer teardown()
+
+	out, resp, err := client.GradientAI.UpdateModelEvaluationRun(ctx, "12345678-1234-1234-1234-123456789012", nil)
+	assert.Error(t, err)
+	assert.Nil(t, out)
+	assert.Nil(t, resp)
+}
+
+func TestUpdateModelEvaluationRunServerError(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/gen-ai/model_evaluation_runs/99999999-9999-9999-9999-999999999999", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPut)
+		http.Error(w, `{"id":"not_found","message":"evaluation run not found"}`, http.StatusNotFound)
+	})
+
+	out, resp, err := client.GradientAI.UpdateModelEvaluationRun(ctx, "99999999-9999-9999-9999-999999999999", &UpdateModelEvaluationRunRequest{Name: "x"})
+	assert.Error(t, err)
+	assert.Nil(t, out)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusNotFound, resp.Response.StatusCode)
+}
+
+func TestUpdateModelEvaluationRunInvalidURL(t *testing.T) {
+	setup()
+	defer teardown()
+
+	out, resp, err := client.GradientAI.UpdateModelEvaluationRun(ctx, "bad\nuuid", &UpdateModelEvaluationRunRequest{Name: "x"})
+	assert.Error(t, err)
+	assert.Nil(t, out)
+	assert.Nil(t, resp)
+}
+
 var createModelEvaluationRunResponse = `
 {
 	"eval_run_uuid": "12345678-1234-1234-1234-123456789012"

--- a/gradientai_test.go
+++ b/gradientai_test.go
@@ -3463,7 +3463,7 @@ func TestUpdateModelEvaluationRun(t *testing.T) {
 	evalRunUUID := "33c32a9b-aa48-4577-b513-0a0257dd00f2"
 
 	mux.HandleFunc(fmt.Sprintf("/v2/gen-ai/model_evaluation_runs/%s", evalRunUUID), func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, http.MethodPut)
+		testMethod(t, r, http.MethodPatch)
 
 		v := new(UpdateModelEvaluationRunRequest)
 		if err := json.NewDecoder(r.Body).Decode(v); err != nil {
@@ -3522,7 +3522,7 @@ func TestUpdateModelEvaluationRunServerError(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/gen-ai/model_evaluation_runs/99999999-9999-9999-9999-999999999999", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, http.MethodPut)
+		testMethod(t, r, http.MethodPatch)
 		http.Error(w, `{"id":"not_found","message":"evaluation run not found"}`, http.StatusNotFound)
 	})
 


### PR DESCRIPTION
## Summary
- Add `UpdateModelEvaluationRun` method to the `GradientAIService` interface for renaming
  an existing model evaluation run via `PUT /v2/gen-ai/model_evaluation_runs/{eval_run_uuid}`
- Add `UpdateModelEvaluationRunRequest` (only `name` is mutable today) and
  `ModelEvaluationRunUpdateResponse` types
- Add unit tests covering: happy path, missing UUID, missing request body,
  server error (404), and invalid URL handling
