### PR TITLE
hosted agents: carry native protocol frames alongside the canonical surface

### DIFF
--- a/hosted_agents.go
+++ b/hosted_agents.go
@@ -24,6 +24,7 @@ const (
 	hostedAgentSessionByIDPath                      = hostedAgentsSessionsBasePath + "/%s"
 	hostedAgentSessionStreamPath                    = hostedAgentSessionByIDPath + "/stream"
 	hostedAgentSessionInputPath                     = hostedAgentSessionByIDPath + "/input"
+	hostedAgentSessionRequestPath                   = hostedAgentSessionByIDPath + "/request"
 	hostedAgentSessionHITLPath                      = hostedAgentSessionByIDPath + "/hitl/%s"
 	hostedAgentSessionSandboxExecPath               = hostedAgentSessionByIDPath + "/sandbox/exec"
 	hostedAgentSessionPausePath                     = hostedAgentSessionByIDPath + "/pause"
@@ -68,6 +69,7 @@ type HostedAgentsService interface {
 	ResumeSession(context.Context, string) (*Response, error)
 	StreamSession(context.Context, string, *HostedAgentSessionStreamOptions) (*HostedAgentSessionStream, *Response, error)
 	SendInput(context.Context, string, *HostedAgentSendInputRequest) (*HostedAgentSendInputResponse, *Response, error)
+	RelayRequest(context.Context, string, *HostedAgentRelayRequest) (*HostedAgentRelayResponse, *Response, error)
 	ResolveHITL(context.Context, string, string, *HostedAgentResolveHITLRequest) (*Response, error)
 	ExecInSandbox(context.Context, string, *HostedAgentSandboxExecRequest) (*HostedAgentSandboxExecResponse, *Response, error)
 	UploadWorkspace(context.Context, string, *HostedAgentWorkspaceUploadRequest) (*HostedAgentWorkspaceUploadResponse, *Response, error)
@@ -315,18 +317,35 @@ type HostedAgentEvent struct {
 	At        Timestamp
 	Kind      HostedAgentEventKind
 	Payload   json.RawMessage
+
+	// SourceEventID is the native event id from the agent runtime before
+	// canonical mapping (Event.source_event_id). Empty when the runtime does
+	// not supply stable ids or the server does not forward it.
+	SourceEventID string
+	// SourceEventType is the native event type label from the agent runtime
+	// (e.g. codex's "item/agentMessage/delta"). Empty when not forwarded.
+	SourceEventType string
+	// SourceRaw is the exact native event bytes the in-sandbox adapter
+	// captured before canonical mapping (Event.source_raw) — for codex, one
+	// JSON-RPC frame as read off the app-server transport. Only present when
+	// the stream was opened with HostedAgentSessionStreamOptions.IncludeRaw
+	// and the server retained the bytes; base64 on the wire (JSON []byte).
+	SourceRaw []byte
 }
 
 // hostedAgentEventWire is the on-the-wire SPI canonical event envelope.
 type hostedAgentEventWire struct {
-	EventID   string               `json:"event_id"`
-	RunID     string               `json:"run_id"`
-	TenantID  string               `json:"tenant_id"`
-	SessionID string               `json:"session_id"`
-	Timestamp Timestamp            `json:"timestamp"`
-	Seq       uint64               `json:"seq"`
-	Type      HostedAgentEventKind `json:"type"`
-	Data      json.RawMessage      `json:"data"`
+	EventID         string               `json:"event_id"`
+	RunID           string               `json:"run_id"`
+	TenantID        string               `json:"tenant_id"`
+	SessionID       string               `json:"session_id"`
+	Timestamp       Timestamp            `json:"timestamp"`
+	Seq             uint64               `json:"seq"`
+	SourceEventID   string               `json:"source_event_id,omitempty"`
+	SourceEventType string               `json:"source_event_type,omitempty"`
+	SourceRaw       []byte               `json:"source_raw,omitempty"`
+	Type            HostedAgentEventKind `json:"type"`
+	Data            json.RawMessage      `json:"data"`
 }
 
 // UnmarshalJSON decodes the SPI canonical event wire shape.
@@ -342,6 +361,9 @@ func (e *HostedAgentEvent) UnmarshalJSON(b []byte) error {
 	e.At = w.Timestamp
 	e.Kind = w.Type
 	e.Payload = w.Data
+	e.SourceEventID = w.SourceEventID
+	e.SourceEventType = w.SourceEventType
+	e.SourceRaw = w.SourceRaw
 	if w.TenantID != "" {
 		id, err := strconv.ParseUint(w.TenantID, 10, 64)
 		if err != nil {
@@ -405,11 +427,28 @@ type HostedAgentSessionStreamOptions struct {
 	// Before. Zero leaves the server's default (200); the server also caps
 	// any request at its replay budget.
 	Limit int
+
+	// IncludeRaw asks the server to include each event's native source bytes
+	// (HostedAgentEvent.SourceRaw) alongside the canonical payload. Raw
+	// payloads meaningfully fatten every event, so this is opt-in; consumers
+	// that don't translate native protocols should leave it off.
+	IncludeRaw bool
 }
 
 // HostedAgentSendInputRequest is the body for POST .../input.
 type HostedAgentSendInputRequest struct {
 	Text string `json:"text"`
+
+	// SourceRaw optionally carries the client's exact native protocol frame
+	// this input was extracted from — for codex, the TUI's turn/start
+	// JSON-RPC message with its full params. The in-sandbox adapter uses it
+	// as the template for the turn it drives, so client intent beyond plain
+	// text (input items, model, effort, approval policy, ...) survives the
+	// text reduction. Only meaningful when the caller speaks the session's
+	// own agent protocol; Text stays required either way. Inbound
+	// counterpart of HostedAgentEvent.SourceRaw. Base64 on the wire per the
+	// proto bytes JSON mapping — encoding/json does that for []byte.
+	SourceRaw []byte `json:"source_raw,omitempty"`
 }
 
 // HostedAgentSendInputResponse is returned by POST .../input.
@@ -417,11 +456,48 @@ type HostedAgentSendInputResponse struct {
 	RunID string `json:"run_id"`
 }
 
+// HostedAgentRelayRequest is the body for POST .../request: one native
+// agent-protocol request frame, forwarded to the session's agent verbatim.
+//
+// Where SendInput carries the one message with a canonical meaning ("the user
+// said something"), this carries everything else a client that speaks the
+// session's own protocol needs to ask — for codex, the requests behind
+// interrupts, slash commands, and model pickers. The control plane never
+// parses the frame; only the in-sandbox adapter decides what is safe to
+// forward.
+type HostedAgentRelayRequest struct {
+	// SourceRaw is the caller's native protocol request frame — for codex, a
+	// single JSON-RPC request object carrying the caller's own id. Named to
+	// match SendInput's field: both mean "my own frame, verbatim". Base64 on
+	// the wire per the proto bytes JSON mapping.
+	SourceRaw []byte `json:"source_raw"`
+}
+
+// HostedAgentRelayResponse is the reply to POST .../request.
+type HostedAgentRelayResponse struct {
+	// SourceRaw is the agent's reply frame, addressed to the caller's own
+	// request id but otherwise verbatim. A protocol-level failure (a JSON-RPC
+	// error object) is a normal reply and arrives here rather than as an HTTP
+	// error.
+	//
+	// Empty means the in-sandbox adapter declined to forward the method.
+	// Callers must answer their own caller on that case rather than waiting
+	// for something that will not come.
+	SourceRaw []byte `json:"source_raw,omitempty"`
+}
+
 // HostedAgentResolveHITLRequest is the body for POST .../hitl/{requestID}.
 type HostedAgentResolveHITLRequest struct {
 	Outcome HostedAgentHITLOutcome      `json:"outcome"`
 	Reason  string                      `json:"reason,omitempty"`
 	Source  HostedAgentResolutionSource `json:"source,omitempty"`
+
+	// SourceRaw is the client's reply in the agent's own protocol, forwarded
+	// to the in-sandbox agent untouched. It carries what Outcome cannot: an
+	// elicitation's content, a tool's requested input, a scope beyond this one
+	// call. Outcome stays required alongside it — it is what the audit trail
+	// records, and what the agent falls back to when this is absent.
+	SourceRaw []byte `json:"source_raw,omitempty"`
 }
 
 // HostedAgentSandboxExecRequest is the body for POST .../sandbox/exec.
@@ -731,6 +807,9 @@ func (s *HostedAgentsServiceOp) StreamSession(ctx context.Context, sessionID str
 		if opt.Limit > 0 {
 			q.Set("limit", strconv.Itoa(opt.Limit))
 		}
+		if opt.IncludeRaw {
+			q.Set("include_raw", "true")
+		}
 		if encoded := q.Encode(); encoded != "" {
 			path += "?" + encoded
 		}
@@ -772,6 +851,30 @@ func (s *HostedAgentsServiceOp) SendInput(ctx context.Context, sessionID string,
 		return nil, nil, err
 	}
 	root := new(HostedAgentSendInputResponse)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root, resp, nil
+}
+
+// RelayRequest forwards one native agent-protocol request frame to the
+// session's agent and returns its reply verbatim. Blocks on the agent, so it
+// is slower than the other session calls; an empty reply means the in-sandbox
+// adapter declined the method.
+func (s *HostedAgentsServiceOp) RelayRequest(ctx context.Context, sessionID string, body *HostedAgentRelayRequest) (*HostedAgentRelayResponse, *Response, error) {
+	if sessionID == "" {
+		return nil, nil, errors.New("hosted agents: session id is required")
+	}
+	if body == nil || len(body.SourceRaw) == 0 {
+		return nil, nil, errors.New("hosted agents: source_raw is required")
+	}
+	path := fmt.Sprintf(hostedAgentSessionRequestPath, sessionID)
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, body)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(HostedAgentRelayResponse)
 	resp, err := s.client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err

--- a/hosted_agents_test.go
+++ b/hosted_agents_test.go
@@ -2,6 +2,7 @@ package godo
 
 import (
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -469,6 +470,149 @@ func TestHostedAgents_ResolveHITL(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
 
+// TestHostedAgents_SendInput_CarriesNativeFrame pins that a caller speaking the
+// session's own protocol can send the frame its text came from, and that Text
+// still rides alongside it for every consumer that reads only the canonical
+// field.
+func TestHostedAgents_SendInput_CarriesNativeFrame(t *testing.T) {
+	setup()
+	defer teardown()
+
+	const frame = `{"jsonrpc":"2.0","method":"turn/start","params":{"model":"gpt-5","input":[{"type":"text","text":"fix the failing test"}]}}`
+
+	mux.HandleFunc("/v2/agents/sessions/sess-abc123/input", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		raw, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		// Bytes are base64 on the wire, per the proto JSON mapping.
+		assert.Contains(t, string(raw), base64.StdEncoding.EncodeToString([]byte(frame)))
+
+		var body HostedAgentSendInputRequest
+		require.NoError(t, json.Unmarshal(raw, &body))
+		assert.Equal(t, "fix the failing test", body.Text)
+		assert.Equal(t, frame, string(body.SourceRaw))
+		fmt.Fprint(w, `{"run_id":"run-001"}`)
+	})
+
+	got, _, err := client.HostedAgents.SendInput(ctx, "sess-abc123", &HostedAgentSendInputRequest{
+		Text:      "fix the failing test",
+		SourceRaw: []byte(frame),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "run-001", got.RunID)
+}
+
+// TestHostedAgents_SendInput_OmitsNativeFrameWhenUnset keeps the field off the
+// wire for every caller that does not speak the agent's protocol.
+func TestHostedAgents_SendInput_OmitsNativeFrameWhenUnset(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/agents/sessions/sess-abc123/input", func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		assert.NotContains(t, string(raw), "source_raw")
+		fmt.Fprint(w, `{"run_id":"run-001"}`)
+	})
+
+	_, _, err := client.HostedAgents.SendInput(ctx, "sess-abc123", &HostedAgentSendInputRequest{
+		Text: "hello",
+	})
+	require.NoError(t, err)
+}
+
+// TestHostedAgents_ResolveHITL_CarriesNativeReply pins the resolve-side raw
+// field: the client answers in the agent's own protocol, and Outcome still
+// rides along as the coarse verdict the audit trail records.
+func TestHostedAgents_ResolveHITL_CarriesNativeReply(t *testing.T) {
+	setup()
+	defer teardown()
+
+	const reply = `{"id":7,"result":{"action":"accept","content":{"answer":"yes"}}}`
+
+	mux.HandleFunc("/v2/agents/sessions/sess-abc123/hitl/req-001", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		var body HostedAgentResolveHITLRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, HostedAgentHITLOutcomeApprove, body.Outcome,
+			"outcome stays required alongside the native reply")
+		assert.Equal(t, reply, string(body.SourceRaw))
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	resp, err := client.HostedAgents.ResolveHITL(ctx, "sess-abc123", "req-001", &HostedAgentResolveHITLRequest{
+		Outcome:   HostedAgentHITLOutcomeApprove,
+		SourceRaw: []byte(reply),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestHostedAgents_RelayRequest(t *testing.T) {
+	setup()
+	defer teardown()
+
+	const (
+		request = `{"jsonrpc":"2.0","id":3,"method":"turn/interrupt","params":{"threadId":"th-1"}}`
+		reply   = `{"jsonrpc":"2.0","id":3,"result":{}}`
+	)
+
+	mux.HandleFunc("/v2/agents/sessions/sess-abc123/request", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		var body HostedAgentRelayRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, request, string(body.SourceRaw))
+		fmt.Fprintf(w, `{"source_raw":%q}`, base64.StdEncoding.EncodeToString([]byte(reply)))
+	})
+
+	got, resp, err := client.HostedAgents.RelayRequest(ctx, "sess-abc123", &HostedAgentRelayRequest{
+		SourceRaw: []byte(request),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, reply, string(got.SourceRaw),
+		"the agent's reply comes back verbatim")
+}
+
+// TestHostedAgents_RelayRequest_ProtocolErrorIsANormalReply: a JSON-RPC error
+// object is the agent answering, not an HTTP failure, so it arrives in the
+// reply rather than as an error.
+func TestHostedAgents_RelayRequest_ProtocolErrorIsANormalReply(t *testing.T) {
+	setup()
+	defer teardown()
+
+	const rpcErr = `{"jsonrpc":"2.0","id":4,"error":{"code":-32601,"message":"method not found"}}`
+
+	mux.HandleFunc("/v2/agents/sessions/sess-abc123/request", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"source_raw":%q}`, base64.StdEncoding.EncodeToString([]byte(rpcErr)))
+	})
+
+	got, _, err := client.HostedAgents.RelayRequest(ctx, "sess-abc123", &HostedAgentRelayRequest{
+		SourceRaw: []byte(`{"jsonrpc":"2.0","id":4,"method":"nope"}`),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, rpcErr, string(got.SourceRaw))
+}
+
+// TestHostedAgents_RelayRequest_DeclinedMethodYieldsEmptyReply: the adapter
+// refusing to forward a method is reported as an empty reply, which callers
+// must distinguish from an answer.
+func TestHostedAgents_RelayRequest_DeclinedMethodYieldsEmptyReply(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/agents/sessions/sess-abc123/request", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{}`)
+	})
+
+	got, _, err := client.HostedAgents.RelayRequest(ctx, "sess-abc123", &HostedAgentRelayRequest{
+		SourceRaw: []byte(`{"jsonrpc":"2.0","id":5,"method":"thread/close"}`),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Empty(t, got.SourceRaw)
+}
+
 func TestHostedAgents_StreamSession(t *testing.T) {
 	setup()
 	defer teardown()
@@ -522,6 +666,62 @@ func TestHostedAgentEvent_UnmarshalSPIWire(t *testing.T) {
 	assert.Equal(t, HostedAgentEventKindTokenChunk, ev.Kind)
 	assert.False(t, ev.At.IsZero())
 	assert.JSONEq(t, `{"text":"Paris"}`, string(ev.Payload))
+
+	assert.Empty(t, ev.SourceRaw, "absent source fields decode to zero, not an error")
+	assert.Empty(t, ev.SourceEventID)
+	assert.Empty(t, ev.SourceEventType)
+}
+
+// TestHostedAgentEvent_UnmarshalSPIWire_SourceFields pins the native-provenance
+// fields: the runtime's own event id and type label, and the exact pre-mapping
+// bytes (base64 on the wire).
+func TestHostedAgentEvent_UnmarshalSPIWire_SourceFields(t *testing.T) {
+	const native = `{"jsonrpc":"2.0","method":"item/agentMessage/delta","params":{"delta":"Paris"}}`
+
+	frame := fmt.Sprintf(
+		`{"event_id":"ev-9","run_id":"run-7","tenant_id":"120","session_id":"sess-1","timestamp":"2026-06-05T12:56:24Z","seq":3,"type":"run.token_delta","data":{"text":"Paris"},"source_event_id":"native-1","source_event_type":"item/agentMessage/delta","source_raw":%q}`,
+		base64.StdEncoding.EncodeToString([]byte(native)),
+	)
+
+	var ev HostedAgentEvent
+	require.NoError(t, json.Unmarshal([]byte(frame), &ev))
+
+	assert.Equal(t, "native-1", ev.SourceEventID)
+	assert.Equal(t, "item/agentMessage/delta", ev.SourceEventType)
+	assert.Equal(t, native, string(ev.SourceRaw))
+	// The canonical fields are unaffected by the presence of raw.
+	assert.Equal(t, HostedAgentEventKindTokenChunk, ev.Kind)
+	assert.JSONEq(t, `{"text":"Paris"}`, string(ev.Payload))
+}
+
+func TestHostedAgents_StreamSession_IncludeRaw(t *testing.T) {
+	setup()
+	defer teardown()
+
+	const native = `{"jsonrpc":"2.0","method":"item/agentMessage/delta","params":{"delta":"hello"}}`
+
+	mux.HandleFunc("/v2/agents/sessions/sess-abc123/stream", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		assert.Equal(t, "true", r.URL.Query().Get("include_raw"))
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, ": connected\n\n")
+		fmt.Fprintf(w,
+			"id: ev-1\nevent: run.token_delta\ndata: {\"event_id\":\"ev-1\",\"run_id\":\"run-1\",\"tenant_id\":\"42\",\"session_id\":\"sess-abc123\",\"timestamp\":\"2026-03-01T12:01:00Z\",\"seq\":1,\"type\":\"run.token_delta\",\"data\":{\"text\":\"hello\"},\"source_event_type\":\"item/agentMessage/delta\",\"source_raw\":%q}\n\n",
+			base64.StdEncoding.EncodeToString([]byte(native)),
+		)
+	})
+
+	stream, _, err := client.HostedAgents.StreamSession(ctx, "sess-abc123", &HostedAgentSessionStreamOptions{
+		IncludeRaw: true,
+	})
+	require.NoError(t, err)
+	defer stream.Close()
+
+	require.True(t, stream.Next())
+	ev := stream.Current()
+	assert.Equal(t, native, string(ev.SourceRaw))
+	assert.Equal(t, "item/agentMessage/delta", ev.SourceEventType)
+	assert.NoError(t, stream.Err())
 }
 
 func TestHostedAgents_ListSessions_PageToken(t *testing.T) {
@@ -673,6 +873,7 @@ func TestHostedAgents_StreamSession_NoPagingParamsWhenUnset(t *testing.T) {
 		q := r.URL.Query()
 		assert.False(t, q.Has("before"))
 		assert.False(t, q.Has("limit"))
+		assert.False(t, q.Has("include_raw"))
 		w.Header().Set("Content-Type", "text/event-stream")
 		fmt.Fprint(w, ": connected\n\n")
 	})
@@ -722,6 +923,18 @@ func TestHostedAgents_ValidationErrors(t *testing.T) {
 
 	_, err = client.HostedAgents.ResolveHITL(ctx, "sess-abc123", "req-001", &HostedAgentResolveHITLRequest{})
 	require.EqualError(t, err, "hosted agents: outcome is required")
+
+	_, _, err = client.HostedAgents.RelayRequest(ctx, "", &HostedAgentRelayRequest{
+		SourceRaw: []byte(`{}`),
+	})
+	require.EqualError(t, err, "hosted agents: session id is required")
+
+	_, _, err = client.HostedAgents.RelayRequest(ctx, "sess-abc123", nil)
+	require.EqualError(t, err, "hosted agents: source_raw is required")
+
+	// A relay with nothing to relay would block on the agent for no reason.
+	_, _, err = client.HostedAgents.RelayRequest(ctx, "sess-abc123", &HostedAgentRelayRequest{})
+	require.EqualError(t, err, "hosted agents: source_raw is required")
 
 	_, _, err = client.HostedAgents.ExecInSandbox(ctx, "sess-abc123", &HostedAgentSandboxExecRequest{})
 	require.EqualError(t, err, "hosted agents: argv is required")


### PR DESCRIPTION
## Why

The canonical event and input surface is a lossy rendering of what the agent runtimes actually speak. That is the right trade for a client that wants "the agent said something", and the wrong one for a client that speaks the session's own protocol and is trying to reproduce its behaviour faithfully — which is what `doctl agents start-proxy` does for the codex TUI.

Concretely, the canonical surface cannot express:

- a `turn/start`'s real params (input items, model, effort, approval policy) — they are flattened to plain text
- the requests behind interrupt, slash commands and model pickers — there is no endpoint for a request that isn't user input
- a gated-request answer richer than approve/reject — an MCP elicitation wants content back, a tool asking for user input wants answers

These additions let such a client opt into the native frames. Nothing changes for callers that don't.

## What

**Outbound.** `HostedAgentEvent` gains `SourceEventID`, `SourceEventType` and `SourceRaw` — the runtime's own event id, its type label, and the exact pre-mapping bytes. Raw payloads meaningfully fatten every event, so they are opt-in behind `HostedAgentSessionStreamOptions.IncludeRaw` (`include_raw=true`).

**Inbound.** `HostedAgentSendInputRequest` and `HostedAgentResolveHITLRequest` gain `SourceRaw`, so the frame an input was reduced from, and a reply the outcome enum cannot express, survive the trip. `Text` and `Outcome` stay required alongside them: they remain what non-native clients send, and `Outcome` is what the audit trail records.

**New.** `RelayRequest` (`POST /v2/agents/sessions/{id}/request`) forwards one native request frame and returns the agent's reply verbatim. A JSON-RPC error object is the agent *answering* and arrives as a normal reply; an **empty** reply means the in-sandbox adapter declined the method, which callers must not mistake for an answer.

Every field is additive and `omitempty`, so existing callers see no change on the wire.


godo addition | Who calls it in doctl | What the user loses without it
-- | -- | --
HostedAgentEvent.SourceRaw + IncludeRaw | the facade's stream open, tryRawPassthrough, tryNativeApproval | The proxy can't receive native frames at all. Every event falls back to canonical reconstruction — no raw passthrough, period
RelayRequest (new method) | the facade's request relay | Esc-to-interrupt hangs the TUI. turn/interrupt is a JSON-RPC request the TUI blocks on; with no way to relay it, it's never answered. Same for the model picker and slash-command plumbing
HostedAgentSendInputRequest.SourceRaw | turn/start handling | The TUI's turn params — model, effort, input items — get flattened to plain text. This is what caused the original runtimeWorkspaceRoots failures and "edit a file" hangs
HostedAgentResolveHITLRequest.SourceRaw | answerNativeApproval | Approval answers collapse back to approve/reject. The acceptWithExecpolicyAmendment you sent through the TUI today has no field to travel in — MCP elicitations and tool questions become dead ends again



## Notes for review

- Based on `OHS_endpoints` rather than `main` -> where the hosted agents surface lives and where the betas are cut from.
- No `CHANGELOG.md` / `godo.go` change, per `CONTRIBUTING.md` -> those belong to the release PR.
- Server side is implemented; this is the client half of that work.

## Test plan

- [x] `go test .` — full suite green
- [x] 65 hosted-agent tests pass; `go vet` and `gofmt` clean
- [x] New coverage: relay round-trip; JSON-RPC error as a normal reply; declined-method empty reply; native frame on input and on resolve; `include_raw` present when set and absent when unset; `source_*` decode, including absent-fields-decode-to-zero
- [ ] Exercised end to end against a live harness session via the codex proxy (done against a locally patched vendor copy of this change)