### PR TITLE
Implement BillingInsights.List Endpoint

### DIFF
--- a/billing_insights.go
+++ b/billing_insights.go
@@ -1,0 +1,75 @@
+package godo
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+const billingInsightsBasePath = "v2/billing"
+
+// BillingInsightsService is an interface for interfacing with the BillingInsights
+// endpoint of the DigitalOcean API
+// See: https://docs.digitalocean.com/reference/api/reference/billing/#billingInsights_list
+type BillingInsightsService interface {
+	List(ctx context.Context, accountURN, startDate, endDate string, opt *ListOptions) (*BillingInsights, *Response, error)
+}
+
+// BillingInsightsServiceOp handles communication with the BillingInsights related methods of
+// the DigitalOcean API.
+type BillingInsightsServiceOp struct {
+	client *Client
+}
+
+var _ BillingInsightsService = &BillingInsightsServiceOp{}
+
+// BillingInsights represents a DigitalOcean Billing Insight
+type BillingInsights struct {
+	CurrentPage int                    `json:"current_page"`
+	DataPoints  []BillingInsightsEntry `json:"data_points"`
+	TotalItems  int                    `json:"total_items"`
+	TotalPages  int                    `json:"total_pages"`
+}
+
+// BillingInsightsEntry represents an entry in a customer's Billing Insights
+type BillingInsightsEntry struct {
+	Description      string `json:"description"`
+	GroupDescription string `json:"group_description"`
+	Region           string `json:"region"`
+	SKU              string `json:"sku"`
+	StartDate        string `json:"start_date"` // Explicitly string-based YYYY-MM-DD, not full timestamp
+	TotalAmount      string `json:"total_amount"`
+	UsageTeamURN     string `json:"usage_team_urn"`
+}
+
+func (b BillingInsights) String() string {
+	return Stringify(b)
+}
+
+// List the Billing Insights for a customer
+func (s *BillingInsightsServiceOp) List(ctx context.Context, accountURN, startDate, endDate string, opt *ListOptions) (*BillingInsights, *Response, error) {
+	path := fmt.Sprintf("%s/%s/insights/%s/%s", billingInsightsBasePath, accountURN, startDate, endDate)
+	path, err := addOptions(path, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(BillingInsights)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	resp.Meta = &Meta{
+		Page:  root.CurrentPage,
+		Pages: root.TotalPages,
+		Total: root.TotalItems,
+	}
+
+	return root, resp, err
+}

--- a/billing_insights.go
+++ b/billing_insights.go
@@ -23,7 +23,10 @@ type BillingInsightsServiceOp struct {
 
 var _ BillingInsightsService = &BillingInsightsServiceOp{}
 
-// BillingInsights represents a DigitalOcean Billing Insight
+// BillingInsights represents a DigitalOcean Billing Insight.
+//
+// Page metadata is returned as individual values. Values of `CurrentPage`, `TotalItems`, and
+// `TotalPages` are returned as string-quoted integers.
 type BillingInsights struct {
 	DataPoints  []BillingInsightsEntry `json:"data_points"`
 	CurrentPage int                    `json:"current_page,string"`

--- a/billing_insights.go
+++ b/billing_insights.go
@@ -25,10 +25,10 @@ var _ BillingInsightsService = &BillingInsightsServiceOp{}
 
 // BillingInsights represents a DigitalOcean Billing Insight
 type BillingInsights struct {
-	CurrentPage int                    `json:"current_page"`
 	DataPoints  []BillingInsightsEntry `json:"data_points"`
-	TotalItems  int                    `json:"total_items"`
-	TotalPages  int                    `json:"total_pages"`
+	CurrentPage int                    `json:"current_page,string"`
+	TotalItems  int                    `json:"total_items,string"`
+	TotalPages  int                    `json:"total_pages,string"`
 }
 
 // BillingInsightsEntry represents an entry in a customer's Billing Insights

--- a/billing_insights_test.go
+++ b/billing_insights_test.go
@@ -1,0 +1,80 @@
+package godo
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestBillingInsights_List(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/billing/do:team:12345678-1234-1234-1234-123456789012/insights/2025-01-01/2025-01-31", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{
+			"current_page": 1,
+			"data_points": [
+				{
+					"description": "droplet name (c-2-4GiB)",
+					"group_description": "",
+					"region": "nyc3",
+					"sku": "1-DO-DROP-0109",
+					"start_date": "2025-01-01",
+					"total_amount": "0.86",
+					"usage_team_urn": "do:team:12345678-1234-1234-1234-123456789012"
+				},
+				{
+					"description": "3 nodes - 4 GB / 2 vCPU / 80 GB SSD",
+					"group_description": "kubernetes cluster name",
+					"region": "nyc3",
+					"sku": "1-KS-K8SWN-00109",
+					"start_date": "2025-01-01",
+					"total_amount": "2.57",
+					"usage_team_urn": "do:team:12345678-1234-1234-1234-123456789012"
+				}
+			],
+			"total_items": 2,
+			"total_pages": 1
+		}`)
+	})
+
+	history, resp, err := client.BillingInsights.List(ctx, "do:team:12345678-1234-1234-1234-123456789012", "2025-01-01", "2025-01-31", nil)
+	if err != nil {
+		t.Errorf("BillingInsights.List returned error: %v", err)
+	}
+
+	expectedBillingInsights := []BillingInsightsEntry{
+		{
+			Description:      "droplet name (c-2-4GiB)",
+			GroupDescription: "",
+			Region:           "nyc3",
+			SKU:              "1-DO-DROP-0109",
+			StartDate:        "2025-01-01",
+			TotalAmount:      "0.86",
+			UsageTeamURN:     "do:team:12345678-1234-1234-1234-123456789012",
+		},
+		{
+			Description:      "3 nodes - 4 GB / 2 vCPU / 80 GB SSD",
+			GroupDescription: "kubernetes cluster name",
+			Region:           "nyc3",
+			SKU:              "1-KS-K8SWN-00109",
+			StartDate:        "2025-01-01",
+			TotalAmount:      "2.57",
+			UsageTeamURN:     "do:team:12345678-1234-1234-1234-123456789012",
+		},
+	}
+	entries := history.DataPoints
+	if !reflect.DeepEqual(entries, expectedBillingInsights) {
+		t.Errorf("BillingInsights.List\nBillingInsights: got=%#v\nwant=%#v", entries, expectedBillingInsights)
+	}
+	expectedMeta := &Meta{
+		Page:  1,
+		Total: 2,
+		Pages: 1,
+	}
+	if !reflect.DeepEqual(resp.Meta, expectedMeta) {
+		t.Errorf("BillingInsights.List\nMeta: got=%#v\nwant=%#v", resp.Meta, expectedMeta)
+	}
+}

--- a/billing_insights_test.go
+++ b/billing_insights_test.go
@@ -14,7 +14,6 @@ func TestBillingInsights_List(t *testing.T) {
 	mux.HandleFunc("/v2/billing/do:team:12345678-1234-1234-1234-123456789012/insights/2025-01-01/2025-01-31", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{
-			"current_page": 1,
 			"data_points": [
 				{
 					"description": "droplet name (c-2-4GiB)",
@@ -35,8 +34,9 @@ func TestBillingInsights_List(t *testing.T) {
 					"usage_team_urn": "do:team:12345678-1234-1234-1234-123456789012"
 				}
 			],
-			"total_items": 2,
-			"total_pages": 1
+			"current_page": "1",
+			"total_items": "2",
+			"total_pages": "1"
 		}`)
 	})
 

--- a/godo.go
+++ b/godo.go
@@ -59,6 +59,7 @@ type Client struct {
 	Apps                AppsService
 	Balance             BalanceService
 	BillingHistory      BillingHistoryService
+	BillingInsights     BillingInsightsService
 	CDNs                CDNService
 	Certificates        CertificatesService
 	Databases           DatabasesService
@@ -304,6 +305,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.Apps = &AppsServiceOp{client: c}
 	c.Balance = &BalanceServiceOp{client: c}
 	c.BillingHistory = &BillingHistoryServiceOp{client: c}
+	c.BillingInsights = &BillingInsightsServiceOp{client: c}
 	c.CDNs = &CDNServiceOp{client: c}
 	c.Certificates = &CertificatesServiceOp{client: c}
 	c.Databases = &DatabasesServiceOp{client: c}

--- a/godo_test.go
+++ b/godo_test.go
@@ -82,6 +82,7 @@ func testClientServices(t *testing.T, c *Client) {
 		"Actions",
 		"Balance",
 		"BillingHistory",
+		"BillingInsights",
 		"CDNs",
 		"Domains",
 		"Droplets",


### PR DESCRIPTION
Closes #1064.

Implemented the [BillingInsights.List](https://docs.digitalocean.com/reference/api/reference/billing/#billingInsights_list) endpoint, and added corresponding tests.

I based the structure of `billing_insights.go` and `billing_insights_test.go` off of `billing_history.go` and `billing_history_test.go` respectively, to try and keep things stylistically aligned.

One thing I noticed while working on this: Unlike most other endpoints I've seen so far, page metadata (`CurrentPage`, `TotalItems`, `TotalPages`) are returned as individual string-quoted integers by this endpoint, rather than straight integers in a `Meta` struct. Not sure if this will change in the future, but I added a comment to the `BillingInsights` struct indicating this.