### PR TITLE
databases: add Description to DatabaseFirewallRule

### DIFF
--- a/databases.go
+++ b/databases.go
@@ -584,6 +584,7 @@ type DatabaseFirewallRule struct {
 	ClusterUUID string    `json:"cluster_uuid"`
 	Type        string    `json:"type"`
 	Value       string    `json:"value"`
+	Description string    `json:"description,omitempty"`
 	CreatedAt   time.Time `json:"created_at"`
 }
 

--- a/databases_test.go
+++ b/databases_test.go
@@ -2214,6 +2214,7 @@ func TestDatabases_GetFirewallRules(t *testing.T) {
 			Value:       "192.168.1.1",
 			UUID:        "deadbeef-dead-4aa5-beef-deadbeef347d",
 			ClusterUUID: "deadbeef-dead-4aa5-beef-deadbeef347d",
+			Description: "an IP address for local development",
 		},
 	}
 
@@ -2221,7 +2222,8 @@ func TestDatabases_GetFirewallRules(t *testing.T) {
 		"type": "ip_addr",
 		"value": "192.168.1.1",
 		"uuid": "deadbeef-dead-4aa5-beef-deadbeef347d",
-		"cluster_uuid": "deadbeef-dead-4aa5-beef-deadbeef347d"
+		"cluster_uuid": "deadbeef-dead-4aa5-beef-deadbeef347d",
+		"description": "an IP address for local development"
 	}]} `
 
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

`DatabaseFirewallRule` is missing the `description` field that the database firewall API both returns and accepts ([spec](https://github.com/digitalocean/openapi/blob/main/specification/resources/databases/models/firewall_rule.yml)).

Because `PUT /v2/databases/{id}/firewall` replaces the entire rule set, any client that reads the existing rules and writes them back — the only way to add or remove a single rule — silently discards the descriptions of every rule it did not touch.

This is what causes digitalocean/doctl#1869: `doctl databases firewalls append` wipes the descriptions of the rules that were already there, since godo never decoded them in the first place.

## Change

Adds `Description string \`json:"description,omitempty"\`` to `DatabaseFirewallRule` and extends the `GetFirewallRules` test fixture to cover it.

`omitempty` keeps the request body unchanged for callers that do not set a description.

## Testing

`go test ./...` passes.
