### PR TITLE
gradientai: remove deprecated SaveAsPreset field

### DIFF
--- a/gradientai.go
+++ b/gradientai.go
@@ -2762,7 +2762,6 @@ type CreateModelEvaluationRunRequest struct {
 	MetricUUIDs              []string                  `json:"metric_uuids,omitempty"`
 	Name                     string                    `json:"name,omitempty"`
 	PresetName               string                    `json:"preset_name,omitempty"`
-	SaveAsPreset             bool                      `json:"save_as_preset,omitempty"`
 	Source                   string                    `json:"source,omitempty"`
 	StarMetric               *StarMetric               `json:"star_metric,omitempty"`
 }


### PR DESCRIPTION
## Summary
- Removes the deprecated `SaveAsPreset` boolean from `CreateModelEvaluationRunRequest`.
- This field has been superseded by `PresetSaveSections`, which allows selecting individual preset sections to save instead of an all-or-nothing boolean.
- Mirrors the removal of the corresponding deprecated `save_as_preset` field from the gen-ai API's proto definition.

## Test plan
- `go build ./...` and `go vet ./...` pass.
- `go test ./... -run ModelEvaluationRun` passes (no test referenced the removed field).

Made with [Cursor](https://cursor.com)