### PR TITLE
hosted agents: let rotate-secret revoke the outgoing webhook secret (MARSOHS-1078)

### DIFF
--- a/hosted_agent_triggers.go
+++ b/hosted_agent_triggers.go
@@ -27,7 +27,7 @@ type HostedAgentTriggersService interface {
 	Get(context.Context, string) (*HostedAgentTrigger, *Response, error)
 	Update(context.Context, string, *HostedAgentTriggerUpdateRequest) (*HostedAgentTrigger, *Response, error)
 	Delete(context.Context, string) (*Response, error)
-	RotateSecret(context.Context, string) (*HostedAgentTriggerRotateSecretResponse, *Response, error)
+	RotateSecret(context.Context, string, *HostedAgentTriggerRotateSecretOptions) (*HostedAgentTriggerRotateSecretResponse, *Response, error)
 	ListExecutions(context.Context, string, *HostedAgentTriggerExecutionListOptions) (*HostedAgentTriggerExecutionsListResponse, *Response, error)
 	GetExecution(context.Context, string, string) (*HostedAgentTriggerExecution, *Response, error)
 	GetBySession(context.Context, string) (*HostedAgentTrigger, *Response, error)
@@ -214,9 +214,26 @@ type HostedAgentTriggersListResponse struct {
 	NextPageToken string               `json:"next_page_token,omitempty"`
 }
 
+// HostedAgentTriggerRotateSecretOptions specifies optional rotation behaviour.
+// The zero value (or a nil pointer) selects the server default, which keeps the
+// outgoing secret verifying for a short grace window.
+type HostedAgentTriggerRotateSecretOptions struct {
+	// RevokePrevious retires the outgoing secret on this call instead of at the
+	// end of the grace window. Intended for a compromised secret: deliveries
+	// still signed with the old value start failing immediately.
+	RevokePrevious bool `url:"revoke_previous,omitempty"`
+}
+
 // HostedAgentTriggerRotateSecretResponse is returned by RotateSecret.
+// Exactly one of PreviousSecretExpiresAt and PreviousSecretRevoked is set, so a
+// caller never has to infer the outcome from a missing field.
 type HostedAgentTriggerRotateSecretResponse struct {
 	WebhookSecret string `json:"webhook_secret,omitempty"`
+	// PreviousSecretExpiresAt is when the outgoing secret stops verifying
+	// deliveries. Nil when the secret was revoked on the rotate call.
+	PreviousSecretExpiresAt *Timestamp `json:"previous_secret_expires_at,omitempty"`
+	// PreviousSecretRevoked reports that the outgoing secret is already dead.
+	PreviousSecretRevoked bool `json:"previous_secret_revoked,omitempty"`
 }
 
 // HostedAgentTriggerExecution is one row per firing.
@@ -393,11 +410,18 @@ func (s *HostedAgentTriggersServiceOp) Delete(ctx context.Context, triggerID str
 }
 
 // RotateSecret issues a new webhook secret (webhook triggers only).
-func (s *HostedAgentTriggersServiceOp) RotateSecret(ctx context.Context, triggerID string) (*HostedAgentTriggerRotateSecretResponse, *Response, error) {
+// By default the outgoing secret keeps verifying deliveries for a short
+// server-configured window, and PreviousSecretExpiresAt reports when it dies;
+// set opt.RevokePrevious to retire it on this call instead.
+func (s *HostedAgentTriggersServiceOp) RotateSecret(ctx context.Context, triggerID string, opt *HostedAgentTriggerRotateSecretOptions) (*HostedAgentTriggerRotateSecretResponse, *Response, error) {
 	if triggerID == "" {
 		return nil, nil, errors.New("hosted agent triggers: trigger id is required")
 	}
 	path := fmt.Sprintf(hostedAgentTriggerRotateSecretPath, triggerID)
+	path, err := addOptions(path, opt)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest(ctx, http.MethodPost, path, struct{}{})
 	if err != nil {
 		return nil, nil, err

--- a/hosted_agent_triggers_test.go
+++ b/hosted_agent_triggers_test.go
@@ -344,12 +344,34 @@ func TestHostedAgentTriggers_RotateSecret(t *testing.T) {
 
 	mux.HandleFunc("/v2/agents/triggers/trig-abc123/rotate-secret", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
-		fmt.Fprint(w, `{"webhook_secret":"whsec_rotated"}`)
+		assert.Empty(t, r.URL.Query().Get("revoke_previous"), "the default rotate must not ask for revocation")
+		fmt.Fprint(w, `{"webhook_secret":"whsec_rotated","previous_secret_expires_at":"2026-07-01T12:05:00Z"}`)
 	})
 
-	got, resp, err := client.HostedAgentTriggers.RotateSecret(ctx, "trig-abc123")
+	got, resp, err := client.HostedAgentTriggers.RotateSecret(ctx, "trig-abc123", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "whsec_rotated", got.WebhookSecret)
+	require.NotNil(t, got.PreviousSecretExpiresAt)
+	assert.Equal(t, time.Date(2026, 7, 1, 12, 5, 0, 0, time.UTC), got.PreviousSecretExpiresAt.UTC())
+	assert.False(t, got.PreviousSecretRevoked)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestHostedAgentTriggers_RotateSecret_RevokePrevious(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/agents/triggers/trig-abc123/rotate-secret", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		assert.Equal(t, "true", r.URL.Query().Get("revoke_previous"))
+		fmt.Fprint(w, `{"webhook_secret":"whsec_rotated","previous_secret_revoked":true}`)
+	})
+
+	got, resp, err := client.HostedAgentTriggers.RotateSecret(ctx, "trig-abc123", &HostedAgentTriggerRotateSecretOptions{RevokePrevious: true})
+	require.NoError(t, err)
+	assert.Equal(t, "whsec_rotated", got.WebhookSecret)
+	assert.True(t, got.PreviousSecretRevoked)
+	assert.Nil(t, got.PreviousSecretExpiresAt, "there is no expiry to report when the old secret is already dead")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 

--- a/hosted_agent_triggers_test.go
+++ b/hosted_agent_triggers_test.go
@@ -357,6 +357,34 @@ func TestHostedAgentTriggers_RotateSecret(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
+// A non-nil options struct with RevokePrevious unset must be indistinguishable
+// on the wire from passing nil. This is what the `omitempty` tag buys, and
+// without it a caller building options programmatically would send
+// revoke_previous=false and depend on the server parsing it.
+func TestHostedAgentTriggers_RotateSecret_ExplicitFalseOmitsParam(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/agents/triggers/trig-abc123/rotate-secret", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		assert.Empty(t, r.URL.RawQuery, "an unset RevokePrevious must put nothing on the wire")
+		fmt.Fprint(w, `{"webhook_secret":"whsec_rotated","previous_secret_expires_at":"2026-07-01T12:05:00Z"}`)
+	})
+
+	got, _, err := client.HostedAgentTriggers.RotateSecret(ctx, "trig-abc123", &HostedAgentTriggerRotateSecretOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "whsec_rotated", got.WebhookSecret)
+	assert.False(t, got.PreviousSecretRevoked)
+}
+
+func TestHostedAgentTriggers_RotateSecret_RequiresTriggerID(t *testing.T) {
+	setup()
+	defer teardown()
+
+	_, _, err := client.HostedAgentTriggers.RotateSecret(ctx, "", nil)
+	require.Error(t, err, "an empty id would POST to the collection path instead of a trigger")
+}
+
 func TestHostedAgentTriggers_RotateSecret_RevokePrevious(t *testing.T) {
 	setup()
 	defer teardown()

--- a/hosted_agent_triggers_test.go
+++ b/hosted_agent_triggers_test.go
@@ -403,6 +403,29 @@ func TestHostedAgentTriggers_RotateSecret_RevokePrevious(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
+// The API sets exactly one of previous_secret_expires_at and
+// previous_secret_revoked. A response carrying neither should therefore not
+// happen — but if it does (an older server, a proxy dropping a field) the
+// decode must leave both at their zero values rather than letting a caller read
+// the missing expiry as proof of revocation. doctl renders these two fields as
+// "the old secret is dead" versus "it dies at T", so a wrong default here is an
+// operator being told a live secret is safe.
+func TestHostedAgentTriggers_RotateSecret_NeitherOutcomeField(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/agents/triggers/trig-abc123/rotate-secret", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		fmt.Fprint(w, `{"webhook_secret":"whsec_rotated"}`)
+	})
+
+	got, _, err := client.HostedAgentTriggers.RotateSecret(ctx, "trig-abc123", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "whsec_rotated", got.WebhookSecret)
+	assert.Nil(t, got.PreviousSecretExpiresAt)
+	assert.False(t, got.PreviousSecretRevoked, "an absent field is not a revocation")
+}
+
 func TestHostedAgentTriggers_ListExecutions(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
## Summary

`RotateSecret` today can only ask for the default rotation, and the response only carries the new secret. Two gaps fall out of that:

- **No way to revoke.** Rotation keeps the outgoing secret verifying for a short grace window so in-flight deliveries survive the handoff — the provider side holds one secret at a time (a GitHub webhook has a single `Secret` field), so it keeps signing with the old value until a human pastes the new one in. That is the right default for routine rotation and the wrong one for a *leaked* secret, where the point is to kill the old value now. `MARSOHS-1078` filed the missing emergency path as a P1.
- **No way to tell what happened.** The caller can't distinguish "old secret dies at 12:05" from "old secret is already dead", which is exactly what an operator responding to a leak needs to know.

This adds both, additively — the default is unchanged.

```go
// routine rotation: grace window, unchanged behaviour
got, _, err := c.HostedAgentTriggers.RotateSecret(ctx, triggerID, nil)
got.PreviousSecretExpiresAt // when the old secret stops verifying

// breach response: retire the outgoing secret on this call
got, _, err = c.HostedAgentTriggers.RotateSecret(ctx, triggerID,
    &godo.HostedAgentTriggerRotateSecretOptions{RevokePrevious: true})
got.PreviousSecretRevoked // true; PreviousSecretExpiresAt is nil
```

Exactly one of `PreviousSecretExpiresAt` and `PreviousSecretRevoked` is set, so a caller never has to infer the outcome from a missing field.

## Notes for review

- **Signature change** to `RotateSecret`. It takes `*HostedAgentTriggerRotateSecretOptions` rather than a bare `bool`, matching how `List`, `ListExecutions`, and `ListReusableSessions` already take an options pointer in this file and routing through `addOptions` like they do. `nil` means "server defaults", which maps onto grace-is-the-default. This surface is only on `OHS_endpoints` and the beta tags — it has never shipped on `main` — so the break is pre-GA, and taking it now avoids a second one when the next knob shows up.
- `RevokePrevious` is `url:"revoke_previous,omitempty"`, so the default rotate sends no query parameter at all. Both tests assert on the wire.

## Related

- Server side: `digitalocean/cthulhu#172453` (harness-trigger — `?revoke_previous=true`, plus a cleaner sweep that nulls the expired ciphertext).
- Consumer: `digitalocean/doctl#1922` (`doctl agents triggers rotate-secret --revoke-previous`), which is waiting on this to land so it can bump the dependency instead of carrying a vendor patch.

## Test plan

- [x] `go build ./...`
- [x] `go test . -run HostedAgentTriggers` — `TestHostedAgentTriggers_RotateSecret` (asserts no `revoke_previous` on the wire, parses the expiry) and `TestHostedAgentTriggers_RotateSecret_RevokePrevious` (asserts `revoke_previous=true`, nil expiry) both pass
- [x] `gofmt -l` clean, `go vet` clean

Made with [Cursor](https://cursor.com)