### PR TITLE
added support for ADVANCED MySQL config patch and get operations

### DIFF
--- a/databases.go
+++ b/databases.go
@@ -171,6 +171,7 @@ type DatabasesService interface {
 	GetOpensearchConfig(context.Context, string) (*OpensearchConfig, *Response, error)
 	GetKafkaConfig(context.Context, string) (*KafkaConfig, *Response, error)
 	GetAdvancedPostgresSQLConfig(context.Context, string) (*AdvancedPostgresConfig, *Response, error)
+	GetAdvancedMySQLConfig(context.Context, string) (*AdvancedMySQLConfig, *Response, error)
 	UpdatePostgreSQLConfig(context.Context, string, *PostgreSQLConfig) (*Response, error)
 	UpdateRedisConfig(context.Context, string, *RedisConfig) (*Response, error)
 	UpdateValkeyConfig(context.Context, string, *ValkeyConfig) (*Response, error)
@@ -179,6 +180,7 @@ type DatabasesService interface {
 	UpdateOpensearchConfig(context.Context, string, *OpensearchConfig) (*Response, error)
 	UpdateKafkaConfig(context.Context, string, *KafkaConfig) (*Response, error)
 	UpdateAdvancedPostgresSQLConfig(context.Context, string, *AdvancedPostgresConfigUpdate) (*Response, error)
+	UpdateAdvancedMySQLConfig(context.Context, string, *AdvancedMySQLConfigUpdate) (*Response, error)
 	ListOptions(todo context.Context) (*DatabaseOptions, *Response, error)
 	UpgradeMajorVersion(context.Context, string, *UpgradeVersionRequest) (*Response, error)
 	ListTopics(context.Context, string, *ListOptions) ([]DatabaseTopic, *Response, error)
@@ -760,6 +762,25 @@ type AdvancedPostgresConfigUpdate struct {
 	PGParameters map[string]string `json:"pg_parameters,omitempty"`
 }
 
+// AdvancedMySQLParameter is one system variable returned by GET /config for advanced_mysql clusters.
+type AdvancedMySQLParameter struct {
+	Name            string `json:"name,omitempty"`
+	Value           string `json:"value,omitempty"`
+	Description     string `json:"description,omitempty"`
+	RequiresRestart bool   `json:"requires_restart,omitempty"`
+	DefaultValue    string `json:"default_value,omitempty"`
+}
+
+// AdvancedMySQLConfig holds advanced configurations for advanced_mysql database clusters.
+type AdvancedMySQLConfig struct {
+	MySQLParameters []AdvancedMySQLParameter `json:"mysql_parameters,omitempty"`
+}
+
+// AdvancedMySQLConfigUpdate is the PATCH payload for advanced_mysql database clusters.
+type AdvancedMySQLConfigUpdate struct {
+	MySQLParameters map[string]string `json:"mysql_parameters,omitempty"`
+}
+
 // PostgreSQLBouncerConfig configuration
 type PostgreSQLBouncerConfig struct {
 	ServerResetQueryAlways  *bool     `json:"server_reset_query_always,omitempty"`
@@ -982,6 +1003,14 @@ type databaseAdvancedPostgresConfigRoot struct {
 
 type databaseAdvancedPostgresConfigUpdateRoot struct {
 	Config *AdvancedPostgresConfigUpdate `json:"config"`
+}
+
+type databaseAdvancedMySQLConfigRoot struct {
+	Config *AdvancedMySQLConfig `json:"config"`
+}
+
+type databaseAdvancedMySQLConfigUpdateRoot struct {
+	Config *AdvancedMySQLConfigUpdate `json:"config"`
 }
 
 type databaseBackupsRoot struct {
@@ -2004,6 +2033,38 @@ func (svc *DatabasesServiceOp) GetAdvancedPostgresSQLConfig(ctx context.Context,
 func (svc *DatabasesServiceOp) UpdateAdvancedPostgresSQLConfig(ctx context.Context, databaseID string, config *AdvancedPostgresConfigUpdate) (*Response, error) {
 	path := fmt.Sprintf(databaseConfigPath, databaseID)
 	root := &databaseAdvancedPostgresConfigUpdateRoot{
+		Config: config,
+	}
+	req, err := svc.client.NewRequest(ctx, http.MethodPatch, path, root)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := svc.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}
+
+// GetAdvancedMySQLConfig retrieves the config for an advanced_mysql database cluster.
+func (svc *DatabasesServiceOp) GetAdvancedMySQLConfig(ctx context.Context, databaseID string) (*AdvancedMySQLConfig, *Response, error) {
+	path := fmt.Sprintf(databaseConfigPath, databaseID)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(databaseAdvancedMySQLConfigRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Config, resp, nil
+}
+
+// UpdateAdvancedMySQLConfig updates the config for an advanced_mysql database cluster.
+func (svc *DatabasesServiceOp) UpdateAdvancedMySQLConfig(ctx context.Context, databaseID string, config *AdvancedMySQLConfigUpdate) (*Response, error) {
+	path := fmt.Sprintf(databaseConfigPath, databaseID)
+	root := &databaseAdvancedMySQLConfigUpdateRoot{
 		Config: config,
 	}
 	req, err := svc.client.NewRequest(ctx, http.MethodPatch, path, root)

--- a/databases_test.go
+++ b/databases_test.go
@@ -3271,6 +3271,84 @@ func TestDatabases_UpdateConfigAdvancedPostgres(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestDatabases_GetConfigAdvancedMySQL(t *testing.T) {
+	setup()
+	defer teardown()
+
+	var (
+		dbSvc = client.Databases
+		dbID  = "da4e0206-d019-41d7-b51f-deadbeefbb8f"
+		path  = fmt.Sprintf("/v2/databases/%s/config", dbID)
+
+		advancedMySQLConfigJSON = `{
+  "config": {
+    "mysql_parameters": [
+      {
+        "name": "max_connections",
+        "value": "200",
+        "description": "The maximum permitted number of simultaneous client connections.",
+        "requires_restart": true,
+        "default_value": "151"
+      }
+    ]
+  }
+}`
+
+		advancedMySQLConfig = AdvancedMySQLConfig{
+			MySQLParameters: []AdvancedMySQLParameter{
+				{
+					Name:            "max_connections",
+					Value:           "200",
+					Description:     "The maximum permitted number of simultaneous client connections.",
+					RequiresRestart: true,
+					DefaultValue:    "151",
+				},
+			},
+		}
+	)
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, advancedMySQLConfigJSON)
+	})
+
+	got, _, err := dbSvc.GetAdvancedMySQLConfig(ctx, dbID)
+	require.NoError(t, err)
+	require.Equal(t, &advancedMySQLConfig, got)
+}
+
+func TestDatabases_UpdateConfigAdvancedMySQL(t *testing.T) {
+	setup()
+	defer teardown()
+
+	var (
+		dbID = "deadbeef-dead-4aa5-beef-deadbeef347d"
+		path = fmt.Sprintf("/v2/databases/%s/config", dbID)
+
+		advancedMySQLConfig = &AdvancedMySQLConfigUpdate{
+			MySQLParameters: map[string]string{
+				"max_connections": "200",
+			},
+		}
+	)
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+
+		var b databaseAdvancedMySQLConfigUpdateRoot
+		decoder := json.NewDecoder(r.Body)
+		err := decoder.Decode(&b)
+		require.NoError(t, err)
+
+		assert.Equal(t, b.Config, advancedMySQLConfig)
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	_, err := client.Databases.UpdateAdvancedMySQLConfig(ctx, dbID, advancedMySQLConfig)
+	require.NoError(t, err)
+}
+
 func TestDatabases_GetConfigRedis(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
The aim of this PR is to add support for configuration get and update calls to ADVANCED_MYSQL engine type

the code is tested using the example below


```
package main

import (
	"context"
	"fmt"
	"os"

	"github.com/digitalocean/godo"
)

func main() {
	token := os.Getenv("DIGITALOCEAN_TOKEN")
	if token == "" {
		fmt.Fprintln(os.Stderr, "DIGITALOCEAN_TOKEN environment variable is required")
		os.Exit(1)
	}

	databaseID := os.Getenv("DATABASE_ID")
	if databaseID == "" {
		fmt.Fprintln(os.Stderr, "DATABASE_ID environment variable is required")
		os.Exit(1)
	}

	client := godo.NewFromToken(token)
	ctx := context.Background()

	// Get current advanced MySQL configuration
	fmt.Printf("Getting advanced MySQL config for database %s...\n", databaseID)
	config, _, err := client.Databases.GetAdvancedMySQLConfig(ctx, databaseID)
	if err != nil {
		fmt.Fprintf(os.Stderr, "Error getting advanced MySQL config: %v\n", err)
		os.Exit(1)
	}

	fmt.Printf("Current config (%d parameters):\n", len(config.MySQLParameters))
	for _, param := range config.MySQLParameters {
		fmt.Printf("  %s = %s (default: %s, requires_restart: %v)\n",
			param.Name, param.Value, param.DefaultValue, param.RequiresRestart)
		if param.Description != "" {
			fmt.Printf("    %s\n", param.Description)
		}
	}

	// Update advanced MySQL configuration
	update := &godo.AdvancedMySQLConfigUpdate{
		MySQLParameters: map[string]string{
			"max_connections": "700",
		},
	}

	fmt.Printf("\nUpdating advanced MySQL config for database %s...\n", databaseID)
	resp, err := client.Databases.UpdateAdvancedMySQLConfig(ctx, databaseID, update)
	if err != nil {
		fmt.Fprintf(os.Stderr, "Error updating advanced MySQL config: %v\n", err)
		if resp != nil {
			fmt.Fprintf(os.Stderr, "HTTP Status: %s\n", resp.Status)
		}
		os.Exit(1)
	}

	fmt.Printf("Update successful! HTTP Status: %s\n", resp.Status)

	// Verify by getting the config again
	fmt.Printf("\nVerifying updated config...\n")
	updated, _, err := client.Databases.GetAdvancedMySQLConfig(ctx, databaseID)
	if err != nil {
		fmt.Fprintf(os.Stderr, "Error verifying advanced MySQL config: %v\n", err)
		os.Exit(1)
	}

	fmt.Printf("Updated config (%d parameters):\n", len(updated.MySQLParameters))
	for _, param := range updated.MySQLParameters {
		fmt.Printf("  %s = %s (default: %s, requires_restart: %v)\n",
			param.Name, param.Value, param.DefaultValue, param.RequiresRestart)
	}
}
```
