### PR TITLE
Add run progress model and update tests

### DIFF
--- a/gradientai.go
+++ b/gradientai.go
@@ -2520,17 +2520,18 @@ type ModelEvaluationRunDeleteResponse struct {
 // ModelEvaluationRunSummary is a lightweight view of an evaluation run used in
 // run history listings and the cancel response.
 type ModelEvaluationRunSummary struct {
-	CandidateModelName   string                   `json:"candidate_model_name,omitempty"`
-	CandidateModelSource CandidateModelSource     `json:"candidate_model_source,omitempty"`
-	CandidateModelUuid   string                   `json:"candidate_model_uuid,omitempty"`
-	CreatedAt            *Timestamp               `json:"created_at,omitempty"`
-	DatasetName          string                   `json:"dataset_name,omitempty"`
-	DatasetUuid          string                   `json:"dataset_uuid,omitempty"`
-	EvalRunUuid          string                   `json:"eval_run_uuid,omitempty"`
-	JudgeModelName       string                   `json:"judge_model_name,omitempty"`
-	JudgeModelUuid       string                   `json:"judge_model_uuid,omitempty"`
-	Name                 string                   `json:"name,omitempty"`
-	Status               ModelEvaluationRunStatus `json:"status,omitempty"`
+	CandidateModelName   string                      `json:"candidate_model_name,omitempty"`
+	CandidateModelSource CandidateModelSource        `json:"candidate_model_source,omitempty"`
+	CandidateModelUuid   string                      `json:"candidate_model_uuid,omitempty"`
+	CreatedAt            *Timestamp                  `json:"created_at,omitempty"`
+	DatasetName          string                      `json:"dataset_name,omitempty"`
+	DatasetUuid          string                      `json:"dataset_uuid,omitempty"`
+	EvalRunUuid          string                      `json:"eval_run_uuid,omitempty"`
+	JudgeModelName       string                      `json:"judge_model_name,omitempty"`
+	JudgeModelUuid       string                      `json:"judge_model_uuid,omitempty"`
+	Name                 string                      `json:"name,omitempty"`
+	Progress             *ModelEvaluationRunProgress `json:"progress,omitempty"`
+	Status               ModelEvaluationRunStatus    `json:"status,omitempty"`
 }
 
 // CancelModelEvaluationRunRequest represents the request payload for cancelling
@@ -2834,6 +2835,24 @@ type ModelEvaluationRunResultSummary struct {
 	TotalDurationSeconds int64                    `json:"total_duration_seconds,omitempty"`
 }
 
+// ModelEvaluationRunProgress reports per-phase progress for a model evaluation
+// run. The candidate phase invokes the candidate model once per dataset row;
+// the judge phase scores each candidate-success row with the configured
+// metrics. Counts grow as the run advances; compare against TotalRows to render
+// a progress bar.
+type ModelEvaluationRunProgress struct {
+	// CandidateRowsEvaluated is the number of dataset rows whose candidate model
+	// call has completed (success or failure).
+	CandidateRowsEvaluated *int64 `json:"candidate_rows_evaluated,omitempty"`
+	// JudgeRowsEvaluated is the number of candidate-success rows the judge has
+	// finished (scored or skipped). It caps at the number of candidate
+	// successes, which may be below TotalRows.
+	JudgeRowsEvaluated *int64 `json:"judge_rows_evaluated,omitempty"`
+	// TotalRows is the total number of dataset rows for the run, sourced from the
+	// evaluation dataset.
+	TotalRows *int64 `json:"total_rows,omitempty"`
+}
+
 // ModelEvaluationRunDetail is the full view of a model evaluation run
 // returned when fetching a specific run.
 type ModelEvaluationRunDetail struct {
@@ -2853,6 +2872,7 @@ type ModelEvaluationRunDetail struct {
 	JudgeModelUuid           string                           `json:"judge_model_uuid,omitempty"`
 	Metrics                  []*EvaluationMetric              `json:"metrics,omitempty"`
 	Name                     string                           `json:"name,omitempty"`
+	Progress                 *ModelEvaluationRunProgress      `json:"progress,omitempty"`
 	ResultSummary            *ModelEvaluationRunResultSummary `json:"result_summary,omitempty"`
 	StarMetric               *StarMetric                      `json:"star_metric,omitempty"`
 	StartedAt                *Timestamp                       `json:"started_at,omitempty"`

--- a/gradientai_test.go
+++ b/gradientai_test.go
@@ -3685,6 +3685,11 @@ var getModelEvaluationRunResponse = `
 		"created_at": "2025-05-08T03:37:28Z",
 		"started_at": "2025-05-08T03:38:00Z",
 		"completed_at": "2025-05-08T03:45:00Z",
+		"progress": {
+			"candidate_rows_evaluated": 80,
+			"judge_rows_evaluated": 75,
+			"total_rows": 100
+		},
 		"result_summary": {
 			"overall_score_percent": 87.5,
 			"total_duration_seconds": 420,
@@ -3758,6 +3763,10 @@ func TestGetModelEvaluationRun(t *testing.T) {
 	assert.Equal(t, "my-eval-run", out.Run.Name)
 	assert.Equal(t, ModelEvaluationRunSuccessful, out.Run.Status)
 	assert.Equal(t, CandidateModelSourceServerless, out.Run.CandidateModelSource)
+	assert.NotNil(t, out.Run.Progress)
+	assert.Equal(t, int64(80), *out.Run.Progress.CandidateRowsEvaluated)
+	assert.Equal(t, int64(75), *out.Run.Progress.JudgeRowsEvaluated)
+	assert.Equal(t, int64(100), *out.Run.Progress.TotalRows)
 	assert.NotNil(t, out.Run.ResultSummary)
 	assert.Equal(t, 87.5, out.Run.ResultSummary.OverallScorePercent)
 	assert.Equal(t, int64(420), out.Run.ResultSummary.TotalDurationSeconds)
@@ -3963,7 +3972,12 @@ var listModelEvaluationRunsResponse = `
 			"status": "MODEL_EVALUATION_RUN_SUCCESSFUL",
 			"candidate_model_name": "candidate-1",
 			"candidate_model_source": "CANDIDATE_MODEL_SOURCE_SERVERLESS",
-			"created_at": "2025-05-08T03:37:28Z"
+			"created_at": "2025-05-08T03:37:28Z",
+			"progress": {
+				"candidate_rows_evaluated": 40,
+				"judge_rows_evaluated": 35,
+				"total_rows": 100
+			}
 		},
 		{
 			"eval_run_uuid": "22222222-2222-2222-2222-222222222222",
@@ -4032,6 +4046,11 @@ func TestListModelEvaluationRuns(t *testing.T) {
 	assert.Equal(t, "run-1", out.Runs[0].Name)
 	assert.Equal(t, ModelEvaluationRunSuccessful, out.Runs[0].Status)
 	assert.Equal(t, CandidateModelSourceServerless, out.Runs[0].CandidateModelSource)
+	assert.NotNil(t, out.Runs[0].Progress)
+	assert.Equal(t, int64(40), *out.Runs[0].Progress.CandidateRowsEvaluated)
+	assert.Equal(t, int64(35), *out.Runs[0].Progress.JudgeRowsEvaluated)
+	assert.Equal(t, int64(100), *out.Runs[0].Progress.TotalRows)
+	assert.Nil(t, out.Runs[1].Progress)
 	assert.Equal(t, ModelEvaluationRunQueued, out.Runs[1].Status)
 	assert.Equal(t, CandidateModelSourceDedicated, out.Runs[1].CandidateModelSource)
 }


### PR DESCRIPTION
Introduce ModelEvaluationRunProgress to report per-phase progress (candidate_rows_evaluated, judge_rows_evaluated, total_rows). Wire a Progress *ModelEvaluationRunProgress field into ModelEvaluationRunSummary and ModelEvaluationRunDetail. Update test fixtures and assertions to include and validate progress in the get/list evaluation run responses (including a nil check for runs without progress). This exposes progress metrics so callers can render progress bars and inspect run advancement.