### PR TITLE
MARSOHS-551: Session.origin on HostedAgents (stack on OHS_endpoints)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [Unreleased]
+
+- Add HostedAgents `Session.origin` product provenance (`direct`|`simulation`|`evaluation`); document ListSessions server-side sim/eval omission (MARSOHS-551, stacks on #1021)
+
 ## [1.201.0] - 2026-07-24
 
 - #1060 - @DO-rrao - Add GPU partition mode support to Droplets and Sizes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Change Log
 
-## [Unreleased]
-
-- Add HostedAgents `Session.origin` product provenance (`direct`|`simulation`|`evaluation`); document ListSessions server-side sim/eval omission (MARSOHS-551, stacks on #1021)
-
 ## [1.201.0] - 2026-07-24
 
 - #1060 - @DO-rrao - Add GPU partition mode support to Droplets and Sizes

--- a/hosted_agents.go
+++ b/hosted_agents.go
@@ -208,6 +208,34 @@ const (
 	HostedAgentEventKindRunLog               HostedAgentEventKind = "run.log"
 )
 
+// HostedAgentSessionOriginProduct identifies the product workflow that created
+// a session. Wire values match harness SessionOrigin.product.
+type HostedAgentSessionOriginProduct string
+
+const (
+	HostedAgentSessionOriginProductDirect     HostedAgentSessionOriginProduct = "direct"
+	HostedAgentSessionOriginProductSimulation HostedAgentSessionOriginProduct = "simulation"
+	HostedAgentSessionOriginProductEvaluation HostedAgentSessionOriginProduct = "evaluation"
+)
+
+// HostedAgentSessionOriginRequest is the product-provenance claim on create.
+// Omission creates a verified direct session. Simulation and evaluation require
+// resource_id; direct forbids it. verified is server-assigned and must not be
+// sent on create (see HostedAgentSessionOrigin).
+type HostedAgentSessionOriginRequest struct {
+	Product    HostedAgentSessionOriginProduct `json:"product"`
+	ResourceID string                          `json:"resource_id,omitempty"`
+}
+
+// HostedAgentSessionOrigin is server-returned product-workflow provenance.
+// Verified is true for direct sessions and for product claims established
+// through a trusted adapter.
+type HostedAgentSessionOrigin struct {
+	Product    HostedAgentSessionOriginProduct `json:"product"`
+	ResourceID string                          `json:"resource_id,omitempty"`
+	Verified   bool                            `json:"verified"`
+}
+
 // HostedAgentSession is a provisioned hosted-agent sandbox session.
 type HostedAgentSession struct {
 	SessionID    string                                  `json:"session_id"`
@@ -219,6 +247,9 @@ type HostedAgentSession struct {
 	LastEventAt  Timestamp                               `json:"last_event_at"`
 	RepoHint     string                                  `json:"repo_hint,omitempty"`
 	ProviderAuth map[string]HostedAgentProviderAuthState `json:"provider_auth,omitempty"`
+	// Origin is present for newly created sessions (including direct). Older
+	// sessions may omit it.
+	Origin *HostedAgentSessionOrigin `json:"origin,omitempty"`
 }
 
 // HostedAgentRun represents a single execution within a session.
@@ -310,6 +341,9 @@ type HostedAgentSessionCreateRequest struct {
 	AgentKind          HostedAgentKind `json:"agent_kind"`
 	RepoHint           string          `json:"repo_hint,omitempty"`
 	IdleTimeoutSeconds int64           `json:"idle_timeout_seconds,omitempty"`
+	// Origin claims product-workflow provenance. Omit for a verified direct
+	// session. Simulation/evaluation require resource_id.
+	Origin *HostedAgentSessionOriginRequest `json:"origin,omitempty"`
 }
 
 // HostedAgentSessionListOptions specifies optional list filters.
@@ -548,6 +582,10 @@ func (s *HostedAgentsServiceOp) newCreateSessionPostRequest(ctx context.Context,
 }
 
 // ListSessions returns sessions visible to the caller's team.
+//
+// The server omits simulation and evaluation sessions from the list so customer
+// surfaces stay free of product-owned internal runs. GetSession by session_id
+// still returns those sessions for the owning product workflow.
 func (s *HostedAgentsServiceOp) ListSessions(ctx context.Context, opt *HostedAgentSessionListOptions) (*HostedAgentSessionsListResponse, *Response, error) {
 	path, err := addOptions(hostedAgentsSessionsBasePath, opt)
 	if err != nil {

--- a/hosted_agents_test.go
+++ b/hosted_agents_test.go
@@ -68,6 +68,150 @@ func TestHostedAgents_CreateSession(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
+func TestHostedAgents_CreateSession_WithOrigin(t *testing.T) {
+	setup()
+	defer teardown()
+
+	wantCreate := &HostedAgentSessionCreateRequest{
+		AgentKind: HostedAgentKindClaudeCode,
+		RepoHint:  "github.com/digitalocean/example",
+		Origin: &HostedAgentSessionOriginRequest{
+			Product:    HostedAgentSessionOriginProductSimulation,
+			ResourceID: "sim-run-123",
+		},
+	}
+
+	mux.HandleFunc("/v2/agents/sessions", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		var got HostedAgentSessionCreateRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		assert.Equal(t, wantCreate.AgentKind, got.AgentKind)
+		assert.Equal(t, wantCreate.RepoHint, got.RepoHint)
+		require.NotNil(t, got.Origin)
+		assert.Equal(t, HostedAgentSessionOriginProductSimulation, got.Origin.Product)
+		assert.Equal(t, "sim-run-123", got.Origin.ResourceID)
+
+		// Request wire must not include verified.
+		raw, err := json.Marshal(got.Origin)
+		require.NoError(t, err)
+		assert.NotContains(t, string(raw), "verified")
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"session": {
+				"session_id": "sess-1",
+				"name": "session-claude-code-2026-07-27",
+				"team_id": 42,
+				"agent_kind": "AGENT_KIND_CLAUDE_CODE",
+				"status": "SESSION_STATUS_PROVISIONING",
+				"created_at": "2026-07-27T12:00:00Z",
+				"last_event_at": "2026-07-27T12:00:00Z",
+				"repo_hint": "github.com/digitalocean/example",
+				"origin": {
+					"product": "simulation",
+					"resource_id": "sim-run-123",
+					"verified": true
+				}
+			}
+		}`)
+	})
+
+	session, _, err := client.HostedAgents.CreateSession(ctx, wantCreate)
+	require.NoError(t, err)
+	require.NotNil(t, session.Origin)
+	assert.Equal(t, HostedAgentSessionOriginProductSimulation, session.Origin.Product)
+	assert.Equal(t, "sim-run-123", session.Origin.ResourceID)
+	assert.True(t, session.Origin.Verified)
+}
+
+func TestHostedAgents_CreateSession_DirectOmitsOrigin(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/agents/sessions", func(w http.ResponseWriter, r *http.Request) {
+		var raw map[string]json.RawMessage
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&raw))
+		_, hasOrigin := raw["origin"]
+		assert.False(t, hasOrigin, "omitted Origin should not appear in JSON body")
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"session": {
+				"session_id": "sess-direct",
+				"team_id": 7,
+				"agent_kind": "AGENT_KIND_OPENCODE",
+				"status": "SESSION_STATUS_READY",
+				"created_at": "2026-07-27T12:00:00Z",
+				"last_event_at": "2026-07-27T12:00:00Z",
+				"origin": {
+					"product": "direct",
+					"verified": true
+				}
+			}
+		}`)
+	})
+
+	session, _, err := client.HostedAgents.CreateSession(ctx, &HostedAgentSessionCreateRequest{
+		AgentKind: HostedAgentKindOpenCode,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, session.Origin)
+	assert.Equal(t, HostedAgentSessionOriginProductDirect, session.Origin.Product)
+	assert.Empty(t, session.Origin.ResourceID)
+	assert.True(t, session.Origin.Verified)
+}
+
+func TestHostedAgents_GetSession_WithOrigin(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/agents/sessions/sess-eval", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"session": {
+				"session_id": "sess-eval",
+				"team_id": 9,
+				"agent_kind": "AGENT_KIND_CODEX_CLI",
+				"status": "SESSION_STATUS_READY",
+				"created_at": "2026-07-27T12:00:00Z",
+				"last_event_at": "2026-07-27T12:05:00Z",
+				"origin": {
+					"product": "evaluation",
+					"resource_id": "eval-456",
+					"verified": true
+				}
+			}
+		}`)
+	})
+
+	session, _, err := client.HostedAgents.GetSession(ctx, "sess-eval")
+	require.NoError(t, err)
+	require.NotNil(t, session.Origin)
+	assert.Equal(t, HostedAgentSessionOriginProductEvaluation, session.Origin.Product)
+	assert.Equal(t, "eval-456", session.Origin.ResourceID)
+	assert.True(t, session.Origin.Verified)
+}
+
+func TestHostedAgentSessionOriginRequest_JSONOmitsVerified(t *testing.T) {
+	body, err := json.Marshal(&HostedAgentSessionOriginRequest{
+		Product:    HostedAgentSessionOriginProductEvaluation,
+		ResourceID: "eval-1",
+	})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"product":"evaluation","resource_id":"eval-1"}`, string(body))
+}
+
+func TestHostedAgentSessionOrigin_JSONIncludesVerified(t *testing.T) {
+	body, err := json.Marshal(&HostedAgentSessionOrigin{
+		Product:  HostedAgentSessionOriginProductDirect,
+		Verified: true,
+	})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"product":"direct","verified":true}`, string(body))
+}
+
 func TestHostedAgents_CreateSessionFromManifest(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
## Summary
- Add `Session.origin` / create-request origin (`direct`|`simulation`|`evaluation`) to the HostedAgents client on **`OHS_endpoints`**.
- Document that `ListSessions` omits simulation/evaluation server-side (clients mirror; no client-side filter).
- Stacks on [#1021](https://github.com/digitalocean/godo/pull/1021); supersedes [#1066](https://github.com/digitalocean/godo/pull/1066) (which incorrectly targeted `main` as a standalone HostedAgents dump).

## Test plan
- [x] `go test -count=1 -run 'HostedAgents|HostedAgentSessionOrigin' .`
- [ ] CI green


Made with [Cursor](https://cursor.com)