### PR TITLE
hosted agents: declare workspace upload size and negotiate before sending

### DIFF
--- a/hosted_agents.go
+++ b/hosted_agents.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -45,6 +46,16 @@ const (
 	// (e.g. Cloudflare). Format: DOWSSHA1 + 64 lowercase hex + '\n' = 73 bytes.
 	workspaceDownloadFooterPrefix = "DOWSSHA1"
 	workspaceDownloadFooterLen    = len(workspaceDownloadFooterPrefix) + 64 + 1
+
+	// workspaceUploadExpectContinueMinBytes is the payload size at which
+	// UploadWorkspace switches to an Expect: 100-continue handshake. OHS caps
+	// upload size and limits concurrent transfers, so it can refuse a request
+	// from its headers alone; waiting for that verdict keeps a doomed payload
+	// off the wire entirely. Below this size the extra round trip costs more
+	// than the bytes it saves. If an intermediary ignores the handshake the
+	// transport falls back to sending the body after ExpectContinueTimeout, so
+	// this only ever delays an upload, never fails one.
+	workspaceUploadExpectContinueMinBytes = 1 << 20
 )
 
 // HostedAgentsService exposes the DigitalOcean Hosted Agents session API
@@ -407,6 +418,16 @@ type HostedAgentWorkspaceUploadRequest struct {
 	ContentSHA256 string
 	// Body is the raw file or tar bytes to upload. Required.
 	Body io.Reader
+	// ContentLength is the payload size in bytes. Optional: when zero it is
+	// derived from Body if Body is an *os.File or an in-memory reader. Set it
+	// explicitly for any other reader whose size is known in advance. Declaring
+	// the size lets OHS reject an oversize or unservable upload before the
+	// payload is transmitted; without it the request is sent chunked and the
+	// caller pays for the whole transfer before learning it was refused.
+	//
+	// A value set here must match exactly what Body yields. The transport
+	// enforces the promise and fails the request on a mismatch.
+	ContentLength int64
 }
 
 // HostedAgentWorkspaceUploadResponse is returned by UploadWorkspace.
@@ -767,6 +788,36 @@ func (s *HostedAgentsServiceOp) ExecInSandbox(ctx context.Context, sessionID str
 	return root, resp, nil
 }
 
+// uploadBodyLength reports how many bytes input.Body will yield, or 0 when that
+// cannot be known without consuming it. An explicit ContentLength always wins.
+func uploadBodyLength(input *HostedAgentWorkspaceUploadRequest) int64 {
+	if input.ContentLength > 0 {
+		return input.ContentLength
+	}
+
+	switch body := input.Body.(type) {
+	case *os.File:
+		// A size is only meaningful for a regular file, and only the bytes from
+		// the current offset onward are going to be sent.
+		st, err := body.Stat()
+		if err != nil || !st.Mode().IsRegular() {
+			return 0
+		}
+		off, err := body.Seek(0, io.SeekCurrent)
+		if err != nil || off > st.Size() {
+			return 0
+		}
+		return st.Size() - off
+	case interface{ Len() int }:
+		// Covers *bytes.Reader, *bytes.Buffer and *strings.Reader, which report
+		// their unread remainder. http.NewRequest already measures those three;
+		// this is a backstop for equivalent readers it does not recognise.
+		return int64(body.Len())
+	default:
+		return 0
+	}
+}
+
 // UploadWorkspace streams a file (or tar archive) into the session workspace.
 func (s *HostedAgentsServiceOp) UploadWorkspace(ctx context.Context, sessionID string, input *HostedAgentWorkspaceUploadRequest) (*HostedAgentWorkspaceUploadResponse, *Response, error) {
 	if sessionID == "" {
@@ -803,6 +854,17 @@ func (s *HostedAgentsServiceOp) UploadWorkspace(ctx context.Context, sessionID s
 	req.Header.Set("User-Agent", s.client.UserAgent)
 	if input.ContentSHA256 != "" {
 		req.Header.Set(workspaceContentSHA256Header, input.ContentSHA256)
+	}
+
+	// http.NewRequest derives Content-Length only for a few in-memory body
+	// types, so the *os.File callers typically pass would go out chunked. OHS
+	// cannot enforce its size cap or shed load on a body of undeclared length,
+	// so publish the size whenever it is knowable.
+	if n := uploadBodyLength(input); n > 0 {
+		req.ContentLength = n
+	}
+	if req.ContentLength >= workspaceUploadExpectContinueMinBytes {
+		req.Header.Set("Expect", "100-continue")
 	}
 
 	root := new(HostedAgentWorkspaceUploadResponse)

--- a/hosted_agents_test.go
+++ b/hosted_agents_test.go
@@ -2,6 +2,7 @@ package godo
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -20,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 )
 
 var hostedAgentSession = HostedAgentSession{
@@ -781,6 +783,65 @@ func TestHostedAgents_UploadWorkspace_WithholdsPayloadWhenRefusedAtHeaders(t *te
 	// Only the request headers should have crossed the wire.
 	assert.Less(t, atomic.LoadInt64(read), int64(32<<10),
 		"payload was transmitted despite the request being refused at headers")
+}
+
+// The withholding above must survive the client stack doctl actually builds:
+// an oauth2 client wrapped by the retryablehttp transport. That transport is
+// where Expect could quietly stop working, since honouring it depends on a
+// non-zero ExpectContinueTimeout, and where a retry could replay the payload.
+func TestHostedAgents_UploadWorkspace_WithholdsPayloadThroughRetryTransport(t *testing.T) {
+	const size = 4 << 20
+
+	var (
+		attempts int64
+		read     int64
+	)
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&attempts, 1)
+		assert.Equal(t, "100-continue", r.Header.Get("Expect"))
+		w.Header().Set("Retry-After", "1")
+		http.Error(w, "workspace transfer capacity exhausted, retry later", http.StatusServiceUnavailable)
+	}))
+	srv.Listener = countingListener{Listener: srv.Listener, read: &read}
+	srv.Start()
+	defer srv.Close()
+
+	// Mirrors doctl: oauth2 client + WithRetryAndBackoffs. The waits are
+	// squeezed only to keep the test quick.
+	oauthClient := oauth2.NewClient(context.Background(),
+		oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}))
+	c, err := New(oauthClient,
+		WithRetryAndBackoffs(RetryConfig{
+			RetryMax:     1,
+			RetryWaitMin: PtrTo(0.01),
+			RetryWaitMax: PtrTo(0.02),
+		}),
+		SetBaseURL(srv.URL),
+	)
+	require.NoError(t, err)
+
+	start := time.Now()
+	_, resp, err := c.HostedAgents.UploadWorkspace(ctx, "sess-abc123", &HostedAgentWorkspaceUploadRequest{
+		Path: "big.bin",
+		Body: workspaceUploadFile(t, size),
+	})
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+
+	// A 503 is retryable, so the shed must actually be replayed rather than
+	// surfacing on the first attempt.
+	assert.Equal(t, int64(2), atomic.LoadInt64(&attempts), "initial attempt plus one retry")
+
+	// The retry must wait out the Retry-After OHS sent rather than the far
+	// shorter backoff configured above, so a shedding server is not hammered.
+	assert.GreaterOrEqual(t, elapsed, time.Second, "Retry-After was ignored")
+
+	// Neither attempt may put the payload on the wire.
+	assert.Less(t, atomic.LoadInt64(&read), int64(32<<10),
+		"payload was transmitted through the retry transport despite being refused at headers")
 }
 
 // Control for the test above: an accepted upload must still deliver every byte.

--- a/hosted_agents_test.go
+++ b/hosted_agents_test.go
@@ -1,14 +1,20 @@
 package godo
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -577,6 +583,259 @@ func TestHostedAgents_UploadWorkspace(t *testing.T) {
 	assert.Equal(t, "/workspace/src/main.go", got.Path)
 	assert.Equal(t, int64(len(payload)), got.BytesWritten)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// workspaceUploadFile writes n bytes to a temp file and returns it positioned
+// at the start, mirroring how doctl hands a file to UploadWorkspace.
+func workspaceUploadFile(t *testing.T, n int) *os.File {
+	t.Helper()
+
+	f, err := os.CreateTemp(t.TempDir(), "upload")
+	require.NoError(t, err)
+	t.Cleanup(func() { f.Close() })
+
+	_, err = f.Write(bytes.Repeat([]byte("x"), n))
+	require.NoError(t, err)
+	_, err = f.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+
+	return f
+}
+
+func TestHostedAgents_UploadWorkspace_DeclaresContentLength(t *testing.T) {
+	const payload = "hello world"
+
+	tests := []struct {
+		name string
+		body func(t *testing.T) io.Reader
+		// contentLength is the explicit request field, left zero to exercise
+		// inference from the body.
+		contentLength int64
+		want          int64
+	}{
+		{
+			name: "os.File is measured by stat",
+			body: func(t *testing.T) io.Reader { return workspaceUploadFile(t, len(payload)) },
+			want: int64(len(payload)),
+		},
+		{
+			name: "os.File is measured from its current offset",
+			body: func(t *testing.T) io.Reader {
+				f := workspaceUploadFile(t, len(payload))
+				_, err := f.Seek(4, io.SeekStart)
+				require.NoError(t, err)
+				return f
+			},
+			want: int64(len(payload) - 4),
+		},
+		{
+			name: "in-memory reader reports its remainder",
+			body: func(t *testing.T) io.Reader { return strings.NewReader(payload) },
+			want: int64(len(payload)),
+		},
+		{
+			name: "opaque reader falls back to the explicit length",
+			body: func(t *testing.T) io.Reader {
+				// Hides Len() so neither http.NewRequest nor uploadBodyLength
+				// can measure it.
+				return struct{ io.Reader }{strings.NewReader(payload)}
+			},
+			contentLength: int64(len(payload)),
+			want:          int64(len(payload)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setup()
+			defer teardown()
+
+			var (
+				gotLength   int64
+				gotEncoding []string
+			)
+			mux.HandleFunc("/v2/agents/sessions/sess-abc123/workspace/upload", func(w http.ResponseWriter, r *http.Request) {
+				gotLength = r.ContentLength
+				gotEncoding = r.TransferEncoding
+				io.Copy(io.Discard, r.Body)
+				fmt.Fprint(w, `{"path":"/workspace/f","bytes_written":0}`)
+			})
+
+			_, _, err := client.HostedAgents.UploadWorkspace(ctx, "sess-abc123", &HostedAgentWorkspaceUploadRequest{
+				Path:          "f",
+				Body:          tt.body(t),
+				ContentLength: tt.contentLength,
+			})
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.want, gotLength, "declared Content-Length")
+			assert.Empty(t, gotEncoding, "payload must not be chunked")
+		})
+	}
+}
+
+func TestHostedAgents_UploadWorkspace_ExpectContinueThreshold(t *testing.T) {
+	tests := []struct {
+		name string
+		size int
+		want string
+	}{
+		{name: "below threshold negotiates nothing", size: 16, want: ""},
+		{name: "at threshold negotiates", size: workspaceUploadExpectContinueMinBytes, want: "100-continue"},
+		{name: "above threshold negotiates", size: workspaceUploadExpectContinueMinBytes + 1, want: "100-continue"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setup()
+			defer teardown()
+
+			var got string
+			mux.HandleFunc("/v2/agents/sessions/sess-abc123/workspace/upload", func(w http.ResponseWriter, r *http.Request) {
+				got = r.Header.Get("Expect")
+				io.Copy(io.Discard, r.Body)
+				fmt.Fprint(w, `{"path":"/workspace/f","bytes_written":0}`)
+			})
+
+			_, _, err := client.HostedAgents.UploadWorkspace(ctx, "sess-abc123", &HostedAgentWorkspaceUploadRequest{
+				Path: "f",
+				Body: workspaceUploadFile(t, tt.size),
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// countingListener totals the bytes read off every accepted connection, which
+// is how the tests below distinguish "payload withheld" from "payload sent".
+type countingListener struct {
+	net.Listener
+	read *int64
+}
+
+func (l countingListener) Accept() (net.Conn, error) {
+	c, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	return countingConn{Conn: c, read: l.read}, nil
+}
+
+type countingConn struct {
+	net.Conn
+	read *int64
+}
+
+func (c countingConn) Read(p []byte) (int, error) {
+	n, err := c.Conn.Read(p)
+	atomic.AddInt64(c.read, int64(n))
+	return n, err
+}
+
+// newCountingUploadServer serves handler and reports bytes received on the wire.
+func newCountingUploadServer(t *testing.T, handler http.HandlerFunc) (*Client, *int64) {
+	t.Helper()
+
+	var read int64
+	srv := httptest.NewUnstartedServer(handler)
+	srv.Listener = countingListener{Listener: srv.Listener, read: &read}
+	srv.Start()
+	t.Cleanup(srv.Close)
+
+	// NewClient does not retry, so a 503 surfaces on the first attempt rather
+	// than being replayed.
+	c := NewClient(nil)
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	c.BaseURL = u
+
+	return c, &read
+}
+
+// The point of the Expect handshake: when OHS refuses from the headers alone --
+// its size cap or an exhausted transfer slot -- the payload never leaves the
+// client.
+func TestHostedAgents_UploadWorkspace_WithholdsPayloadWhenRefusedAtHeaders(t *testing.T) {
+	const size = 4 << 20
+
+	var gotExpect string
+	c, read := newCountingUploadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotExpect = r.Header.Get("Expect")
+		// Refuse without touching r.Body, so net/http never emits 100 Continue.
+		w.Header().Set("Retry-After", "1")
+		http.Error(w, "workspace transfer capacity exhausted, retry later", http.StatusServiceUnavailable)
+	})
+
+	_, resp, err := c.HostedAgents.UploadWorkspace(ctx, "sess-abc123", &HostedAgentWorkspaceUploadRequest{
+		Path: "big.bin",
+		Body: workspaceUploadFile(t, size),
+	})
+
+	require.Error(t, err, "a 503 must surface to the caller")
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	assert.Equal(t, "100-continue", gotExpect)
+	assert.Equal(t, "1", resp.Header.Get("Retry-After"))
+
+	// Only the request headers should have crossed the wire.
+	assert.Less(t, atomic.LoadInt64(read), int64(32<<10),
+		"payload was transmitted despite the request being refused at headers")
+}
+
+// Control for the test above: an accepted upload must still deliver every byte.
+func TestHostedAgents_UploadWorkspace_SendsPayloadWhenAccepted(t *testing.T) {
+	const size = 4 << 20
+
+	var got int64
+	c, read := newCountingUploadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		n, err := io.Copy(io.Discard, r.Body)
+		require.NoError(t, err)
+		got = n
+		fmt.Fprintf(w, `{"path":"/workspace/big.bin","bytes_written":%d}`, n)
+	})
+
+	out, resp, err := c.HostedAgents.UploadWorkspace(ctx, "sess-abc123", &HostedAgentWorkspaceUploadRequest{
+		Path: "big.bin",
+		Body: workspaceUploadFile(t, size),
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int64(size), got, "handler must receive the whole payload")
+	assert.Equal(t, int64(size), out.BytesWritten)
+	assert.GreaterOrEqual(t, atomic.LoadInt64(read), int64(size))
+}
+
+func TestUploadBodyLength(t *testing.T) {
+	t.Run("explicit length wins over an inferrable body", func(t *testing.T) {
+		got := uploadBodyLength(&HostedAgentWorkspaceUploadRequest{
+			Body:          workspaceUploadFile(t, 4096),
+			ContentLength: 7,
+		})
+		assert.Equal(t, int64(7), got)
+	})
+
+	t.Run("non-regular file is not measurable", func(t *testing.T) {
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		t.Cleanup(func() { r.Close(); w.Close() })
+
+		assert.Zero(t, uploadBodyLength(&HostedAgentWorkspaceUploadRequest{Body: r}))
+	})
+
+	t.Run("opaque reader is not measurable", func(t *testing.T) {
+		body := struct{ io.Reader }{strings.NewReader("hello")}
+		assert.Zero(t, uploadBodyLength(&HostedAgentWorkspaceUploadRequest{Body: body}))
+	})
+
+	t.Run("fully consumed file measures zero", func(t *testing.T) {
+		f := workspaceUploadFile(t, 8)
+		_, err := io.Copy(io.Discard, f)
+		require.NoError(t, err)
+
+		assert.Zero(t, uploadBodyLength(&HostedAgentWorkspaceUploadRequest{Body: f}))
+	})
 }
 
 func workspaceDownloadFooter(payload string) string {

--- a/hosted_agents_test.go
+++ b/hosted_agents_test.go
@@ -785,6 +785,59 @@ func TestHostedAgents_UploadWorkspace_WithholdsPayloadWhenRefusedAtHeaders(t *te
 		"payload was transmitted despite the request being refused at headers")
 }
 
+// HTTP/2 implements the handshake in a completely separate transport, and the
+// API is reached over TLS with h2 negotiation enabled, so the guarantee has to
+// hold there too.
+func TestHostedAgents_UploadWorkspace_WithholdsPayloadOverHTTP2(t *testing.T) {
+	const size = 4 << 20
+
+	var (
+		read     int64
+		gotProto string
+	)
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotProto = r.Proto
+		http.Error(w, "workspace transfer capacity exhausted, retry later", http.StatusServiceUnavailable)
+	}))
+	srv.Listener = countingListener{Listener: srv.Listener, read: &read}
+	srv.EnableHTTP2 = true
+	srv.StartTLS()
+	defer srv.Close()
+
+	hc := srv.Client()
+	// httptest leaves ExpectContinueTimeout at zero, and the h2 transport reads
+	// it to decide whether to negotiate at all -- zero means send the body
+	// immediately. Every transport godo runs on in production sets it (both
+	// http.DefaultTransport and cleanhttp use 1s), so match them or this would
+	// test a configuration that does not exist.
+	hc.Transport.(*http.Transport).ExpectContinueTimeout = time.Second
+
+	c := NewClient(hc)
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	c.BaseURL = u
+
+	_, resp, err := c.HostedAgents.UploadWorkspace(ctx, "sess-abc123", &HostedAgentWorkspaceUploadRequest{
+		Path: "big.bin",
+		Body: workspaceUploadFile(t, size),
+	})
+
+	require.Error(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	require.Equal(t, "HTTP/2.0", gotProto, "test did not exercise h2")
+
+	// The handler is deliberately not asserted on Expect: net/http lifts it out
+	// of the headers into an internal flag before an h2 handler runs, so the
+	// negotiation is invisible server-side and only the byte count can show it
+	// happened.
+	//
+	// Counted before TLS decryption, so the bound allows for handshake and
+	// framing overhead while staying far below the payload.
+	assert.Less(t, atomic.LoadInt64(&read), int64(64<<10),
+		"payload was transmitted over h2 despite being refused at headers")
+}
+
 // The withholding above must survive the client stack doctl actually builds:
 // an oauth2 client wrapped by the retryablehttp transport. That transport is
 // where Expect could quietly stop working, since honouring it depends on a


### PR DESCRIPTION
Companion to cthulhu [#169365](https://github.internal.digitalocean.com/digitalocean/cthulhu/pull/169365) (MARSOHS-626), which makes OHS shed saturated workspace transfers with a 503 and refuse over-cap uploads from their headers. Both of those verdicts need a client that declares a size and, ideally, asks before sending.

#### Summary

**Declare `Content-Length`.** `UploadWorkspace` handed its `io.Reader` straight to `http.NewRequest`, which derives a length only for a few in-memory types. The `*os.File` callers pass falls through, so uploads went out **chunked with no declared size**.

OHS caps uploads at 50 MiB and limits concurrent transfers, but with no length to inspect it cannot apply either verdict until it has read the body. An over-cap upload was therefore only refused mid-stream, after the whole payload had crossed the network — measured on staging at **176s for a 51 MiB file** that was doomed from its first byte.

`uploadBodyLength` measures a regular `*os.File` from its current offset, or any reader exposing `Len()`. A new optional `ContentLength` field covers readers we cannot measure.

**Negotiate above 1 MiB.** With `Expect: 100-continue` the payload stays on the client until OHS approves, so a rejection at headers costs one round trip instead of a full transfer. The threshold keeps the extra round trip off small uploads, and an intermediary that ignores the handshake only *delays* a transfer — the transport falls back to sending the body after `ExpectContinueTimeout`.

Both changes are additive. `doctl` needs no source change: it already passes an `*os.File` rewound to the start after hashing.

#### Testing

Tests count bytes on the socket rather than trusting headers. A 4 MiB upload refused with 503 puts **under 32 KiB** on the wire, and a paired control confirms an accepted upload still delivers every byte. Covered over HTTP/1.1, over HTTP/2, and through the exact stack `doctl` builds (oauth2 wrapped in `retryablehttp`), where the payload is withheld across both the initial attempt and its retry, and the retry waits out `Retry-After` rather than its much shorter configured backoff.

Two things worth knowing for review, both easy to get wrong:

- Honouring the handshake depends on a **non-zero `ExpectContinueTimeout`** on the underlying transport. `httptest` leaves it at zero, which silently sends the whole payload and proves nothing, so the tests set it to match production (`http.DefaultTransport` and cleanhttp both use 1s).
- An h2 handler **cannot** assert on the `Expect` header: `net/http` lifts it into an internal flag before the handler runs. Only the byte count shows the negotiation happened.

`go build ./...`, `go vet ./...`, and the full suite pass; the new tests were also run 10x under `-race`.

No CHANGELOG entry, matching the other hosted-agents commits on this branch.

Made with [Cursor](https://cursor.com)