### PR TITLE
Support subnet_uuid in vpcnatgateway

### DIFF
--- a/vpc_nat_gateways.go
+++ b/vpc_nat_gateways.go
@@ -54,6 +54,7 @@ type VPCNATGateway struct {
 // IngressVPC defines the ingress configs supported by a VPC NAT Gateway
 type IngressVPC struct {
 	VpcUUID        string `json:"vpc_uuid"`
+	SubnetUUID     string `json:"subnet_uuid,omitempty"`
 	GatewayIP      string `json:"gateway_ip,omitempty"`
 	DefaultGateway bool   `json:"default_gateway,omitempty"`
 }

--- a/vpc_nat_gateways_test.go
+++ b/vpc_nat_gateways_test.go
@@ -23,6 +23,7 @@ var vpcNatGatewayGetJSONResponse = `
     "vpcs": [
       {
         "vpc_uuid": "4637280e-3842-4661-a628-a6f0392959d3",
+        "subnet_uuid": "3d6f6fdc-8b7e-49fd-a3c2-0d73ec4e40b4",
         "gateway_ip": "10.100.0.110"
       }
     ],
@@ -56,6 +57,7 @@ var vpcNatGatewayListJSONResponse = `
       "vpcs": [
         {
           "vpc_uuid": "4637280e-3842-4661-a628-a6f0392959d3",
+          "subnet_uuid": "3d6f6fdc-8b7e-49fd-a3c2-0d73ec4e40b4",
           "gateway_ip": "10.100.0.110"
         }
       ],
@@ -83,6 +85,7 @@ var vpcNatGatewayListJSONResponse = `
       "vpcs": [
         {
           "vpc_uuid": "4637280e-3842-4661-a628-a6f0392959d3",
+          "subnet_uuid": "f2fb3d4e-8551-4d89-81e3-2a4d331b2ef4",
           "gateway_ip": "10.100.0.106"
         }
       ],
@@ -120,6 +123,7 @@ var vpcNatGatewayUpdateJSONResponse = `
     "vpcs": [
       {
         "vpc_uuid": "4637280e-3842-4661-a628-a6f0392959d3",
+        "subnet_uuid": "3d6f6fdc-8b7e-49fd-a3c2-0d73ec4e40b4",
         "gateway_ip": "10.100.0.110"
       }
     ],
@@ -150,7 +154,7 @@ func TestVPCNATGateways_Create(t *testing.T) {
 		Region: "nyc3",
 		Size:   1,
 		VPCs: []*IngressVPC{
-			{VpcUUID: "4637280e-3842-4661-a628-a6f0392959d3"},
+			{VpcUUID: "4637280e-3842-4661-a628-a6f0392959d3", SubnetUUID: "3d6f6fdc-8b7e-49fd-a3c2-0d73ec4e40b4"},
 		},
 		UDPTimeoutSeconds:  30,
 		ICMPTimeoutSeconds: 30,
@@ -178,7 +182,7 @@ func TestVPCNATGateways_Create(t *testing.T) {
 		Region:    "nyc3",
 		Size:      1,
 		VPCs: []*IngressVPC{
-			{VpcUUID: "4637280e-3842-4661-a628-a6f0392959d3", GatewayIP: "10.100.0.110"},
+			{VpcUUID: "4637280e-3842-4661-a628-a6f0392959d3", SubnetUUID: "3d6f6fdc-8b7e-49fd-a3c2-0d73ec4e40b4", GatewayIP: "10.100.0.110"},
 		},
 		Egresses: &Egresses{
 			PublicGateways: []*PublicGateway{
@@ -216,7 +220,7 @@ func TestVPCNATGateways_Get(t *testing.T) {
 		Region: "nyc3",
 		Size:   1,
 		VPCs: []*IngressVPC{
-			{VpcUUID: "4637280e-3842-4661-a628-a6f0392959d3", GatewayIP: "10.100.0.110"},
+			{VpcUUID: "4637280e-3842-4661-a628-a6f0392959d3", SubnetUUID: "3d6f6fdc-8b7e-49fd-a3c2-0d73ec4e40b4", GatewayIP: "10.100.0.110"},
 		},
 		Egresses: &Egresses{
 			PublicGateways: []*PublicGateway{
@@ -270,7 +274,7 @@ func TestVPCNATGateways_List(t *testing.T) {
 			Region: "nyc3",
 			Size:   1,
 			VPCs: []*IngressVPC{
-				{VpcUUID: "4637280e-3842-4661-a628-a6f0392959d3", GatewayIP: "10.100.0.110"},
+				{VpcUUID: "4637280e-3842-4661-a628-a6f0392959d3", SubnetUUID: "3d6f6fdc-8b7e-49fd-a3c2-0d73ec4e40b4", GatewayIP: "10.100.0.110"},
 			},
 			Egresses: &Egresses{
 				PublicGateways: []*PublicGateway{
@@ -290,7 +294,7 @@ func TestVPCNATGateways_List(t *testing.T) {
 			Region: "nyc3",
 			Size:   1,
 			VPCs: []*IngressVPC{
-				{VpcUUID: "4637280e-3842-4661-a628-a6f0392959d3", GatewayIP: "10.100.0.106"},
+				{VpcUUID: "4637280e-3842-4661-a628-a6f0392959d3", SubnetUUID: "f2fb3d4e-8551-4d89-81e3-2a4d331b2ef4", GatewayIP: "10.100.0.106"},
 			},
 			Egresses: &Egresses{
 				PublicGateways: []*PublicGateway{
@@ -332,7 +336,7 @@ func TestVPCNATGateways_Update(t *testing.T) {
 		Type:   "PUBLIC",
 		Region: "nyc3",
 		VPCs: []*IngressVPC{
-			{VpcUUID: "72b0812c-7535-4388-8507-5ad29b4487b3"},
+			{VpcUUID: "72b0812c-7535-4388-8507-5ad29b4487b3", SubnetUUID: "3d6f6fdc-8b7e-49fd-a3c2-0d73ec4e40b4"},
 		},
 		UDPTimeoutSeconds:  30,
 		ICMPTimeoutSeconds: 30,
@@ -359,7 +363,7 @@ func TestVPCNATGateways_Update(t *testing.T) {
 		Region: "nyc3",
 		Size:   1,
 		VPCs: []*IngressVPC{
-			{VpcUUID: "4637280e-3842-4661-a628-a6f0392959d3", GatewayIP: "10.100.0.110"},
+			{VpcUUID: "4637280e-3842-4661-a628-a6f0392959d3", SubnetUUID: "3d6f6fdc-8b7e-49fd-a3c2-0d73ec4e40b4", GatewayIP: "10.100.0.110"},
 		},
 		Egresses: &Egresses{
 			PublicGateways: []*PublicGateway{


### PR DESCRIPTION
Support subnet_uuid for vpcnatgateway.

Added in the nat gateway API in [cthulhu #162680](https://github.internal.digitalocean.com/digitalocean/cthulhu/pull/162680)