### PR TITLE
hosted agents: add provider OAuth connect endpoints

### DIFF
--- a/examples/hosted-agents/auth/main.go
+++ b/examples/hosted-agents/auth/main.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/digitalocean/godo"
+)
+
+func main() {
+	provider := os.Getenv("HOSTED_AGENT_PROVIDER")
+	if provider == "" {
+		provider = "github"
+	}
+
+	client := mustClient()
+	ctx := context.Background()
+
+	start, _, err := client.HostedAgents.StartProviderAuth(ctx, provider)
+	if err != nil {
+		die(err)
+	}
+
+	if start.Status == "success" {
+		fmt.Printf("%s is already connected for your team\n", provider)
+		return
+	}
+
+	fmt.Printf("To connect %s, open this URL and authorize access:\n\n  %s\n\n", provider, start.ConnectURL)
+	if start.VerificationCode != "" {
+		fmt.Printf("Verify the page shows code: %s\n\n", start.VerificationCode)
+	}
+
+	fmt.Println("Waiting for authorization to complete...")
+	for {
+		poll, _, err := client.HostedAgents.PollProviderAuth(ctx, provider, start.PollURL)
+		if err != nil {
+			die(err)
+		}
+		if poll.Status == "success" {
+			fmt.Printf("%s connected successfully\n", provider)
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
+
+func mustClient() *godo.Client {
+	token := os.Getenv("DIGITALOCEAN_TOKEN")
+	if token == "" {
+		fmt.Fprintln(os.Stderr, "DIGITALOCEAN_TOKEN is required")
+		os.Exit(2)
+	}
+	client := godo.NewFromToken(token)
+	if baseURL := os.Getenv("DIGITALOCEAN_API_URL"); baseURL != "" {
+		u, err := url.Parse(baseURL)
+		if err != nil {
+			panic(err)
+		}
+		client.BaseURL = u
+	}
+	return client
+}
+
+func die(err error) {
+	fmt.Fprintln(os.Stderr, err)
+	os.Exit(1)
+}

--- a/hosted_agents.go
+++ b/hosted_agents.go
@@ -444,21 +444,21 @@ type HostedAgentResolveHITLRequest struct {
 // authorization handle is never exposed: tokens are exchanged server-side at
 // session time.
 type HostedAgentProviderAuthStart struct {
-	Provider         string `json:"provider"`
-	Status           string `json:"status"`
-	ConnectURL       string `json:"connect_url,omitempty"`
-	PollURL          string `json:"poll_url,omitempty"`
-	VerificationCode string `json:"verification_code,omitempty"`
-	ExpiresAt        string `json:"expires_at,omitempty"`
+	Provider         string     `json:"provider"`
+	Status           string     `json:"status"`
+	ConnectURL       string     `json:"connect_url,omitempty"`
+	PollURL          string     `json:"poll_url,omitempty"`
+	VerificationCode string     `json:"verification_code,omitempty"`
+	ExpiresAt        *Timestamp `json:"expires_at,omitempty"`
 }
 
 // HostedAgentProviderAuthPoll is returned by GET
 // /v2/agents/auth/{provider}/poll. It reports only whether authorization has
 // completed ("pending" or "success"); no secret is returned.
 type HostedAgentProviderAuthPoll struct {
-	Provider  string `json:"provider"`
-	Status    string `json:"status"`
-	ExpiresAt string `json:"expires_at,omitempty"`
+	Provider  string     `json:"provider"`
+	Status    string     `json:"status"`
+	ExpiresAt *Timestamp `json:"expires_at,omitempty"`
 }
 
 // HostedAgentSandboxExecRequest is the body for POST .../sandbox/exec.

--- a/hosted_agents.go
+++ b/hosted_agents.go
@@ -36,6 +36,10 @@ const (
 	hostedAgentSessionWorkspaceTransferCommitPath   = hostedAgentSessionWorkspaceTransferByIDPath + "/commit"
 	hostedAgentSessionWorkspaceTransferCancelPath   = hostedAgentSessionWorkspaceTransferByIDPath + "/cancel"
 
+	// Team-scoped external-provider (e.g. GitHub) OAuth connect flow.
+	hostedAgentProviderAuthPath     = "/v2/agents/auth/%s"
+	hostedAgentProviderAuthPollPath = hostedAgentProviderAuthPath + "/poll"
+
 	workspaceContentSHA256Header = "X-Content-Sha256"
 	workspaceIsArchiveHeader     = "X-Workspace-Is-Archive"
 	workspaceSizeBytesHeader     = "X-Workspace-Size-Bytes"
@@ -69,6 +73,14 @@ type HostedAgentsService interface {
 	StreamSession(context.Context, string, *HostedAgentSessionStreamOptions) (*HostedAgentSessionStream, *Response, error)
 	SendInput(context.Context, string, *HostedAgentSendInputRequest) (*HostedAgentSendInputResponse, *Response, error)
 	ResolveHITL(context.Context, string, string, *HostedAgentResolveHITLRequest) (*Response, error)
+
+	// StartProviderAuth begins (or resumes) the team-scoped connect flow for an
+	// external provider (e.g. "github"). The team is derived from the
+	// authenticated principal; there is no request body.
+	StartProviderAuth(context.Context, string) (*HostedAgentProviderAuthStart, *Response, error)
+	// PollProviderAuth reports whether a pending connect link has been
+	// authorized. pollURL is the PollURL returned by StartProviderAuth.
+	PollProviderAuth(context.Context, string, string) (*HostedAgentProviderAuthPoll, *Response, error)
 	ExecInSandbox(context.Context, string, *HostedAgentSandboxExecRequest) (*HostedAgentSandboxExecResponse, *Response, error)
 	UploadWorkspace(context.Context, string, *HostedAgentWorkspaceUploadRequest) (*HostedAgentWorkspaceUploadResponse, *Response, error)
 	DownloadWorkspace(context.Context, string, *HostedAgentWorkspaceDownloadRequest) (*HostedAgentWorkspaceDownload, *Response, error)
@@ -422,6 +434,31 @@ type HostedAgentResolveHITLRequest struct {
 	Outcome HostedAgentHITLOutcome      `json:"outcome"`
 	Reason  string                      `json:"reason,omitempty"`
 	Source  HostedAgentResolutionSource `json:"source,omitempty"`
+}
+
+// HostedAgentProviderAuthStart is returned by POST /v2/agents/auth/{provider}.
+// Status is "pending" when the user must still authorize in a browser
+// (ConnectURL/PollURL/VerificationCode are set), or "success" when the team is
+// already connected (those fields are empty). It is a free-form connect-flow
+// status, distinct from the HostedAgentProviderAuthState session field. The
+// authorization handle is never exposed: tokens are exchanged server-side at
+// session time.
+type HostedAgentProviderAuthStart struct {
+	Provider         string `json:"provider"`
+	Status           string `json:"status"`
+	ConnectURL       string `json:"connect_url,omitempty"`
+	PollURL          string `json:"poll_url,omitempty"`
+	VerificationCode string `json:"verification_code,omitempty"`
+	ExpiresAt        string `json:"expires_at,omitempty"`
+}
+
+// HostedAgentProviderAuthPoll is returned by GET
+// /v2/agents/auth/{provider}/poll. It reports only whether authorization has
+// completed ("pending" or "success"); no secret is returned.
+type HostedAgentProviderAuthPoll struct {
+	Provider  string `json:"provider"`
+	Status    string `json:"status"`
+	ExpiresAt string `json:"expires_at,omitempty"`
 }
 
 // HostedAgentSandboxExecRequest is the body for POST .../sandbox/exec.
@@ -799,6 +836,52 @@ func (s *HostedAgentsServiceOp) ResolveHITL(ctx context.Context, sessionID, requ
 		return nil, err
 	}
 	return s.client.Do(ctx, req, nil)
+}
+
+// StartProviderAuth begins (or resumes) the team-scoped connect flow for an
+// external provider. The server derives the team from the authenticated
+// principal, so the POST carries an empty JSON object body.
+func (s *HostedAgentsServiceOp) StartProviderAuth(ctx context.Context, provider string) (*HostedAgentProviderAuthStart, *Response, error) {
+	if provider == "" {
+		return nil, nil, errors.New("hosted agents: provider is required")
+	}
+	path := fmt.Sprintf(hostedAgentProviderAuthPath, provider)
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, struct{}{})
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(HostedAgentProviderAuthStart)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root, resp, nil
+}
+
+// PollProviderAuth checks whether a pending connect link has been authorized.
+// pollURL is the PollURL returned by StartProviderAuth; it is forwarded to the
+// server as the poll_url query parameter.
+func (s *HostedAgentsServiceOp) PollProviderAuth(ctx context.Context, provider, pollURL string) (*HostedAgentProviderAuthPoll, *Response, error) {
+	if provider == "" {
+		return nil, nil, errors.New("hosted agents: provider is required")
+	}
+	if pollURL == "" {
+		return nil, nil, errors.New("hosted agents: poll url is required")
+	}
+	path := fmt.Sprintf(hostedAgentProviderAuthPollPath, provider)
+	q := url.Values{}
+	q.Set("poll_url", pollURL)
+	path += "?" + q.Encode()
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(HostedAgentProviderAuthPoll)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root, resp, nil
 }
 
 // ExecInSandbox runs a command inside the session sandbox.

--- a/hosted_agents_test.go
+++ b/hosted_agents_test.go
@@ -1152,3 +1152,82 @@ func TestHostedAgents_GetSession_EmptyBody(t *testing.T) {
 	require.EqualError(t, err, "hosted agents: get session returned no session")
 	require.NotNil(t, resp)
 }
+
+func TestHostedAgents_StartProviderAuth(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/agents/auth/github", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		fmt.Fprint(w, `{
+			"provider": "github",
+			"status": "pending",
+			"connect_url": "https://cloud.digitalocean.com/security/connectlinks/confirm?token=abc",
+			"poll_url": "https://cloud.digitalocean.com/api/v1/security/connectlinks/poll?token=def",
+			"verification_code": "k5r2cprq",
+			"expires_at": "2036-08-10T10:44:32Z"
+		}`)
+	})
+
+	got, resp, err := client.HostedAgents.StartProviderAuth(ctx, "github")
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, &HostedAgentProviderAuthStart{
+		Provider:         "github",
+		Status:           "pending",
+		ConnectURL:       "https://cloud.digitalocean.com/security/connectlinks/confirm?token=abc",
+		PollURL:          "https://cloud.digitalocean.com/api/v1/security/connectlinks/poll?token=def",
+		VerificationCode: "k5r2cprq",
+		ExpiresAt:        "2036-08-10T10:44:32Z",
+	}, got)
+}
+
+func TestHostedAgents_StartProviderAuth_AlreadyConnected(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/agents/auth/github", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		fmt.Fprint(w, `{"provider":"github","status":"success"}`)
+	})
+
+	got, _, err := client.HostedAgents.StartProviderAuth(ctx, "github")
+	require.NoError(t, err)
+	assert.Equal(t, "success", got.Status)
+	assert.Empty(t, got.ConnectURL)
+	assert.Empty(t, got.PollURL)
+}
+
+func TestHostedAgents_PollProviderAuth(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/agents/auth/github/poll", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		assert.Equal(t, "https://cloud.digitalocean.com/api/v1/security/connectlinks/poll?token=def", r.URL.Query().Get("poll_url"))
+		fmt.Fprint(w, `{"provider":"github","status":"success","expires_at":"2036-08-10T10:44:32Z"}`)
+	})
+
+	got, resp, err := client.HostedAgents.PollProviderAuth(ctx, "github", "https://cloud.digitalocean.com/api/v1/security/connectlinks/poll?token=def")
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, &HostedAgentProviderAuthPoll{
+		Provider:  "github",
+		Status:    "success",
+		ExpiresAt: "2036-08-10T10:44:32Z",
+	}, got)
+}
+
+func TestHostedAgents_ProviderAuth_RequiredArgs(t *testing.T) {
+	setup()
+	defer teardown()
+
+	_, _, err := client.HostedAgents.StartProviderAuth(ctx, "")
+	require.EqualError(t, err, "hosted agents: provider is required")
+
+	_, _, err = client.HostedAgents.PollProviderAuth(ctx, "", "https://example.com/poll")
+	require.EqualError(t, err, "hosted agents: provider is required")
+
+	_, _, err = client.HostedAgents.PollProviderAuth(ctx, "github", "")
+	require.EqualError(t, err, "hosted agents: poll url is required")
+}

--- a/hosted_agents_test.go
+++ b/hosted_agents_test.go
@@ -1178,7 +1178,7 @@ func TestHostedAgents_StartProviderAuth(t *testing.T) {
 		ConnectURL:       "https://cloud.digitalocean.com/security/connectlinks/confirm?token=abc",
 		PollURL:          "https://cloud.digitalocean.com/api/v1/security/connectlinks/poll?token=def",
 		VerificationCode: "k5r2cprq",
-		ExpiresAt:        "2036-08-10T10:44:32Z",
+		ExpiresAt:        &Timestamp{Time: time.Date(2036, 8, 10, 10, 44, 32, 0, time.UTC)},
 	}, got)
 }
 
@@ -1214,7 +1214,7 @@ func TestHostedAgents_PollProviderAuth(t *testing.T) {
 	assert.Equal(t, &HostedAgentProviderAuthPoll{
 		Provider:  "github",
 		Status:    "success",
-		ExpiresAt: "2036-08-10T10:44:32Z",
+		ExpiresAt: &Timestamp{Time: time.Date(2036, 8, 10, 10, 44, 32, 0, time.UTC)},
 	}, got)
 }
 


### PR DESCRIPTION
## Summary
Adds SDK support for the team-scoped external-provider (e.g. GitHub) OAuth connect flow used to authorize git operations in hosted agent sessions. Targets `OHS_endpoints` (the hosted-agents integration branch), consistent with the rest of the hosted-agents surface.

New on `HostedAgentsService` / `HostedAgentsServiceOp`:
- `StartProviderAuth(ctx, provider)` — `POST /v2/agents/auth/{provider}` (empty body; team derived from the authenticated principal). Returns `connect_url` / `poll_url` / `verification_code` for the browser authorization step, or `status: "success"` when the team is already connected.
- `PollProviderAuth(ctx, provider, pollURL)` — `GET /v2/agents/auth/{provider}/poll?poll_url=...`; reports only `pending` / `success`.

Also adds the `HostedAgentProviderAuthStart` / `HostedAgentProviderAuthPoll` response types (status is a free-form connect-flow string, deliberately distinct from the existing `HostedAgentProviderAuthState` session enum), unit tests, and an `examples/hosted-agents/auth` example.

The authorization handle is never exposed by these endpoints; tokens are exchanged server-side at session time.

## Test plan
- [x] `go build ./...`
- [x] `go vet .`
- [x] `gofmt -l` clean
- [x] `go test .` (full package) passes, including new start/poll/already-connected/required-arg tests
- [x] `examples/hosted-agents/auth` builds

Made with [Cursor](https://cursor.com)