### PR TITLE
Add GPU partition mode support to Droplets and Sizes

### DIFF
--- a/droplets.go
+++ b/droplets.go
@@ -44,6 +44,14 @@ type DropletsServiceOp struct {
 
 var _ DropletsService = &DropletsServiceOp{}
 
+// GPU partition modes supported when creating a GPU Droplet. Omitting the value
+// (or sending an empty string) is treated as PARTITION_MODE_UNSET, i.e. a full
+// GPU with SPX/NPS1 behavior.
+const (
+	GPUPartitionModeSPXNPS1 = "PARTITION_MODE_SPX_NPS1"
+	GPUPartitionModeDPXNPS2 = "PARTITION_MODE_DPX_NPS2"
+)
+
 // Droplet represents a DigitalOcean Droplet
 type Droplet struct {
 	ID               int           `json:"id,float64,omitempty"`
@@ -67,6 +75,10 @@ type Droplet struct {
 	Tags             []string      `json:"tags,omitempty"`
 	VolumeIDs        []string      `json:"volume_ids"`
 	VPCUUID          string        `json:"vpc_uuid,omitempty"`
+	// GPUPartitionMode is echoed back on create when the Droplet was created
+	// with a partitioned GPU. Note: read-back on droplet GET is not delivered in
+	// v1, so this is only reliably populated on the create response.
+	GPUPartitionMode string `json:"gpu_partition_mode,omitempty"`
 }
 
 // PublicIPv4 returns the public IPv4 address for the Droplet.
@@ -238,6 +250,10 @@ type DropletCreateRequest struct {
 	WithDropletAgent  *bool                       `json:"with_droplet_agent,omitempty"`
 	BackupPolicy      *DropletBackupPolicyRequest `json:"backup_policy,omitempty"`
 	PublicNetworking  *bool                       `json:"public_networking,omitempty"`
+	// GPUPartitionMode selects the partition mode for a GPU Droplet. Omit or
+	// leave empty for PARTITION_MODE_UNSET (full GPU). Use one of the
+	// GPUPartitionMode* constants for supported values.
+	GPUPartitionMode string `json:"gpu_partition_mode,omitempty"`
 }
 
 // DropletMultiCreateRequest is a request to create multiple Droplets.
@@ -257,6 +273,10 @@ type DropletMultiCreateRequest struct {
 	WithDropletAgent  *bool                       `json:"with_droplet_agent,omitempty"`
 	BackupPolicy      *DropletBackupPolicyRequest `json:"backup_policy,omitempty"`
 	PublicNetworking  *bool                       `json:"public_networking,omitempty"`
+	// GPUPartitionMode selects the partition mode for the GPU Droplets. Omit or
+	// leave empty for PARTITION_MODE_UNSET (full GPU). Use one of the
+	// GPUPartitionMode* constants for supported values.
+	GPUPartitionMode string `json:"gpu_partition_mode,omitempty"`
 }
 
 // DropletBackupPolicyRequest defines the backup policy when creating a Droplet.

--- a/droplets_test.go
+++ b/droplets_test.go
@@ -455,9 +455,9 @@ func TestDroplets_CreateWithGPUPartitionMode(t *testing.T) {
 	}
 }
 
-// TestDroplets_GetGPUPartitionModeAbsent covers the flipper-off / v1 read-back
-// case: when the API response omits gpu_partition_mode, godo decodes it to the
-// empty string (DROP-13726 GET read-back is out of scope for v1).
+// TestDroplets_GetGPUPartitionModeAbsent covers the v1 read-back case: when the
+// API response omits gpu_partition_mode, godo decodes it to the empty string
+// (GET read-back is out of scope for v1).
 func TestDroplets_GetGPUPartitionModeAbsent(t *testing.T) {
 	setup()
 	defer teardown()

--- a/droplets_test.go
+++ b/droplets_test.go
@@ -398,6 +398,85 @@ func TestDroplets_Create(t *testing.T) {
 	}
 }
 
+func TestDroplets_CreateWithGPUPartitionMode(t *testing.T) {
+	setup()
+	defer teardown()
+
+	createRequest := &DropletCreateRequest{
+		Name:             "name",
+		Region:           "region",
+		Size:             "gpu-mi350x1-288gb",
+		Image:            DropletCreateImage{ID: 1},
+		GPUPartitionMode: GPUPartitionModeDPXNPS2,
+	}
+
+	mux.HandleFunc("/v2/droplets", func(w http.ResponseWriter, r *http.Request) {
+		expected := map[string]interface{}{
+			"name":               "name",
+			"region":             "region",
+			"size":               "gpu-mi350x1-288gb",
+			"image":              float64(1),
+			"ssh_keys":           nil,
+			"backups":            false,
+			"ipv6":               false,
+			"private_networking": false,
+			"monitoring":         false,
+			"tags":               nil,
+			"gpu_partition_mode": "PARTITION_MODE_DPX_NPS2",
+		}
+		jsonBlob := `
+{
+  "droplet": {
+    "id": 1,
+    "gpu_partition_mode": "PARTITION_MODE_DPX_NPS2"
+  }
+}
+`
+
+		var v map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&v); err != nil {
+			t.Fatalf("decode json: %v", err)
+		}
+
+		if !reflect.DeepEqual(v, expected) {
+			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
+		}
+
+		fmt.Fprint(w, jsonBlob)
+	})
+
+	droplet, _, err := client.Droplets.Create(ctx, createRequest)
+	if err != nil {
+		t.Errorf("Droplets.Create returned error: %v", err)
+	}
+
+	if mode := droplet.GPUPartitionMode; mode != GPUPartitionModeDPXNPS2 {
+		t.Errorf("expected gpu_partition_mode '%s', received '%s'", GPUPartitionModeDPXNPS2, mode)
+	}
+}
+
+// TestDroplets_GetGPUPartitionModeAbsent covers the flipper-off / v1 read-back
+// case: when the API response omits gpu_partition_mode, godo decodes it to the
+// empty string (DROP-13726 GET read-back is out of scope for v1).
+func TestDroplets_GetGPUPartitionModeAbsent(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/droplets/12345", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{"droplet":{"id":12345,"size_slug":"gpu-mi350x8-2304gb"}}`)
+	})
+
+	droplet, _, err := client.Droplets.Get(ctx, 12345)
+	if err != nil {
+		t.Errorf("Droplet.Get returned error: %v", err)
+	}
+
+	if droplet.GPUPartitionMode != "" {
+		t.Errorf("expected empty gpu_partition_mode when absent, received %q", droplet.GPUPartitionMode)
+	}
+}
+
 func TestDroplets_CreateWithoutDropletAgent(t *testing.T) {
 	setup()
 	defer teardown()

--- a/sizes.go
+++ b/sizes.go
@@ -54,6 +54,11 @@ type GPUInfo struct {
 	Count int    `json:"count,omitempty"`
 	VRAM  *VRAM  `json:"vram,omitempty"`
 	Model string `json:"model,omitempty"`
+	// SupportedPartitionModes lists the GPU partition modes available for this
+	// size. It is populated by the regions catalog and stripped per-owner by the
+	// gpu_partition_mode_selection flipper, so an empty/absent value means the
+	// caller is not enrolled and the partition-mode picker should be hidden.
+	SupportedPartitionModes []string `json:"supported_partition_modes,omitempty"`
 }
 
 // VRAM provides information about the amount of VRAM available to the GPU.

--- a/sizes.go
+++ b/sizes.go
@@ -55,9 +55,8 @@ type GPUInfo struct {
 	VRAM  *VRAM  `json:"vram,omitempty"`
 	Model string `json:"model,omitempty"`
 	// SupportedPartitionModes lists the GPU partition modes available for this
-	// size. It is populated by the regions catalog and stripped per-owner by the
-	// gpu_partition_mode_selection flipper, so an empty/absent value means the
-	// caller is not enrolled and the partition-mode picker should be hidden.
+	// size. It is only returned to callers with access to the feature, so an
+	// empty/absent value means the partition-mode picker should be hidden.
 	SupportedPartitionModes []string `json:"supported_partition_modes,omitempty"`
 }
 

--- a/sizes_test.go
+++ b/sizes_test.go
@@ -324,10 +324,9 @@ func TestSize_String(t *testing.T) {
 	}
 }
 
-// TestSizes_SupportedPartitionModes verifies that the gpu_partition_mode_selection
-// flipper is handled in both states: when the field is present (flipper on) it is
-// decoded, and when it is absent (flipper off / not enrolled) the slice is nil so
-// callers see len == 0 ("hide the picker").
+// TestSizes_SupportedPartitionModes verifies that supported_partition_modes is
+// handled in both states: when the field is present it is decoded, and when it is
+// absent the slice is nil so callers see len == 0 ("hide the picker").
 func TestSizes_SupportedPartitionModes(t *testing.T) {
 	setup()
 	defer teardown()
@@ -367,19 +366,19 @@ func TestSizes_SupportedPartitionModes(t *testing.T) {
 		t.Fatalf("expected 2 sizes, got %d", len(sizes))
 	}
 
-	// Flipper on: field present and decoded.
+	// Field present and decoded.
 	on := sizes[0]
 	wantModes := []string{GPUPartitionModeSPXNPS1, GPUPartitionModeDPXNPS2}
 	if !reflect.DeepEqual(on.GPUInfo.SupportedPartitionModes, wantModes) {
-		t.Errorf("flipper-on size: SupportedPartitionModes = %v, want %v", on.GPUInfo.SupportedPartitionModes, wantModes)
+		t.Errorf("size with modes: SupportedPartitionModes = %v, want %v", on.GPUInfo.SupportedPartitionModes, wantModes)
 	}
 
-	// Flipper off / not enrolled: field absent -> nil slice, len 0.
+	// Field absent -> nil slice, len 0.
 	off := sizes[1]
 	if off.GPUInfo.SupportedPartitionModes != nil {
-		t.Errorf("flipper-off size: SupportedPartitionModes = %v, want nil", off.GPUInfo.SupportedPartitionModes)
+		t.Errorf("size without modes: SupportedPartitionModes = %v, want nil", off.GPUInfo.SupportedPartitionModes)
 	}
 	if len(off.GPUInfo.SupportedPartitionModes) != 0 {
-		t.Errorf("flipper-off size: len(SupportedPartitionModes) = %d, want 0", len(off.GPUInfo.SupportedPartitionModes))
+		t.Errorf("size without modes: len(SupportedPartitionModes) = %d, want 0", len(off.GPUInfo.SupportedPartitionModes))
 	}
 }

--- a/sizes_test.go
+++ b/sizes_test.go
@@ -90,6 +90,30 @@ func TestSizes_List(t *testing.T) {
 				},
 			},
 		},
+		{
+			Slug:         "gpu-mi350x1-288gb",
+			Memory:       1966080,
+			Vcpus:        160,
+			Disk:         200,
+			PriceMonthly: 35414.4,
+			PriceHourly:  52.7,
+			Regions:      []string{"tor1"},
+			Available:    true,
+			Transfer:     60,
+			Description:  "AMD MI350X GPU - 1X",
+			GPUInfo: &GPUInfo{
+				Count: 1,
+				VRAM: &VRAM{
+					Amount: 288,
+					Unit:   "gib",
+				},
+				Model: "amd_mi350x",
+				SupportedPartitionModes: []string{
+					GPUPartitionModeSPXNPS1,
+					GPUPartitionModeDPXNPS2,
+				},
+			},
+		},
 	}
 
 	mux.HandleFunc("/v2/sizes", func(w http.ResponseWriter, r *http.Request) {
@@ -182,10 +206,36 @@ func TestSizes_List(t *testing.T) {
 							}
 						}
 					]
+				},
+				{
+					"slug": "gpu-mi350x1-288gb",
+					"memory": 1966080,
+					"vcpus": 160,
+					"disk": 200,
+					"transfer": 60,
+					"price_monthly": 35414.4,
+					"price_hourly": 52.7,
+					"regions": [
+						"tor1"
+					],
+					"available": true,
+					"description": "AMD MI350X GPU - 1X",
+					"gpu_info": {
+						"count": 1,
+						"vram": {
+							"amount": 288,
+							"unit": "gib"
+						},
+						"model": "amd_mi350x",
+						"supported_partition_modes": [
+							"PARTITION_MODE_SPX_NPS1",
+							"PARTITION_MODE_DPX_NPS2"
+						]
+					}
 				}
 			],
 			"meta": {
-				"total": 3
+				"total": 4
 			}
 		}`)
 	})
@@ -199,7 +249,7 @@ func TestSizes_List(t *testing.T) {
 		t.Errorf("Sizes.List returned sizes %+v, expected %+v", sizes, expectedSizes)
 	}
 
-	expectedMeta := &Meta{Total: 3}
+	expectedMeta := &Meta{Total: 4}
 	if !reflect.DeepEqual(resp.Meta, expectedMeta) {
 		t.Errorf("Sizes.List returned meta %+v, expected %+v", resp.Meta, expectedMeta)
 	}
@@ -271,5 +321,65 @@ func TestSize_String(t *testing.T) {
 	expected := `godo.Size{Slug:"slize", Memory:123, Vcpus:456, Disk:789, PriceMonthly:123, PriceHourly:456, Regions:["1" "2"], Available:true, Transfer:789, Description:"Basic"}`
 	if expected != stringified {
 		t.Errorf("Size.String returned %+v, expected %+v", stringified, expected)
+	}
+}
+
+// TestSizes_SupportedPartitionModes verifies that the gpu_partition_mode_selection
+// flipper is handled in both states: when the field is present (flipper on) it is
+// decoded, and when it is absent (flipper off / not enrolled) the slice is nil so
+// callers see len == 0 ("hide the picker").
+func TestSizes_SupportedPartitionModes(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/sizes", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{
+			"sizes": [
+				{
+					"slug": "gpu-mi350x8-2304gb",
+					"gpu_info": {
+						"count": 8,
+						"model": "amd_mi350x",
+						"supported_partition_modes": [
+							"PARTITION_MODE_SPX_NPS1",
+							"PARTITION_MODE_DPX_NPS2"
+						]
+					}
+				},
+				{
+					"slug": "gpu-mi350x1-288gb",
+					"gpu_info": {
+						"count": 1,
+						"model": "amd_mi350x"
+					}
+				}
+			],
+			"meta": { "total": 2 }
+		}`)
+	})
+
+	sizes, _, err := client.Sizes.List(ctx, nil)
+	if err != nil {
+		t.Fatalf("Sizes.List returned error: %v", err)
+	}
+	if len(sizes) != 2 {
+		t.Fatalf("expected 2 sizes, got %d", len(sizes))
+	}
+
+	// Flipper on: field present and decoded.
+	on := sizes[0]
+	wantModes := []string{GPUPartitionModeSPXNPS1, GPUPartitionModeDPXNPS2}
+	if !reflect.DeepEqual(on.GPUInfo.SupportedPartitionModes, wantModes) {
+		t.Errorf("flipper-on size: SupportedPartitionModes = %v, want %v", on.GPUInfo.SupportedPartitionModes, wantModes)
+	}
+
+	// Flipper off / not enrolled: field absent -> nil slice, len 0.
+	off := sizes[1]
+	if off.GPUInfo.SupportedPartitionModes != nil {
+		t.Errorf("flipper-off size: SupportedPartitionModes = %v, want nil", off.GPUInfo.SupportedPartitionModes)
+	}
+	if len(off.GPUInfo.SupportedPartitionModes) != 0 {
+		t.Errorf("flipper-off size: len(SupportedPartitionModes) = %d, want 0", len(off.GPUInfo.SupportedPartitionModes))
 	}
 }


### PR DESCRIPTION
## Background

DigitalOcean is adding **AMD GPU partition mode** support. A GPU Droplet can be created either as a full GPU or split into partitions. v1 scope is the AMD **MI350X** with two modes: `PARTITION_MODE_SPX_NPS1` (the default / full GPU) and `PARTITION_MODE_DPX_NPS2`.

The backend (public API + regions catalog) is already deployed. This PR is the godo (Go SDK) counterpart so API/UI/CLI consumers can discover supported modes and create Droplets with a mode.

### Why these fields are optional

The supported-modes list is only returned to callers who have access to the feature. From the SDK's perspective there is **no gating logic to implement** — the field is simply *present* for callers with access and *absent* for everyone else. The correct SDK behavior is therefore to model these as optional fields so "absent" round-trips to a zero value cleanly. That is why the field types below use `omitempty` + `nil`/`""` semantics rather than a required field or a custom unmarshaler.

## What changed

**`sizes.go` — discovery**
- `GPUInfo.SupportedPartitionModes []string` (`json:"supported_partition_modes,omitempty"`).
- Populated on `GET /v2/sizes` (and `options_for_create`) when the caller has access; **absent → decodes to `nil`**. Consumers should treat `len(...) == 0` as "hide the picker".

**`droplets.go` — create request + response echo**
- `DropletCreateRequest.GPUPartitionMode` and `DropletMultiCreateRequest.GPUPartitionMode` (`json:"gpu_partition_mode,omitempty"`). Optional: omit / empty → server treats it as `PARTITION_MODE_UNSET` (full GPU). No client-side validation — the server 422s invalid combinations (unknown enum, non-GPU size, mode not in the size's supported list).
- `Droplet.GPUPartitionMode` — the value echoed back on the **create** response.
- `GPUPartitionModeSPXNPS1` / `GPUPartitionModeDPXNPS2` string constants for the v1 values, so callers don't hardcode enum strings.

### v1 scope caveat (reviewers please note)
Read-back of `gpu_partition_mode` on **`GET /v2/droplets/{id}`** is **not** delivered in v1 ("Out of scope"). So `Droplet.GPUPartitionMode` is only reliably populated on the create response; on GET it decodes to `""` today. The field is added now so it's forward-compatible when read-back lands. A code comment calls this out.

## Test plan
- [x] `go test ./` passes, including new coverage for both states:
  - `TestSizes_SupportedPartitionModes` — one size with the field (present → decoded slice) and one without (absent → `nil`).
  - `TestSizes_List` (updated) — adds an MI350X size carrying both modes.
  - `TestDroplets_CreateWithGPUPartitionMode` — asserts the request body serializes `gpu_partition_mode` and the create-response echo decodes.
  - `TestDroplets_GetGPUPartitionModeAbsent` — the v1 no-read-back case decodes to `""`.
- [x] **Manually verified against prod** `GET /v2/sizes`:
  - Without access: MI350X sizes absent; no `supported_partition_modes` on any size; godo decoded to `nil`.
  - With access: `gpu-mi350x8-2304gb` returned `["PARTITION_MODE_DPX_NPS2","PARTITION_MODE_SPX_NPS1"]` on the wire and godo decoded it identically.
