### PR TITLE
hosted agents: read session events from the data-plane /events endpoint (stack on OHS_endpoints)

### DIFF
--- a/hosted_agents.go
+++ b/hosted_agents.go
@@ -22,6 +22,7 @@ const (
 
 	hostedAgentsSessionsBasePath                    = "/v2/agents/sessions"
 	hostedAgentSessionByIDPath                      = hostedAgentsSessionsBasePath + "/%s"
+	hostedAgentSessionEventsPath                    = hostedAgentSessionByIDPath + "/events"
 	hostedAgentSessionStreamPath                    = hostedAgentSessionByIDPath + "/stream"
 	hostedAgentSessionInputPath                     = hostedAgentSessionByIDPath + "/input"
 	hostedAgentSessionHITLPath                      = hostedAgentSessionByIDPath + "/hitl/%s"
@@ -39,6 +40,10 @@ const (
 	workspaceContentSHA256Header = "X-Content-Sha256"
 	workspaceIsArchiveHeader     = "X-Workspace-Is-Archive"
 	workspaceSizeBytesHeader     = "X-Workspace-Size-Bytes"
+
+	// sseLastEventIDHeader is the standard SSE resume cursor. The data-plane
+	// events endpoint takes the cursor here rather than as a query parameter.
+	sseLastEventIDHeader = "Last-Event-ID"
 
 	// workspaceDownloadFooter is appended by OHS after a successful download
 	// payload so integrity survives intermediaries that strip HTTP trailers
@@ -208,6 +213,39 @@ const (
 	HostedAgentEventKindRunSandboxReleased   HostedAgentEventKind = "run.sandbox_released"
 	HostedAgentEventKindRunCostAccrued       HostedAgentEventKind = "run.cost_accrued"
 	HostedAgentEventKindRunLog               HostedAgentEventKind = "run.log"
+
+	// HostedAgentEventKindStreamState is a transport control frame, not an agent
+	// event: it reports the health of the SSE connection itself. Only the
+	// data-plane events endpoint emits it. It arrives in the same envelope as an
+	// event, but only SessionID, At and Payload are meaningful — decode Payload
+	// with HostedAgentStreamState. Renderers should skip it rather than display
+	// it as session activity.
+	HostedAgentEventKindStreamState HostedAgentEventKind = "stream.state"
+)
+
+// HostedAgentStreamState is the payload of a HostedAgentEventKindStreamState
+// frame: the current health of the SSE connection.
+type HostedAgentStreamState struct {
+	State  HostedAgentStreamStateValue `json:"state"`
+	Cursor string                      `json:"cursor,omitempty"`
+}
+
+// HostedAgentStreamStateValue enumerates the stream health states.
+type HostedAgentStreamStateValue string
+
+const (
+	// HostedAgentStreamStateLive means events are being delivered contiguously.
+	HostedAgentStreamStateLive HostedAgentStreamStateValue = "live"
+	// HostedAgentStreamStateCatchingUp means the connection is replaying recent
+	// history before it joins the live tail.
+	HostedAgentStreamStateCatchingUp HostedAgentStreamStateValue = "catching_up"
+	// HostedAgentStreamStateDegraded means delivery continues with reduced
+	// guarantees (the server fell back to polling).
+	HostedAgentStreamStateDegraded HostedAgentStreamStateValue = "degraded"
+	// HostedAgentStreamStateSuperseded means a newer connection from the same
+	// device took over. The server closes this stream; the client should stop
+	// rather than reconnect, or the two connections will evict each other.
+	HostedAgentStreamStateSuperseded HostedAgentStreamStateValue = "superseded"
 )
 
 // HostedAgentSessionOriginProduct identifies the product workflow that created
@@ -284,7 +322,7 @@ type HostedAgentHITLDecision struct {
 	Reason    string                 `json:"reason,omitempty"`
 }
 
-// HostedAgentEvent is one SSE payload from GET /v2/agents/sessions/{id}/stream.
+// HostedAgentEvent is one SSE payload from a session stream (see StreamSession).
 //
 // The server serializes the SPI canonical event envelope, whose JSON shape
 // differs from this struct's field names: the discriminator is `type` (not
@@ -363,8 +401,16 @@ type HostedAgentSessionsListResponse struct {
 }
 
 // HostedAgentSessionStreamOptions configures the session SSE stream.
+//
+// The two fields select between the two SSE surfaces StreamSession can open;
+// see StreamSession for why they are served by different endpoints.
 type HostedAgentSessionStreamOptions struct {
+	// ReplayFrom is the resume cursor: the id of the last event the caller
+	// already rendered. On the live stream it is sent as Last-Event-ID; on a
+	// ReplayOnly read it is sent as the replay_from query parameter.
 	ReplayFrom string
+	// ReplayOnly reads the stored event history and ends the stream at the last
+	// stored event instead of holding the connection open for live events.
 	ReplayOnly bool
 }
 
@@ -664,23 +710,41 @@ func (s *HostedAgentsServiceOp) ResumeSession(ctx context.Context, sessionID str
 }
 
 // StreamSession opens the SSE stream for a session. Callers MUST Close the stream.
+//
+// Live and replay-only reads are served by two different endpoints, because
+// streaming moved out of the control plane onto the data plane:
+//
+//   - Live (the default) reads GET .../sessions/{id}/events, served by the data
+//     plane. Delivery is forward-only from the moment of attach, so a live
+//     stream never carries events that predate it. ReplayFrom is sent as the
+//     standard Last-Event-ID header.
+//   - ReplayOnly reads GET .../sessions/{id}/stream?replay_only=true, served by
+//     the control plane, which owns the stored event history. The stream ends
+//     after the last stored event.
+//
+// The live stream also carries HostedAgentEventKindStreamState control frames
+// (see HostedAgentStreamState); replay-only reads do not.
 func (s *HostedAgentsServiceOp) StreamSession(ctx context.Context, sessionID string, opt *HostedAgentSessionStreamOptions) (*HostedAgentSessionStream, *Response, error) {
 	if sessionID == "" {
 		return nil, nil, errors.New("hosted agents: session id is required")
 	}
-	path := fmt.Sprintf(hostedAgentSessionStreamPath, sessionID)
+	replayOnly := opt != nil && opt.ReplayOnly
+	cursor := ""
 	if opt != nil {
-		q := url.Values{}
-		if opt.ReplayFrom != "" {
-			q.Set("replay_from", opt.ReplayFrom)
-		}
-		if opt.ReplayOnly {
-			q.Set("replay_only", "true")
-		}
-		if encoded := q.Encode(); encoded != "" {
-			path += "?" + encoded
-		}
+		cursor = opt.ReplayFrom
 	}
+
+	path := fmt.Sprintf(hostedAgentSessionEventsPath, sessionID)
+	if replayOnly {
+		path = fmt.Sprintf(hostedAgentSessionStreamPath, sessionID)
+		q := url.Values{}
+		q.Set("replay_only", "true")
+		if cursor != "" {
+			q.Set("replay_from", cursor)
+		}
+		path += "?" + q.Encode()
+	}
+
 	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
@@ -688,6 +752,9 @@ func (s *HostedAgentsServiceOp) StreamSession(ctx context.Context, sessionID str
 	req.Header.Set("Accept", "text/event-stream")
 	req.Header.Set("Cache-Control", "no-cache")
 	req.Header.Set("Connection", "keep-alive")
+	if !replayOnly && cursor != "" {
+		req.Header.Set(sseLastEventIDHeader, cursor)
+	}
 
 	resp, err := s.client.DoStream(ctx, req)
 	if err != nil {

--- a/hosted_agents.go
+++ b/hosted_agents.go
@@ -23,7 +23,6 @@ const (
 	hostedAgentsSessionsBasePath                    = "/v2/agents/sessions"
 	hostedAgentSessionByIDPath                      = hostedAgentsSessionsBasePath + "/%s"
 	hostedAgentSessionEventsPath                    = hostedAgentSessionByIDPath + "/events"
-	hostedAgentSessionStreamPath                    = hostedAgentSessionByIDPath + "/stream"
 	hostedAgentSessionInputPath                     = hostedAgentSessionByIDPath + "/input"
 	hostedAgentSessionHITLPath                      = hostedAgentSessionByIDPath + "/hitl/%s"
 	hostedAgentSessionSandboxExecPath               = hostedAgentSessionByIDPath + "/sandbox/exec"
@@ -402,8 +401,8 @@ type HostedAgentSessionsListResponse struct {
 
 // HostedAgentSessionStreamOptions configures the session SSE stream.
 //
-// The two fields select between the two SSE surfaces StreamSession can open;
-// see StreamSession for why they are served by different endpoints.
+// The two fields select between the two modes StreamSession can open on the
+// events endpoint; see StreamSession.
 type HostedAgentSessionStreamOptions struct {
 	// ReplayFrom is the resume cursor: the id of the last event the caller
 	// already rendered. On the live stream it is sent as Last-Event-ID; on a
@@ -711,19 +710,21 @@ func (s *HostedAgentsServiceOp) ResumeSession(ctx context.Context, sessionID str
 
 // StreamSession opens the SSE stream for a session. Callers MUST Close the stream.
 //
-// Live and replay-only reads are served by two different endpoints, because
-// streaming moved out of the control plane onto the data plane:
+// Both reads are served by the data plane at GET .../sessions/{id}/events; the
+// two modes differ in where the stream starts and whether it ends:
 //
-//   - Live (the default) reads GET .../sessions/{id}/events, served by the data
-//     plane. Delivery is forward-only from the moment of attach, so a live
-//     stream never carries events that predate it. ReplayFrom is sent as the
-//     standard Last-Event-ID header.
-//   - ReplayOnly reads GET .../sessions/{id}/stream?replay_only=true, served by
-//     the control plane, which owns the stored event history. The stream ends
-//     after the last stored event.
+//   - Live (the default) delivers forward-only from the moment of attach,
+//     preceded by whatever recent history the server decides to replay, and
+//     holds the connection open. ReplayFrom is sent as the standard
+//     Last-Event-ID header.
+//   - ReplayOnly adds ?replay_only=true: the server writes the session's stored
+//     event history and then ends the stream, so the read terminates on its own.
+//     ReplayFrom is sent as the replay_from query parameter, since it is an
+//     explicit pagination cursor here rather than a resume hint.
 //
-// The live stream also carries HostedAgentEventKindStreamState control frames
-// (see HostedAgentStreamState); replay-only reads do not.
+// Both carry HostedAgentEventKindStreamState control frames (see
+// HostedAgentStreamState). A replay-only read reports catching_up and then
+// simply ends; it never reaches live.
 func (s *HostedAgentsServiceOp) StreamSession(ctx context.Context, sessionID string, opt *HostedAgentSessionStreamOptions) (*HostedAgentSessionStream, *Response, error) {
 	if sessionID == "" {
 		return nil, nil, errors.New("hosted agents: session id is required")
@@ -736,7 +737,6 @@ func (s *HostedAgentsServiceOp) StreamSession(ctx context.Context, sessionID str
 
 	path := fmt.Sprintf(hostedAgentSessionEventsPath, sessionID)
 	if replayOnly {
-		path = fmt.Sprintf(hostedAgentSessionStreamPath, sessionID)
 		q := url.Values{}
 		q.Set("replay_only", "true")
 		if cursor != "" {

--- a/hosted_agents_test.go
+++ b/hosted_agents_test.go
@@ -383,12 +383,16 @@ func TestHostedAgents_StreamSession(t *testing.T) {
 	// `timestamp`, and the team id rides as a decimal string in `tenant_id`.
 	const eventJSON = `{"event_id":"ev-1","run_id":"run-1","tenant_id":"42","session_id":"sess-abc123","timestamp":"2026-03-01T12:01:00Z","seq":1,"type":"run.token_delta","data":{"text":"hello"}}`
 
-	mux.HandleFunc("/v2/agents/sessions/sess-abc123/stream", func(w http.ResponseWriter, r *http.Request) {
+	// The live stream is served by the data plane at .../events, and the resume
+	// cursor rides in the standard Last-Event-ID header rather than a query
+	// parameter.
+	mux.HandleFunc("/v2/agents/sessions/sess-abc123/events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		assert.Equal(t, "text/event-stream", r.Header.Get("Accept"))
-		assert.Equal(t, "ev-0", r.URL.Query().Get("replay_from"))
+		assert.Equal(t, "ev-0", r.Header.Get("Last-Event-ID"))
+		assert.Empty(t, r.URL.RawQuery)
 		w.Header().Set("Content-Type", "text/event-stream")
-		fmt.Fprintf(w, ": connected\n\n")
+		fmt.Fprintf(w, ": keepalive\n\n")
 		fmt.Fprintf(w, "id: ev-1\nevent: run.token_delta\ndata: %s\n\n", eventJSON)
 	})
 
@@ -489,6 +493,9 @@ func TestHostedAgents_ExecInSandbox(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
+// TestHostedAgents_StreamSession_ReplayOnly pins the history lane on the control
+// plane's .../stream endpoint: only it holds the stored event history, so a
+// replay-only read must not be sent to the forward-only data-plane endpoint.
 func TestHostedAgents_StreamSession_ReplayOnly(t *testing.T) {
 	setup()
 	defer teardown()
@@ -496,17 +503,56 @@ func TestHostedAgents_StreamSession_ReplayOnly(t *testing.T) {
 	mux.HandleFunc("/v2/agents/sessions/sess-abc123/stream", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		assert.Equal(t, "true", r.URL.Query().Get("replay_only"))
+		assert.Equal(t, "ev-0", r.URL.Query().Get("replay_from"))
+		assert.Empty(t, r.Header.Get("Last-Event-ID"))
 		w.Header().Set("Content-Type", "text/event-stream")
 		fmt.Fprint(w, ": replay only\n\n")
 	})
 
 	stream, resp, err := client.HostedAgents.StreamSession(ctx, "sess-abc123", &HostedAgentSessionStreamOptions{
+		ReplayFrom: "ev-0",
 		ReplayOnly: true,
 	})
 	require.NoError(t, err)
 	defer stream.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.False(t, stream.Next())
+}
+
+// TestHostedAgents_StreamSession_StreamState pins the data plane's transport
+// control frame. It arrives in the same canonical envelope as an agent event, so
+// it decodes through the same parser: callers identify it by Kind and skip it
+// rather than rendering it as session activity.
+func TestHostedAgents_StreamSession_StreamState(t *testing.T) {
+	setup()
+	defer teardown()
+
+	const frame = `{"event_id":"","run_id":"","tenant_id":"0","session_id":"sess-abc123","timestamp":"2026-03-01T12:00:00Z","seq":0,"type":"stream.state","data":{"state":"live","cursor":""}}`
+
+	mux.HandleFunc("/v2/agents/sessions/sess-abc123/events", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprintf(w, "event: stream.state\ndata: %s\n\n", frame)
+	})
+
+	stream, _, err := client.HostedAgents.StreamSession(ctx, "sess-abc123", nil)
+	require.NoError(t, err)
+	defer stream.Close()
+
+	require.True(t, stream.Next())
+	ev := stream.Current()
+	assert.Equal(t, HostedAgentEventKindStreamState, ev.Kind)
+	assert.Equal(t, "sess-abc123", ev.SessionID)
+	// A control frame is not a durable event, so it carries no event_id of its
+	// own and the server sends no `id:` line for it. (Per the SSE spec the
+	// reader's last-event-id buffer persists, so a control frame arriving after
+	// an event reports that event's id — never a new cursor position.)
+	assert.Empty(t, ev.EventID)
+
+	var state HostedAgentStreamState
+	require.NoError(t, json.Unmarshal(ev.Payload, &state))
+	assert.Equal(t, HostedAgentStreamStateLive, state.State)
+	assert.Empty(t, state.Cursor)
 }
 
 func TestHostedAgents_ValidationErrors(t *testing.T) {

--- a/hosted_agents_test.go
+++ b/hosted_agents_test.go
@@ -493,14 +493,15 @@ func TestHostedAgents_ExecInSandbox(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
-// TestHostedAgents_StreamSession_ReplayOnly pins the history lane on the control
-// plane's .../stream endpoint: only it holds the stored event history, so a
-// replay-only read must not be sent to the forward-only data-plane endpoint.
+// TestHostedAgents_StreamSession_ReplayOnly pins the history lane on the same
+// data-plane .../events endpoint as the live lane, selected by ?replay_only=true.
+// The cursor moves to the replay_from query parameter here: on a history read it
+// is an explicit pagination cursor, not the Last-Event-ID resume hint.
 func TestHostedAgents_StreamSession_ReplayOnly(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/agents/sessions/sess-abc123/stream", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/v2/agents/sessions/sess-abc123/events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		assert.Equal(t, "true", r.URL.Query().Get("replay_only"))
 		assert.Equal(t, "ev-0", r.URL.Query().Get("replay_from"))
@@ -517,6 +518,51 @@ func TestHostedAgents_StreamSession_ReplayOnly(t *testing.T) {
 	defer stream.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.False(t, stream.Next())
+}
+
+// TestHostedAgents_StreamSession_ReplayOnly_HistoryThenEOF covers what a
+// replay-only read is for: the stored history arrives as ordinary events and the
+// stream then ends on its own, which is what lets a history reader exit instead
+// of blocking on a connection that stays open forever.
+func TestHostedAgents_StreamSession_ReplayOnly_HistoryThenEOF(t *testing.T) {
+	setup()
+	defer teardown()
+
+	const (
+		catchingUp = `{"event_id":"","run_id":"","tenant_id":"0","session_id":"sess-abc123","timestamp":"2026-03-01T12:00:00Z","seq":0,"type":"stream.state","data":{"state":"catching_up","cursor":""}}`
+		first      = `{"event_id":"ev-1","run_id":"run-1","tenant_id":"42","session_id":"sess-abc123","timestamp":"2026-03-01T12:01:00Z","seq":1,"type":"run.token_delta","data":{"text":"hello"}}`
+		second     = `{"event_id":"ev-2","run_id":"run-1","tenant_id":"42","session_id":"sess-abc123","timestamp":"2026-03-01T12:02:00Z","seq":2,"type":"run.completed","data":{}}`
+	)
+
+	mux.HandleFunc("/v2/agents/sessions/sess-abc123/events", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		assert.Equal(t, "true", r.URL.Query().Get("replay_only"))
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprintf(w, "event: stream.state\ndata: %s\n\n", catchingUp)
+		fmt.Fprintf(w, "id: ev-1\nevent: run.token_delta\ndata: %s\n\n", first)
+		fmt.Fprintf(w, "id: ev-2\nevent: run.completed\ndata: %s\n\n", second)
+	})
+
+	stream, _, err := client.HostedAgents.StreamSession(ctx, "sess-abc123", &HostedAgentSessionStreamOptions{
+		ReplayOnly: true,
+	})
+	require.NoError(t, err)
+	defer stream.Close()
+
+	// A history read opens with catching_up and never reaches live.
+	require.True(t, stream.Next())
+	assert.Equal(t, HostedAgentEventKindStreamState, stream.Current().Kind)
+
+	require.True(t, stream.Next())
+	assert.Equal(t, HostedAgentEventKindTokenChunk, stream.Current().Kind)
+	assert.Equal(t, "ev-1", stream.Current().EventID)
+
+	require.True(t, stream.Next())
+	assert.Equal(t, HostedAgentEventKindRunCompleted, stream.Current().Kind)
+	assert.Equal(t, "ev-2", stream.Current().EventID)
+
+	assert.False(t, stream.Next(), "replay-only stream must end after the last stored event")
+	assert.NoError(t, stream.Err())
 }
 
 // TestHostedAgents_StreamSession_StreamState pins the data plane's transport


### PR DESCRIPTION
Re-applies the two commits reverted from `OHS_endpoints` by `eae8993` and `ab376b8` (see #1021), unchanged, on a branch of their own.

The point of the separate branch is to let the matching doctl work (digitalocean/doctl, stacked on `feat/agents-subcommands`) pin a godo revision that actually has `/events`, so `doctl` builds can be tested against the OHP data plane without moving either shared PR branch.

### What the commits do

`StreamSession` moves off the control plane's `/v2/agents/sessions/{id}/stream` onto the data plane's `/v2/agents/sessions/{id}/events`, for both reads:

- **Live** (the default) delivers forward-only from the moment of attach and holds the connection open. `ReplayFrom` is sent as the standard `Last-Event-ID` header.
- **ReplayOnly** adds `?replay_only=true`: the server writes the session's stored history and then ends the stream, so the read terminates on its own. `ReplayFrom` stays on the `replay_from` query parameter, since it is an explicit pagination cursor here rather than a resume hint the server may widen.

Both reads carry `stream.state` transport control frames reporting connection health (`live` / `catching_up` / `degraded` / `superseded`). They arrive in the same canonical envelope as an event, so `HostedAgentEventKindStreamState` and `HostedAgentStreamState` name the kind and its payload, letting callers identify and skip them instead of rendering them as session activity.

### Testing

`go build ./...`, `go vet ./...` and `go test ./...` all pass, including the four `StreamSession` tests covering the live path, replay-only, replay-only history-then-EOF, and `stream.state` decoding.
