### PR TITLE
microdroplets: add image region, fix image URN, drop https protocol

### DIFF
--- a/micro_droplet_images.go
+++ b/micro_droplet_images.go
@@ -42,6 +42,7 @@ var _ MicroDropletImagesService = &MicroDropletImagesServiceOp{}
 type MicroDropletImage struct {
 	ID      string                  `json:"id,omitempty"`
 	Name    string                  `json:"name,omitempty"`
+	Region  string                  `json:"region,omitempty"`
 	Source  string                  `json:"source,omitempty"`
 	Status  MicroDropletImageStatus `json:"status,omitempty"`
 	Created string                  `json:"created_at,omitempty"`
@@ -51,6 +52,7 @@ type MicroDropletImage struct {
 // MicroDroplet image from a public OCI ref or a DOCR ref.
 type MicroDropletImageCreateRequest struct {
 	Name   string `json:"name"`
+	Region string `json:"region"`
 	Source string `json:"source"`
 }
 
@@ -61,7 +63,7 @@ func (i MicroDropletImage) String() string {
 
 // URN returns the MicroDropletImage ID in a valid DO API URN form.
 func (i MicroDropletImage) URN() string {
-	return ToURN("MicroDropletImage", i.ID)
+	return ToURN("microdroplet_image", i.ID)
 }
 
 // String returns a human-readable description of a MicroDropletImageCreateRequest.

--- a/micro_droplet_images_test.go
+++ b/micro_droplet_images_test.go
@@ -14,8 +14,8 @@ func TestMicroDropletImages_List(t *testing.T) {
 
 	jBlob := `{
 		"images": [
-			{"id": "img-1", "name": "python-3.12", "source": "docker.io/library/python:3.12", "status": "IMAGE_AVAILABLE"},
-			{"id": "img-2", "name": "node-20",     "source": "docker.io/library/node:20",     "status": "IMAGE_IMPORTING"}
+			{"id": "img-1", "name": "python-3.12", "region": "nyc1", "source": "docker.io/library/python:3.12", "status": "IMAGE_AVAILABLE"},
+			{"id": "img-2", "name": "node-20",     "region": "sfo3", "source": "docker.io/library/node:20",     "status": "IMAGE_IMPORTING"}
 		],
 		"meta": {"total": 2}
 	}`
@@ -31,8 +31,8 @@ func TestMicroDropletImages_List(t *testing.T) {
 	}
 
 	expected := []MicroDropletImage{
-		{ID: "img-1", Name: "python-3.12", Source: "docker.io/library/python:3.12", Status: MicroDropletImageStatusAvailable},
-		{ID: "img-2", Name: "node-20", Source: "docker.io/library/node:20", Status: MicroDropletImageStatusImporting},
+		{ID: "img-1", Name: "python-3.12", Region: "nyc1", Source: "docker.io/library/python:3.12", Status: MicroDropletImageStatusAvailable},
+		{ID: "img-2", Name: "node-20", Region: "sfo3", Source: "docker.io/library/node:20", Status: MicroDropletImageStatusImporting},
 	}
 	if !reflect.DeepEqual(images, expected) {
 		t.Errorf("MicroDropletImages.List returned %+v, expected %+v", images, expected)
@@ -73,6 +73,7 @@ func TestMicroDropletImages_Get(t *testing.T) {
 			"image": {
 				"id": "img-1",
 				"name": "python-3.12",
+				"region": "nyc1",
 				"source": "docker.io/library/python:3.12",
 				"status": "IMAGE_AVAILABLE",
 				"created_at": "2026-07-16T10:00:00Z"
@@ -88,6 +89,7 @@ func TestMicroDropletImages_Get(t *testing.T) {
 	expected := &MicroDropletImage{
 		ID:      "img-1",
 		Name:    "python-3.12",
+		Region:  "nyc1",
 		Source:  "docker.io/library/python:3.12",
 		Status:  MicroDropletImageStatusAvailable,
 		Created: "2026-07-16T10:00:00Z",
@@ -113,6 +115,7 @@ func TestMicroDropletImages_Create(t *testing.T) {
 
 	createRequest := &MicroDropletImageCreateRequest{
 		Name:   "python-3.12",
+		Region: "nyc1",
 		Source: "docker.io/library/python:3.12",
 	}
 
@@ -121,6 +124,7 @@ func TestMicroDropletImages_Create(t *testing.T) {
 
 		expected := map[string]interface{}{
 			"name":   "python-3.12",
+			"region": "nyc1",
 			"source": "docker.io/library/python:3.12",
 		}
 		var got map[string]interface{}
@@ -183,7 +187,7 @@ func TestMicroDropletImages_Delete_EmptyID(t *testing.T) {
 
 func TestMicroDropletImage_URN(t *testing.T) {
 	img := MicroDropletImage{ID: "img-1"}
-	want := "do:microdropletimage:img-1"
+	want := "do:microdroplet_image:img-1"
 	if got := img.URN(); got != want {
 		t.Errorf("MicroDropletImage.URN = %q, expected %q", got, want)
 	}

--- a/micro_droplets.go
+++ b/micro_droplets.go
@@ -40,7 +40,6 @@ type MicroDropletHTTPProtocol string
 // Possible HTTP protocol values for a MicroDroplet.
 const (
 	MicroDropletHTTPProtocolHTTP  = MicroDropletHTTPProtocol("http")
-	MicroDropletHTTPProtocolHTTPS = MicroDropletHTTPProtocol("https")
 	MicroDropletHTTPProtocolHTTP2 = MicroDropletHTTPProtocol("http2")
 )
 

--- a/micro_droplets_test.go
+++ b/micro_droplets_test.go
@@ -204,7 +204,7 @@ func TestMicroDroplets_Create(t *testing.T) {
 		AutoPause:    &AutoPauseConfig{Enabled: &autoPauseEnabled, IdleTimeout: "5m"},
 		AutoResume:   &autoResume,
 		HTTPPort:     8080,
-		HTTPProtocol: MicroDropletHTTPProtocolHTTPS,
+		HTTPProtocol: MicroDropletHTTPProtocolHTTP2,
 		Environment:  map[string]string{"FOO": "bar"},
 		Tags:         []string{"env:dev", "team:agents"},
 	}
@@ -225,7 +225,7 @@ func TestMicroDroplets_Create(t *testing.T) {
 			},
 			"auto_resume":   true,
 			"http_port":     float64(8080),
-			"http_protocol": "https",
+			"http_protocol": "http2",
 			"environment":   map[string]interface{}{"FOO": "bar"},
 			"tags":          []interface{}{"env:dev", "team:agents"},
 		}


### PR DESCRIPTION
Aligns the client with the public API contract:

- Image create requires a region (the API returns 400 "region is required" without it) and image responses now carry the region.
- The image URN format is do:microdroplet_image:<uuid>.
- http_protocol supports only http and http2; the https constant is removed since the platform has no HTTPS ingress mode.