### PR TITLE
kubernetes: fix SurgeUpgrade cannot be set to false in update requests

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -103,7 +103,7 @@ type KubernetesClusterUpdateRequest struct {
 	Tags                              []string                                     `json:"tags,omitempty"`
 	MaintenancePolicy                 *KubernetesMaintenancePolicy                 `json:"maintenance_policy,omitempty"`
 	AutoUpgrade                       *bool                                        `json:"auto_upgrade,omitempty"`
-	SurgeUpgrade                      bool                                         `json:"surge_upgrade,omitempty"`
+	SurgeUpgrade                      *bool                                        `json:"surge_upgrade,omitempty"`
 	ControlPlaneFirewall              *KubernetesControlPlaneFirewall              `json:"control_plane_firewall,omitempty"`
 	ClusterAutoscalerConfiguration    *KubernetesClusterAutoscalerConfiguration    `json:"cluster_autoscaler_configuration,omitempty"`
 	RoutingAgent                      *KubernetesRoutingAgent                      `json:"routing_agent,omitempty"`

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -1133,7 +1133,7 @@ func TestKubernetesClusters_Update(t *testing.T) {
 		Name:              want.Name,
 		Tags:              want.Tags,
 		MaintenancePolicy: want.MaintenancePolicy,
-		SurgeUpgrade:      true,
+		SurgeUpgrade:      PtrTo(true),
 		ControlPlaneFirewall: &KubernetesControlPlaneFirewall{
 			Enabled: &enabled,
 			AllowedAddresses: []string{


### PR DESCRIPTION
The `SurgeUpgrade` field in `KubernetesClusterUpdateRequest` was a non-pointer `bool` with `omitempty` in its JSON struct tag. When users set `SurgeUpgrade` to `false`, Go's `omitempty` omitted the field from the JSON payload entirely, preventing the API from receiving the intent to disable surge upgrades.

This fix changes `SurgeUpgrade` from `bool` to `*bool` (pointer to bool), matching the existing pattern used by `AutoUpgrade` in the same struct. With this change:
- `nil` = field not sent (no change requested)
- `PtrTo(true)` = `"surge_upgrade": true`
- `PtrTo(false)` = `"surge_upgrade": false`

Fixes #524