### PR TITLE
Add Kubernetes AMD/NVIDIA DRA plugins and GPU partition mode

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -347,13 +347,13 @@ type KubernetesNvidiaGpuDevicePlugin struct {
 }
 
 // KubernetesNvidiaGpuDraDriver represents information about the NVIDIA GPU DRA Driver cluster plugin.
-// Mutually exclusive with the NVIDIA GPU Device Plugin. Create-only to enable.
+// Mutually exclusive with the NVIDIA GPU Device Plugin.
 type KubernetesNvidiaGpuDraDriver struct {
 	Enabled *bool `json:"enabled"`
 }
 
 // KubernetesAmdGpuDraDriver represents information about the AMD GPU DRA Driver cluster plugin.
-// Mutually exclusive with the AMD GPU Device Plugin. Create-only to enable.
+// Mutually exclusive with the AMD GPU Device Plugin.
 type KubernetesAmdGpuDraDriver struct {
 	Enabled *bool `json:"enabled"`
 }

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -92,6 +92,8 @@ type KubernetesClusterCreateRequest struct {
 	AmdGpuDevicePlugin                *KubernetesAmdGpuDevicePlugin                `json:"amd_gpu_device_plugin,omitempty"`
 	AmdGpuDeviceMetricsExporterPlugin *KubernetesAmdGpuDeviceMetricsExporterPlugin `json:"amd_gpu_device_metrics_exporter_plugin,omitempty"`
 	NvidiaGpuDevicePlugin             *KubernetesNvidiaGpuDevicePlugin             `json:"nvidia_gpu_device_plugin,omitempty"`
+	NvidiaGpuDraDriver                *KubernetesNvidiaGpuDraDriver                `json:"nvidia_gpu_dra_driver,omitempty"`
+	AmdGpuDraDriver                   *KubernetesAmdGpuDraDriver                   `json:"amd_gpu_dra_driver,omitempty"`
 	RdmaSharedDevicePlugin            *KubernetesRdmaSharedDevicePlugin            `json:"rdma_shared_dev_plugin,omitempty"`
 	CorednsAutoscaler                 *KubernetesCorednsAutoscaler                 `json:"coredns_autoscaler,omitempty"`
 	SSO                               *KubernetesClusterSSO                        `json:"sso,omitempty"`
@@ -111,6 +113,8 @@ type KubernetesClusterUpdateRequest struct {
 	AmdGpuDevicePlugin                *KubernetesAmdGpuDevicePlugin                `json:"amd_gpu_device_plugin,omitempty"`
 	AmdGpuDeviceMetricsExporterPlugin *KubernetesAmdGpuDeviceMetricsExporterPlugin `json:"amd_gpu_device_metrics_exporter_plugin,omitempty"`
 	NvidiaGpuDevicePlugin             *KubernetesNvidiaGpuDevicePlugin             `json:"nvidia_gpu_device_plugin,omitempty"`
+	NvidiaGpuDraDriver                *KubernetesNvidiaGpuDraDriver                `json:"nvidia_gpu_dra_driver,omitempty"`
+	AmdGpuDraDriver                   *KubernetesAmdGpuDraDriver                   `json:"amd_gpu_dra_driver,omitempty"`
 	RdmaSharedDevicePlugin            *KubernetesRdmaSharedDevicePlugin            `json:"rdma_shared_dev_plugin,omitempty"`
 	CorednsAutoscaler                 *KubernetesCorednsAutoscaler                 `json:"coredns_autoscaler,omitempty"`
 	SSO                               *KubernetesClusterSSO                        `json:"sso,omitempty"`
@@ -147,18 +151,26 @@ func (t Taint) String() string {
 	return fmt.Sprintf("%s=%s:%s", t.Key, t.Value, t.Effect)
 }
 
+// Kubernetes GPU partition modes for AMD GPU node pools. Omitting the value
+// (or sending an empty string) leaves the pool unpartitioned.
+const (
+	KubernetesAMDPartitionModeSPXNPS1 = "AMD_PARTITION_MODE_SPX_NPS1"
+	KubernetesAMDPartitionModeDPXNPS2 = "AMD_PARTITION_MODE_DPX_NPS2"
+)
+
 // KubernetesNodePoolCreateRequest represents a request to create a node pool for a
 // Kubernetes cluster.
 type KubernetesNodePoolCreateRequest struct {
-	Name      string            `json:"name,omitempty"`
-	Size      string            `json:"size,omitempty"`
-	Count     int               `json:"count,omitempty"`
-	Tags      []string          `json:"tags,omitempty"`
-	Labels    map[string]string `json:"labels,omitempty"`
-	Taints    []Taint           `json:"taints,omitempty"`
-	AutoScale bool              `json:"auto_scale,omitempty"`
-	MinNodes  int               `json:"min_nodes,omitempty"`
-	MaxNodes  int               `json:"max_nodes,omitempty"`
+	Name             string            `json:"name,omitempty"`
+	Size             string            `json:"size,omitempty"`
+	Count            int               `json:"count,omitempty"`
+	Tags             []string          `json:"tags,omitempty"`
+	Labels           map[string]string `json:"labels,omitempty"`
+	Taints           []Taint           `json:"taints,omitempty"`
+	AutoScale        bool              `json:"auto_scale,omitempty"`
+	MinNodes         int               `json:"min_nodes,omitempty"`
+	MaxNodes         int               `json:"max_nodes,omitempty"`
+	GPUPartitionMode string            `json:"gpu_partition_mode,omitempty"`
 }
 
 // KubernetesNodePoolUpdateRequest represents a request to update a node pool in a
@@ -257,6 +269,8 @@ type KubernetesCluster struct {
 	AmdGpuDevicePlugin                *KubernetesAmdGpuDevicePlugin                `json:"amd_gpu_device_plugin,omitempty"`
 	AmdGpuDeviceMetricsExporterPlugin *KubernetesAmdGpuDeviceMetricsExporterPlugin `json:"amd_gpu_device_metrics_exporter_plugin,omitempty"`
 	NvidiaGpuDevicePlugin             *KubernetesNvidiaGpuDevicePlugin             `json:"nvidia_gpu_device_plugin,omitempty"`
+	NvidiaGpuDraDriver                *KubernetesNvidiaGpuDraDriver                `json:"nvidia_gpu_dra_driver,omitempty"`
+	AmdGpuDraDriver                   *KubernetesAmdGpuDraDriver                   `json:"amd_gpu_dra_driver,omitempty"`
 	RdmaSharedDevicePlugin            *KubernetesRdmaSharedDevicePlugin            `json:"rdma_shared_dev_plugin,omitempty"`
 	CorednsAutoscaler                 *KubernetesCorednsAutoscaler                 `json:"coredns_autoscaler,omitempty"`
 	SSO                               *KubernetesClusterSSO                        `json:"sso,omitempty"`
@@ -329,6 +343,18 @@ type KubernetesAmdGpuDeviceMetricsExporterPlugin struct {
 // KubernetesNvidiaGpuDevicePlugin represents information about the NVIDIA GPU Device Plugin cluster plugin.
 // If a cluster has a node pool with an NVIDIA GPU it will be enabled by default.
 type KubernetesNvidiaGpuDevicePlugin struct {
+	Enabled *bool `json:"enabled"`
+}
+
+// KubernetesNvidiaGpuDraDriver represents information about the NVIDIA GPU DRA Driver cluster plugin.
+// Mutually exclusive with the NVIDIA GPU Device Plugin. Create-only to enable.
+type KubernetesNvidiaGpuDraDriver struct {
+	Enabled *bool `json:"enabled"`
+}
+
+// KubernetesAmdGpuDraDriver represents information about the AMD GPU DRA Driver cluster plugin.
+// Mutually exclusive with the AMD GPU Device Plugin. Create-only to enable.
+type KubernetesAmdGpuDraDriver struct {
 	Enabled *bool `json:"enabled"`
 }
 
@@ -507,16 +533,17 @@ type KubernetesClusterStatus struct {
 
 // KubernetesNodePool represents a node pool in a Kubernetes cluster.
 type KubernetesNodePool struct {
-	ID        string            `json:"id,omitempty"`
-	Name      string            `json:"name,omitempty"`
-	Size      string            `json:"size,omitempty"`
-	Count     int               `json:"count,omitempty"`
-	Tags      []string          `json:"tags,omitempty"`
-	Labels    map[string]string `json:"labels,omitempty"`
-	Taints    []Taint           `json:"taints,omitempty"`
-	AutoScale bool              `json:"auto_scale,omitempty"`
-	MinNodes  int               `json:"min_nodes,omitempty"`
-	MaxNodes  int               `json:"max_nodes,omitempty"`
+	ID               string            `json:"id,omitempty"`
+	Name             string            `json:"name,omitempty"`
+	Size             string            `json:"size,omitempty"`
+	Count            int               `json:"count,omitempty"`
+	Tags             []string          `json:"tags,omitempty"`
+	Labels           map[string]string `json:"labels,omitempty"`
+	Taints           []Taint           `json:"taints,omitempty"`
+	AutoScale        bool              `json:"auto_scale,omitempty"`
+	MinNodes         int               `json:"min_nodes,omitempty"`
+	MaxNodes         int               `json:"max_nodes,omitempty"`
+	GPUPartitionMode string            `json:"gpu_partition_mode,omitempty"`
 
 	Nodes []*KubernetesNode `json:"nodes,omitempty"`
 }

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -49,6 +49,12 @@ func TestKubernetesClusters_ListClusters(t *testing.T) {
 			NvidiaGpuDevicePlugin: &KubernetesNvidiaGpuDevicePlugin{
 				Enabled: PtrTo(true),
 			},
+			NvidiaGpuDraDriver: &KubernetesNvidiaGpuDraDriver{
+				Enabled: PtrTo(true),
+			},
+			AmdGpuDraDriver: &KubernetesAmdGpuDraDriver{
+				Enabled: PtrTo(true),
+			},
 			RdmaSharedDevicePlugin: &KubernetesRdmaSharedDevicePlugin{
 				Enabled: PtrTo(true),
 			},
@@ -165,6 +171,12 @@ func TestKubernetesClusters_ListClusters(t *testing.T) {
 				"enabled": true
 			},
 			"nvidia_gpu_device_plugin": {
+				"enabled": true
+			},
+			"nvidia_gpu_dra_driver": {
+				"enabled": true
+			},
+			"amd_gpu_dra_driver": {
 				"enabled": true
 			},
 			"rdma_shared_dev_plugin": {
@@ -337,6 +349,12 @@ func TestKubernetesClusters_Get(t *testing.T) {
 		NvidiaGpuDevicePlugin: &KubernetesNvidiaGpuDevicePlugin{
 			Enabled: PtrTo(true),
 		},
+		NvidiaGpuDraDriver: &KubernetesNvidiaGpuDraDriver{
+			Enabled: PtrTo(true),
+		},
+		AmdGpuDraDriver: &KubernetesAmdGpuDraDriver{
+			Enabled: PtrTo(true),
+		},
 		RdmaSharedDevicePlugin: &KubernetesRdmaSharedDevicePlugin{
 			Enabled: PtrTo(true),
 		},
@@ -413,6 +431,12 @@ func TestKubernetesClusters_Get(t *testing.T) {
 			"enabled": true
 		},
 		"nvidia_gpu_device_plugin": {
+			"enabled": true
+		},
+		"nvidia_gpu_dra_driver": {
+			"enabled": true
+		},
+		"amd_gpu_dra_driver": {
 			"enabled": true
 		},
 		"rdma_shared_dev_plugin": {
@@ -791,6 +815,12 @@ func TestKubernetesClusters_Create(t *testing.T) {
 		NvidiaGpuDevicePlugin: &KubernetesNvidiaGpuDevicePlugin{
 			Enabled: PtrTo(true),
 		},
+		NvidiaGpuDraDriver: &KubernetesNvidiaGpuDraDriver{
+			Enabled: PtrTo(true),
+		},
+		AmdGpuDraDriver: &KubernetesAmdGpuDraDriver{
+			Enabled: PtrTo(true),
+		},
 		RdmaSharedDevicePlugin: &KubernetesRdmaSharedDevicePlugin{
 			Enabled: PtrTo(true),
 		},
@@ -855,6 +885,12 @@ func TestKubernetesClusters_Create(t *testing.T) {
 		NvidiaGpuDevicePlugin: &KubernetesNvidiaGpuDevicePlugin{
 			Enabled: PtrTo(true),
 		},
+		NvidiaGpuDraDriver: &KubernetesNvidiaGpuDraDriver{
+			Enabled: PtrTo(true),
+		},
+		AmdGpuDraDriver: &KubernetesAmdGpuDraDriver{
+			Enabled: PtrTo(true),
+		},
 		RdmaSharedDevicePlugin: &KubernetesRdmaSharedDevicePlugin{
 			Enabled: PtrTo(true),
 		},
@@ -912,6 +948,12 @@ func TestKubernetesClusters_Create(t *testing.T) {
 			"enabled": true
 		},
 		"nvidia_gpu_device_plugin": {
+			"enabled": true
+		},
+		"nvidia_gpu_dra_driver": {
+			"enabled": true
+		},
+		"amd_gpu_dra_driver": {
 			"enabled": true
 		},
 		"rdma_shared_dev_plugin": {
@@ -1143,6 +1185,12 @@ func TestKubernetesClusters_Update(t *testing.T) {
 		NvidiaGpuDevicePlugin: &KubernetesNvidiaGpuDevicePlugin{
 			Enabled: PtrTo(true),
 		},
+		NvidiaGpuDraDriver: &KubernetesNvidiaGpuDraDriver{
+			Enabled: PtrTo(true),
+		},
+		AmdGpuDraDriver: &KubernetesAmdGpuDraDriver{
+			Enabled: PtrTo(true),
+		},
 		RdmaSharedDevicePlugin: &KubernetesRdmaSharedDevicePlugin{
 			Enabled: PtrTo(true),
 		},
@@ -1182,6 +1230,12 @@ func TestKubernetesClusters_Update(t *testing.T) {
 			Enabled: PtrTo(true),
 		},
 		NvidiaGpuDevicePlugin: &KubernetesNvidiaGpuDevicePlugin{
+			Enabled: PtrTo(true),
+		},
+		NvidiaGpuDraDriver: &KubernetesNvidiaGpuDraDriver{
+			Enabled: PtrTo(true),
+		},
+		AmdGpuDraDriver: &KubernetesAmdGpuDraDriver{
 			Enabled: PtrTo(true),
 		},
 		RdmaSharedDevicePlugin: &KubernetesRdmaSharedDevicePlugin{
@@ -1255,6 +1309,12 @@ func TestKubernetesClusters_Update(t *testing.T) {
 		"nvidia_gpu_device_plugin": {
 			"enabled": true
 		},
+		"nvidia_gpu_dra_driver": {
+			"enabled": true
+		},
+		"amd_gpu_dra_driver": {
+			"enabled": true
+		},
 		"rdma_shared_dev_plugin": {
 			"enabled": true
 		},
@@ -1268,7 +1328,7 @@ func TestKubernetesClusters_Update(t *testing.T) {
 	}
 }`
 
-	expectedReqJSON := `{"name":"antoine-test-cluster","tags":["cluster-tag-1","cluster-tag-2"],"maintenance_policy":{"start_time":"00:00","duration":"","day":"monday"},"surge_upgrade":true,"control_plane_firewall":{"enabled":true,"allowed_addresses":["1.2.3.4/32"]},"cluster_autoscaler_configuration":{"scale_down_utilization_threshold":0.2,"scale_down_unneeded_time":"1m27s","expanders":[]},"routing_agent":{"enabled":true},"amd_gpu_device_plugin":{"enabled":true},"amd_gpu_device_metrics_exporter_plugin":{"enabled":true},"nvidia_gpu_device_plugin":{"enabled":true},"rdma_shared_dev_plugin":{"enabled":true},"coredns_autoscaler":{"enabled":true},"sso":{"enabled":false,"required":false},"p2p_oci_registry_plugin":{"enabled":true}}
+	expectedReqJSON := `{"name":"antoine-test-cluster","tags":["cluster-tag-1","cluster-tag-2"],"maintenance_policy":{"start_time":"00:00","duration":"","day":"monday"},"surge_upgrade":true,"control_plane_firewall":{"enabled":true,"allowed_addresses":["1.2.3.4/32"]},"cluster_autoscaler_configuration":{"scale_down_utilization_threshold":0.2,"scale_down_unneeded_time":"1m27s","expanders":[]},"routing_agent":{"enabled":true},"amd_gpu_device_plugin":{"enabled":true},"amd_gpu_device_metrics_exporter_plugin":{"enabled":true},"nvidia_gpu_device_plugin":{"enabled":true},"nvidia_gpu_dra_driver":{"enabled":true},"amd_gpu_dra_driver":{"enabled":true},"rdma_shared_dev_plugin":{"enabled":true},"coredns_autoscaler":{"enabled":true},"sso":{"enabled":false,"required":false},"p2p_oci_registry_plugin":{"enabled":true}}
 `
 
 	mux.HandleFunc("/v2/kubernetes/clusters/8d91899c-0739-4a1a-acc5-deadbeefbb8f", func(w http.ResponseWriter, r *http.Request) {
@@ -1575,6 +1635,54 @@ func TestKubernetesClusters_CreateNodePool(t *testing.T) {
 
 		testMethod(t, r, http.MethodPost)
 		require.Equal(t, v, createRequest)
+		fmt.Fprint(w, jBlob)
+	})
+
+	got, _, err := kubeSvc.CreateNodePool(ctx, "8d91899c-0739-4a1a-acc5-deadbeefbb8f", createRequest)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestKubernetesClusters_CreateNodePool_GPUPartitionMode(t *testing.T) {
+	setup()
+	defer teardown()
+
+	kubeSvc := client.Kubernetes
+
+	want := &KubernetesNodePool{
+		ID:               "8d91899c-0739-4a1a-acc5-deadbeefbb8a",
+		Size:             "gpu-mi300x1-192gb",
+		Count:            1,
+		Name:             "amd-partitioned-pool",
+		GPUPartitionMode: KubernetesAMDPartitionModeSPXNPS1,
+	}
+	createRequest := &KubernetesNodePoolCreateRequest{
+		Size:             want.Size,
+		Count:            want.Count,
+		Name:             want.Name,
+		GPUPartitionMode: KubernetesAMDPartitionModeSPXNPS1,
+	}
+
+	jBlob := `
+{
+	"node_pool": {
+		"id": "8d91899c-0739-4a1a-acc5-deadbeefbb8a",
+		"size": "gpu-mi300x1-192gb",
+		"count": 1,
+		"name": "amd-partitioned-pool",
+		"gpu_partition_mode": "AMD_PARTITION_MODE_SPX_NPS1"
+	}
+}`
+
+	mux.HandleFunc("/v2/kubernetes/clusters/8d91899c-0739-4a1a-acc5-deadbeefbb8f/node_pools", func(w http.ResponseWriter, r *http.Request) {
+		v := new(KubernetesNodePoolCreateRequest)
+		err := json.NewDecoder(r.Body).Decode(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		testMethod(t, r, http.MethodPost)
+		require.Equal(t, createRequest, v)
 		fmt.Fprint(w, jBlob)
 	})
 


### PR DESCRIPTION
- Add `nvidia_gpu_dra_driver` and `amd_gpu_dra_driver` (`{enabled: bool}`) to Kubernetes cluster create/update/get request/response types, mirroring existing device-plugin fields and the DOKS public API.
- Add `gpu_partition_mode` to Kubernetes node pool create request and node pool response, with DOKS enum constants `AMD_PARTITION_MODE_SPX_NPS1` / `AMD_PARTITION_MODE_DPX_NPS2` (distinct from Droplet `PARTITION_MODE_*` constants).
- Extend kubernetes unit tests / JSON fixtures; add a CreateNodePool partition-mode coverage test.

This PR enables extending the feature to terraform provider and doctl. 
