### PR TITLE
DBAAS-8142: Add GetDOSettings and UpdateDOSettings

### DIFF
--- a/databases.go
+++ b/databases.go
@@ -32,6 +32,7 @@ const (
 	databaseEvictionPolicyPath                   = databaseBasePath + "/%s/eviction_policy"
 	databaseSQLModePath                          = databaseBasePath + "/%s/sql_mode"
 	databaseFirewallRulesPath                    = databaseBasePath + "/%s/firewall"
+	databaseDOSettingsPath                       = databaseBasePath + "/%s/do_settings"
 	databaseOptionsPath                          = databaseBasePath + "/options"
 	databaseUpgradeMajorVersionPath              = databaseBasePath + "/%s/upgrade"
 	databasePromoteReplicaToPrimaryPath          = databaseReplicaPath + "/promote"
@@ -160,6 +161,8 @@ type DatabasesService interface {
 	SetSQLMode(context.Context, string, ...string) (*Response, error)
 	GetFirewallRules(context.Context, string) ([]DatabaseFirewallRule, *Response, error)
 	UpdateFirewallRules(context.Context, string, *DatabaseUpdateFirewallRulesRequest) (*Response, error)
+	GetDOSettings(context.Context, string) (*DOSettings, *Response, error)
+	UpdateDOSettings(context.Context, string, *DatabaseUpdateDOSettingsRequest) (*Response, error)
 	GetPostgreSQLConfig(context.Context, string) (*PostgreSQLConfig, *Response, error)
 	GetRedisConfig(context.Context, string) (*RedisConfig, *Response, error)
 	GetValkeyConfig(context.Context, string) (*ValkeyConfig, *Response, error)
@@ -273,6 +276,16 @@ type ServiceAddress struct {
 // DOSettings contains DigitalOcean-specific settings for a database cluster.
 type DOSettings struct {
 	ServiceCnames []string `json:"service_cnames,omitempty"`
+}
+
+// doSettingsRoot is the API response wrapper for GET /do_settings.
+type doSettingsRoot struct {
+	DOSettings *DOSettings `json:"do_settings"`
+}
+
+// DatabaseUpdateDOSettingsRequest is used to update DigitalOcean-specific settings.
+type DatabaseUpdateDOSettingsRequest struct {
+	DOSettings *DOSettings `json:"do_settings"`
 }
 
 // DatabaseUser represents a user in the database
@@ -1738,6 +1751,31 @@ func (svc *DatabasesServiceOp) GetFirewallRules(ctx context.Context, databaseID 
 func (svc *DatabasesServiceOp) UpdateFirewallRules(ctx context.Context, databaseID string, firewallRulesReq *DatabaseUpdateFirewallRulesRequest) (*Response, error) {
 	path := fmt.Sprintf(databaseFirewallRulesPath, databaseID)
 	req, err := svc.client.NewRequest(ctx, http.MethodPut, path, firewallRulesReq)
+	if err != nil {
+		return nil, err
+	}
+	return svc.client.Do(ctx, req, nil)
+}
+
+// GetDOSettings retrieves the DigitalOcean-specific settings for a given cluster.
+func (svc *DatabasesServiceOp) GetDOSettings(ctx context.Context, databaseID string) (*DOSettings, *Response, error) {
+	path := fmt.Sprintf(databaseDOSettingsPath, databaseID)
+	root := new(doSettingsRoot)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.DOSettings, resp, nil
+}
+
+// UpdateDOSettings updates the DigitalOcean-specific settings for a given cluster.
+func (svc *DatabasesServiceOp) UpdateDOSettings(ctx context.Context, databaseID string, updateReq *DatabaseUpdateDOSettingsRequest) (*Response, error) {
+	path := fmt.Sprintf(databaseDOSettingsPath, databaseID)
+	req, err := svc.client.NewRequest(ctx, http.MethodPut, path, updateReq)
 	if err != nil {
 		return nil, err
 	}

--- a/databases_test.go
+++ b/databases_test.go
@@ -2258,6 +2258,90 @@ func TestDatabases_UpdateFirewallRules(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestDatabases_GetDOSettings(t *testing.T) {
+	setup()
+	defer teardown()
+
+	dbID := "deadbeef-dead-4aa5-beef-deadbeef347d"
+	path := fmt.Sprintf("/v2/databases/%s/do_settings", dbID)
+
+	body := `{"do_settings":{"service_cnames":["db.example.com","api.myapp.io"]}}`
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, body)
+	})
+
+	got, _, err := client.Databases.GetDOSettings(ctx, dbID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, []string{"db.example.com", "api.myapp.io"}, got.ServiceCnames)
+}
+
+func TestDatabases_GetDOSettings_Empty(t *testing.T) {
+	setup()
+	defer teardown()
+
+	dbID := "deadbeef-dead-4aa5-beef-deadbeef347d"
+	path := fmt.Sprintf("/v2/databases/%s/do_settings", dbID)
+
+	body := `{"do_settings":{"service_cnames":[]}}`
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, body)
+	})
+
+	got, _, err := client.Databases.GetDOSettings(ctx, dbID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Empty(t, got.ServiceCnames)
+}
+
+func TestDatabases_UpdateDOSettings(t *testing.T) {
+	setup()
+	defer teardown()
+
+	dbID := "deadbeef-dead-4aa5-beef-deadbeef347d"
+	path := fmt.Sprintf("/v2/databases/%s/do_settings", dbID)
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPut)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	_, err := client.Databases.UpdateDOSettings(ctx, dbID, &DatabaseUpdateDOSettingsRequest{
+		DOSettings: &DOSettings{
+			ServiceCnames: []string{"db.example.com"},
+		},
+	})
+	require.NoError(t, err)
+}
+
+func TestDatabases_UpdateDOSettings_ClearCnames(t *testing.T) {
+	setup()
+	defer teardown()
+
+	dbID := "deadbeef-dead-4aa5-beef-deadbeef347d"
+	path := fmt.Sprintf("/v2/databases/%s/do_settings", dbID)
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPut)
+
+		var req DatabaseUpdateDOSettingsRequest
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+		require.NotNil(t, req.DOSettings)
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	_, err := client.Databases.UpdateDOSettings(ctx, dbID, &DatabaseUpdateDOSettingsRequest{
+		DOSettings: &DOSettings{},
+	})
+	require.NoError(t, err)
+}
+
 func TestDatabases_GetDatabaseOptions(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
## Summary

Adds client methods for the dedicated DO settings endpoint:

- `GetDOSettings(ctx, databaseID)` — GET `/v2/databases/{id}/do_settings`
- `UpdateDOSettings(ctx, databaseID, req)` — PUT `/v2/databases/{id}/do_settings`

Backend shipped in [cthulhu #154593](https://github.internal.digitalocean.com/digitalocean/cthulhu/pull/154593). `DOSettings` struct on cluster/replica already merged in #949.

**Clearing cnames:** send `DOSettings{}` (omitempty omits the field; server normalizes to empty array).

## Test plan

- [x] `gofmt -s -l .` clean
- [x] `go test -race ./...` passes (4 new tests: GetDOSettings, GetDOSettings_Empty, UpdateDOSettings, UpdateDOSettings_ClearCnames)
- [x] Stage2 live curl validation against deployed backend (user `8142845`, cluster `bkp-st2-doset-mysql-0619` / `ccadf744-1481-43ab-b25f-128a79f2c3bd`):

| Case | Expected | Result |
|------|----------|--------|
| GET baseline | 200, `service_cnames: []` | PASS |
| PUT set cnames (`api.myapp.io`, `a1.x.com`) | 204 | PASS |
| GET after set | 200, cnames match | PASS |
| PUT clear (`service_cnames: []`) | 204 | PASS |
| GET after clear | 200, `service_cnames: []` | PASS |
| PUT invalid field (`per_table_metrics`) | 422 | PASS |
| PUT missing `do_settings` (`{}`) | 400 | PASS |