### PR TITLE
Add Hosted Agents Agent Configs client + config-backed session create (MARSOHS-741)

### DIFF
--- a/hosted_agent_configs.go
+++ b/hosted_agent_configs.go
@@ -118,8 +118,9 @@ func (s *HostedAgentsServiceOp) GetAgentConfig(ctx context.Context, configID str
 	return root.Config, resp, nil
 }
 
-// CreateAgentConfig creates an immutable Agent Config. When the manifest
-// declares secret slots, Secrets / OAuthAssignments must cover them.
+// CreateAgentConfig creates an immutable Agent Config from a name and
+// agents.yaml. Secret values belong in spec.secrets[].value inside the
+// manifest, not as separate request fields.
 func (s *HostedAgentsServiceOp) CreateAgentConfig(ctx context.Context, create *HostedAgentConfigCreateRequest) (*HostedAgentConfig, *Response, error) {
 	if create == nil {
 		return nil, nil, errors.New("hosted agents: create request is required")

--- a/hosted_agent_configs.go
+++ b/hosted_agent_configs.go
@@ -1,0 +1,175 @@
+package godo
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+const (
+	hostedAgentsConfigsBasePath   = "/v2/agents/configs"
+	hostedAgentConfigByIDPath     = hostedAgentsConfigsBasePath + "/%s"
+	hostedAgentConfigSessionsPath = hostedAgentConfigByIDPath + "/sessions"
+)
+
+// HostedAgentConfigCredentialSlot is redacted credential metadata on GET/create.
+// It echoes only the manifest's declaration for the slot; secret values are
+// never returned. Whether a slot is fulfilled is implied by Source: a
+// tenantSecret is always stored at create, and an oauth slot is a declaration
+// only until oauth brokering is implemented.
+type HostedAgentConfigCredentialSlot struct {
+	Name     string `json:"name"`
+	Source   string `json:"source,omitempty"`
+	Provider string `json:"provider,omitempty"`
+}
+
+// HostedAgentConfig is an immutable team-scoped Agent Config.
+type HostedAgentConfig struct {
+	ID                     string                            `json:"id"`
+	Name                   string                            `json:"name"`
+	AgentSpecSchemaVersion string                            `json:"agentspec_schema_version"`
+	Manifest               json.RawMessage                   `json:"manifest"`
+	ContentHash            string                            `json:"content_hash"`
+	CreatedBy              string                            `json:"created_by"`
+	CreatedAt              Timestamp                         `json:"created_at"`
+	UpdatedAt              Timestamp                         `json:"updated_at"`
+	Credentials            []HostedAgentConfigCredentialSlot `json:"credentials,omitempty"`
+	// Warnings carries non-fatal create-time advisories computed from the
+	// manifest. It is populated on the create response only.
+	Warnings []string `json:"warnings,omitempty"`
+}
+
+// HostedAgentConfigSummary is the list view (no manifest / credentials).
+type HostedAgentConfigSummary struct {
+	ID                     string    `json:"id"`
+	Name                   string    `json:"name"`
+	AgentSpecSchemaVersion string    `json:"agentspec_schema_version"`
+	ContentHash            string    `json:"content_hash"`
+	CreatedBy              string    `json:"created_by"`
+	CreatedAt              Timestamp `json:"created_at"`
+	UpdatedAt              Timestamp `json:"updated_at"`
+}
+
+// HostedAgentConfigCreateRequest is the body for POST /v2/agents/configs.
+// Credentials are not request fields: every secret is declared in the manifest
+// under spec.secrets, and a tenantSecret slot carries its plaintext in a
+// write-only spec.secrets[].value that is extracted server-side and never
+// persisted or returned. Sending the retired secrets or oauth_assignments maps
+// is rejected with a 400.
+type HostedAgentConfigCreateRequest struct {
+	Name         string `json:"name"`
+	ManifestYAML string `json:"manifest_yaml"`
+}
+
+// HostedAgentConfigListOptions specifies optional list pagination.
+type HostedAgentConfigListOptions struct {
+	PageToken string `url:"page_token,omitempty"`
+	PageSize  int    `url:"page_size,omitempty"`
+}
+
+// HostedAgentConfigsListResponse is returned by GET /v2/agents/configs.
+type HostedAgentConfigsListResponse struct {
+	Configs       []HostedAgentConfigSummary `json:"configs"`
+	NextPageToken string                     `json:"next_page_token"`
+}
+
+type hostedAgentConfigRoot struct {
+	Config *HostedAgentConfig `json:"config"`
+}
+
+// ListAgentConfigs lists active Agent Configs for the caller's team.
+func (s *HostedAgentsServiceOp) ListAgentConfigs(ctx context.Context, opt *HostedAgentConfigListOptions) (*HostedAgentConfigsListResponse, *Response, error) {
+	path, err := addOptions(hostedAgentsConfigsBasePath, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(HostedAgentConfigsListResponse)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root, resp, nil
+}
+
+// GetAgentConfig returns one Agent Config with redacted credential slots.
+func (s *HostedAgentsServiceOp) GetAgentConfig(ctx context.Context, configID string) (*HostedAgentConfig, *Response, error) {
+	if configID == "" {
+		return nil, nil, errors.New("hosted agents: config id is required")
+	}
+	path := fmt.Sprintf(hostedAgentConfigByIDPath, configID)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(hostedAgentConfigRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if root.Config == nil {
+		return nil, resp, errors.New("hosted agents: get config returned no config")
+	}
+	return root.Config, resp, nil
+}
+
+// CreateAgentConfig creates an immutable Agent Config. When the manifest
+// declares secret slots, Secrets / OAuthAssignments must cover them.
+func (s *HostedAgentsServiceOp) CreateAgentConfig(ctx context.Context, create *HostedAgentConfigCreateRequest) (*HostedAgentConfig, *Response, error) {
+	if create == nil {
+		return nil, nil, errors.New("hosted agents: create request is required")
+	}
+	req, err := s.client.NewRequest(ctx, http.MethodPost, hostedAgentsConfigsBasePath, create)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(hostedAgentConfigRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if root.Config == nil {
+		return nil, resp, errors.New("hosted agents: create config returned no config")
+	}
+	return root.Config, resp, nil
+}
+
+// DeleteAgentConfig soft-deletes an Agent Config. The API returns HTTP 204.
+func (s *HostedAgentsServiceOp) DeleteAgentConfig(ctx context.Context, configID string) (*Response, error) {
+	if configID == "" {
+		return nil, errors.New("hosted agents: config id is required")
+	}
+	path := fmt.Sprintf(hostedAgentConfigByIDPath, configID)
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(ctx, req, nil)
+}
+
+// ListAgentConfigSessions lists sessions created from a config.
+func (s *HostedAgentsServiceOp) ListAgentConfigSessions(ctx context.Context, configID string, opt *HostedAgentSessionListOptions) (*HostedAgentSessionsListResponse, *Response, error) {
+	if configID == "" {
+		return nil, nil, errors.New("hosted agents: config id is required")
+	}
+	path := fmt.Sprintf(hostedAgentConfigSessionsPath, configID)
+	path, err := addOptions(path, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(HostedAgentSessionsListResponse)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root, resp, nil
+}

--- a/hosted_agent_configs_test.go
+++ b/hosted_agent_configs_test.go
@@ -1,0 +1,153 @@
+package godo
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var hostedAgentConfig = HostedAgentConfig{
+	ID:                     "019fb39c-14d9-7080-933e-b9b90e25acda",
+	Name:                   "support-agent",
+	AgentSpecSchemaVersion: "agents.digitalocean.com/v1alpha1",
+	Manifest:               json.RawMessage(`{"apiVersion":"agents.digitalocean.com/v1alpha1","kind":"Agent"}`),
+	ContentHash:            "75803fef24dc731824ecd4a1853c76153c7d8503534092b94da3ca3f31a882f4",
+	CreatedBy:              "user-1",
+	CreatedAt:              Timestamp{Time: time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)},
+	UpdatedAt:              Timestamp{Time: time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)},
+	Credentials: []HostedAgentConfigCredentialSlot{
+		{Name: "OPENAI_API_KEY", Source: "tenantSecret", Provider: "openai"},
+	},
+}
+
+const hostedAgentConfigJSON = `
+{
+	"id": "019fb39c-14d9-7080-933e-b9b90e25acda",
+	"name": "support-agent",
+	"agentspec_schema_version": "agents.digitalocean.com/v1alpha1",
+	"manifest": {"apiVersion":"agents.digitalocean.com/v1alpha1","kind":"Agent"},
+	"content_hash": "75803fef24dc731824ecd4a1853c76153c7d8503534092b94da3ca3f31a882f4",
+	"created_by": "user-1",
+	"created_at": "2026-08-01T12:00:00Z",
+	"updated_at": "2026-08-01T12:00:00Z",
+	"credentials": [
+		{"name":"OPENAI_API_KEY","source":"tenantSecret","provider":"openai"}
+	]
+}
+`
+
+func TestHostedAgents_ListAgentConfigs(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/agents/configs", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		assert.Equal(t, "10", r.URL.Query().Get("page_size"))
+		fmt.Fprint(w, `{"configs":[{"id":"019fb39c-14d9-7080-933e-b9b90e25acda","name":"support-agent","agentspec_schema_version":"agents.digitalocean.com/v1alpha1","content_hash":"75803fef24dc731824ecd4a1853c76153c7d8503534092b94da3ca3f31a882f4","created_by":"user-1","created_at":"2026-08-01T12:00:00Z","updated_at":"2026-08-01T12:00:00Z"}],"next_page_token":"abc"}`)
+	})
+
+	got, resp, err := client.HostedAgents.ListAgentConfigs(ctx, &HostedAgentConfigListOptions{PageSize: 10})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Len(t, got.Configs, 1)
+	assert.Equal(t, "support-agent", got.Configs[0].Name)
+	assert.Equal(t, "abc", got.NextPageToken)
+}
+
+func TestHostedAgents_GetAgentConfig(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/agents/configs/019fb39c-14d9-7080-933e-b9b90e25acda", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprintf(w, `{"config":%s}`, hostedAgentConfigJSON)
+	})
+
+	got, resp, err := client.HostedAgents.GetAgentConfig(ctx, hostedAgentConfig.ID)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, hostedAgentConfig.ID, got.ID)
+	assert.Equal(t, hostedAgentConfig.Name, got.Name)
+	require.Len(t, got.Credentials, 1)
+	assert.Equal(t, "OPENAI_API_KEY", got.Credentials[0].Name)
+	assert.Equal(t, "tenantSecret", got.Credentials[0].Source)
+	assert.NotContains(t, string(mustMarshal(t, got)), "plaintext")
+	assert.NotContains(t, string(mustMarshal(t, got)), `"configured"`)
+}
+
+func TestHostedAgents_CreateAgentConfig(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/agents/configs", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		var body HostedAgentConfigCreateRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "support-agent", body.Name)
+		assert.Contains(t, body.ManifestYAML, "apiVersion:")
+		// Credentials are declared inline in the manifest under spec.secrets;
+		// there is no separate secrets field on the request body anymore.
+		assert.Contains(t, body.ManifestYAML, "spec:")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprintf(w, `{"config":%s}`, hostedAgentConfigJSON)
+	})
+
+	got, resp, err := client.HostedAgents.CreateAgentConfig(ctx, &HostedAgentConfigCreateRequest{
+		Name: "support-agent",
+		ManifestYAML: "apiVersion: agents.digitalocean.com/v1alpha1\n" +
+			"kind: Agent\n" +
+			"spec:\n" +
+			"  secrets:\n" +
+			"    - name: OPENAI_API_KEY\n" +
+			"      source: tenantSecret\n" +
+			"      value: sk-test\n",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	assert.Equal(t, hostedAgentConfig.ID, got.ID)
+}
+
+func TestHostedAgents_DeleteAgentConfig(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/agents/configs/019fb39c-14d9-7080-933e-b9b90e25acda", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	resp, err := client.HostedAgents.DeleteAgentConfig(ctx, hostedAgentConfig.ID)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestHostedAgents_ListAgentConfigSessions(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/agents/configs/019fb39c-14d9-7080-933e-b9b90e25acda/sessions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		assert.Equal(t, "SESSION_STATUS_READY", r.URL.Query().Get("status"))
+		fmt.Fprintf(w, `{"sessions":[%s],"next_page_token":""}`, hostedAgentSessionJSON)
+	})
+
+	got, resp, err := client.HostedAgents.ListAgentConfigSessions(ctx, hostedAgentConfig.ID, &HostedAgentSessionListOptions{
+		Status: HostedAgentSessionStatusReady,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Len(t, got.Sessions, 1)
+	assert.Equal(t, "sess-abc123", got.Sessions[0].SessionID)
+}
+
+func mustMarshal(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
+}

--- a/hosted_agents.go
+++ b/hosted_agents.go
@@ -350,6 +350,11 @@ type HostedAgentSession struct {
 	ParentSessionID string `json:"parent_session_id,omitempty"`
 	// ForkID is a branch label on forked sessions; empty/omitted for roots.
 	ForkID string `json:"fork_id,omitempty"`
+	// ConfigID is the durable Agent Config UUID the session was created from
+	// (inline manifests persist a config too, named after the session).
+	// Returned on create/get/list; omitted for sessions created before config
+	// references were stored.
+	ConfigID string `json:"config_id,omitempty"`
 }
 
 // HostedAgentRun represents a single execution within a session.

--- a/hosted_agents.go
+++ b/hosted_agents.go
@@ -78,6 +78,11 @@ type HostedAgentsService interface {
 	// doctl resolves ${...} placeholders client-side before calling this API;
 	// there is no server-side variables map.
 	CreateSessionFromManifest(context.Context, []byte, *HostedAgentManifestCreateOptions) (*HostedAgentSession, *Response, error)
+	// CreateSessionFromConfig provisions a session from an existing immutable
+	// Agent Config, referenced by config_id. The request uses Content-Type:
+	// application/json with a {name, config_id} body; the config's stored
+	// manifest and declared credentials seed the session at create time.
+	CreateSessionFromConfig(context.Context, *HostedAgentSessionFromConfigRequest) (*HostedAgentSession, *Response, error)
 	ListSessions(context.Context, *HostedAgentSessionListOptions) (*HostedAgentSessionsListResponse, *Response, error)
 	GetSession(context.Context, string) (*HostedAgentSession, *Response, error)
 	DestroySession(context.Context, string) (*Response, error)
@@ -114,6 +119,14 @@ type HostedAgentsService interface {
 	DeleteCheckpoint(context.Context, string, string) (*HostedAgentCheckpointDeleteResponse, *Response, error)
 	ForkSession(context.Context, string, *HostedAgentForkSessionRequest) (*HostedAgentForkSessionResponse, *Response, error)
 	RollbackToCheckpoint(context.Context, string, string) (*HostedAgentSession, *Response, error)
+
+	// Agent Configs (immutable team-scoped agent definitions). Routes live
+	// under /v2/agents/configs.
+	ListAgentConfigs(context.Context, *HostedAgentConfigListOptions) (*HostedAgentConfigsListResponse, *Response, error)
+	GetAgentConfig(context.Context, string) (*HostedAgentConfig, *Response, error)
+	CreateAgentConfig(context.Context, *HostedAgentConfigCreateRequest) (*HostedAgentConfig, *Response, error)
+	DeleteAgentConfig(context.Context, string) (*Response, error)
+	ListAgentConfigSessions(context.Context, string, *HostedAgentSessionListOptions) (*HostedAgentSessionsListResponse, *Response, error)
 }
 
 // HostedAgentsServiceOp handles communication with Hosted Agents session methods.
@@ -453,6 +466,15 @@ type HostedAgentSessionCreateRequest struct {
 	Origin *HostedAgentSessionOriginRequest `json:"origin,omitempty"`
 }
 
+// HostedAgentSessionFromConfigRequest creates a session from an existing
+// immutable Agent Config (POST /v2/agents/sessions with a JSON body). Name is
+// required and becomes the new session name; ConfigID must be the UUID of a
+// config owned by the caller's team.
+type HostedAgentSessionFromConfigRequest struct {
+	Name     string `json:"name"`
+	ConfigID string `json:"config_id"`
+}
+
 // HostedAgentManifestCreateOptions configures CreateSessionFromManifest.
 // OpenAISessionID is sent as the openai_session_id query parameter (not in the
 // YAML body). harness-api persists it for AGENT_KIND_OPENAI_CODEX attach
@@ -774,6 +796,27 @@ func (s *HostedAgentsServiceOp) CreateSessionFromManifest(ctx context.Context, m
 		return nil, nil, err
 	}
 	req, err := s.newCreateSessionPostRequest(ctx, path, bytes.NewReader(manifest), hostedAgentManifestMediaType)
+	if err != nil {
+		return nil, nil, err
+	}
+	return s.doCreateSession(ctx, req)
+}
+
+// CreateSessionFromConfig provisions a session from a durable Agent Config.
+// The JSON {name, config_id} body selects the config-backed create path on the
+// server, which reloads the config's stored manifest and resolves its declared
+// credentials into the new session.
+func (s *HostedAgentsServiceOp) CreateSessionFromConfig(ctx context.Context, create *HostedAgentSessionFromConfigRequest) (*HostedAgentSession, *Response, error) {
+	if create == nil {
+		return nil, nil, errors.New("hosted agents: create request is required")
+	}
+	if create.Name == "" {
+		return nil, nil, errors.New("hosted agents: name is required")
+	}
+	if create.ConfigID == "" {
+		return nil, nil, errors.New("hosted agents: config_id is required")
+	}
+	req, err := s.client.NewRequest(ctx, http.MethodPost, hostedAgentsSessionsBasePath, create)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/hosted_agents_test.go
+++ b/hosted_agents_test.go
@@ -279,6 +279,59 @@ func TestHostedAgents_CreateSessionFromManifest_Empty(t *testing.T) {
 	require.EqualError(t, err, "hosted agents: manifest is required")
 }
 
+func TestHostedAgents_CreateSessionFromConfig(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/agents/sessions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		// The config-backed path is selected by a JSON body carrying only
+		// name + config_id.
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		var body HostedAgentSessionFromConfigRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "session-from-config", body.Name)
+		assert.Equal(t, "019fb39c-14d9-7080-933e-b9b90e25acda", body.ConfigID)
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"session": {
+				"session_id": "sess-cfg",
+				"name": "session-from-config",
+				"team_id": 42,
+				"agent_kind": "AGENT_KIND_OPENCODE",
+				"status": "SESSION_STATUS_PROVISIONING",
+				"created_at": "2026-08-01T12:00:00Z",
+				"last_event_at": "2026-08-01T12:00:00Z"
+			}
+		}`)
+	})
+
+	session, resp, err := client.HostedAgents.CreateSessionFromConfig(ctx, &HostedAgentSessionFromConfigRequest{
+		Name:     "session-from-config",
+		ConfigID: "019fb39c-14d9-7080-933e-b9b90e25acda",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, session)
+	assert.Equal(t, "sess-cfg", session.SessionID)
+	assert.Equal(t, "session-from-config", session.Name)
+}
+
+func TestHostedAgents_CreateSessionFromConfig_Validation(t *testing.T) {
+	setup()
+	defer teardown()
+
+	_, _, err := client.HostedAgents.CreateSessionFromConfig(ctx, nil)
+	require.Error(t, err)
+
+	_, _, err = client.HostedAgents.CreateSessionFromConfig(ctx, &HostedAgentSessionFromConfigRequest{ConfigID: "019fb39c-14d9-7080-933e-b9b90e25acda"})
+	require.Error(t, err)
+
+	_, _, err = client.HostedAgents.CreateSessionFromConfig(ctx, &HostedAgentSessionFromConfigRequest{Name: "session-from-config"})
+	require.Error(t, err)
+}
+
 func TestHostedAgents_CreateSessionFromManifest_OpenAISessionID(t *testing.T) {
 	setup()
 	defer teardown()

--- a/hosted_agents_test.go
+++ b/hosted_agents_test.go
@@ -302,7 +302,8 @@ func TestHostedAgents_CreateSessionFromConfig(t *testing.T) {
 				"agent_kind": "AGENT_KIND_OPENCODE",
 				"status": "SESSION_STATUS_PROVISIONING",
 				"created_at": "2026-08-01T12:00:00Z",
-				"last_event_at": "2026-08-01T12:00:00Z"
+				"last_event_at": "2026-08-01T12:00:00Z",
+				"config_id": "019fb39c-14d9-7080-933e-b9b90e25acda"
 			}
 		}`)
 	})
@@ -316,6 +317,7 @@ func TestHostedAgents_CreateSessionFromConfig(t *testing.T) {
 	require.NotNil(t, session)
 	assert.Equal(t, "sess-cfg", session.SessionID)
 	assert.Equal(t, "session-from-config", session.Name)
+	assert.Equal(t, "019fb39c-14d9-7080-933e-b9b90e25acda", session.ConfigID)
 }
 
 func TestHostedAgents_CreateSessionFromConfig_Validation(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds the Hosted Agents **Agent Configs** client to godo and wires up config-backed session creation, matching the current harness-api REST contracts. Targets `OHS_endpoints`.

- **Agent Configs client** (`hosted_agent_configs.go`): list / get / create / delete configs under `/v2/agents/configs`, plus list-sessions-by-config.
- **Create contract**: the body is `{name, manifest_yaml}` only — credentials are declared inline in the manifest under `spec.secrets` (the retired `secrets` / `oauth_assignments` maps are rejected server-side with a 400). Create returns `201 Created`.
- **Response shape**: `HostedAgentConfig` carries create-time `warnings`; credential slots echo only the manifest declaration (`{name, source, provider}`) — no redundant `configured` flag (kept in sync with the harness-api change removing it).
- **Config-backed session create** (`CreateSessionFromConfig`): posts a JSON `{name, config_id}` body to `POST /v2/agents/sessions`, which selects the server's config-backed path (reloads the stored manifest and resolves declared credentials into the session).

## Test plan

- [x] `go build ./...`
- [x] `go test .` (full package)
- [ ] CI green

Made with [Cursor](https://cursor.com)