### PR TITLE
hosted agents: replace revoke_previous with grace_period_seconds (MARSOHS-1078)

### DIFF
--- a/hosted_agent_triggers.go
+++ b/hosted_agent_triggers.go
@@ -215,13 +215,14 @@ type HostedAgentTriggersListResponse struct {
 }
 
 // HostedAgentTriggerRotateSecretOptions specifies optional rotation behaviour.
-// The zero value (or a nil pointer) selects the server default, which keeps the
-// outgoing secret verifying for a short grace window.
+// A nil options pointer, or GracePeriodSeconds left nil, selects the server
+// default (5 minutes). Pass a pointer to 0 to revoke the outgoing secret
+// immediately; any positive value is a custom handoff window in seconds
+// (server-enforced max, default 1 hour).
 type HostedAgentTriggerRotateSecretOptions struct {
-	// RevokePrevious retires the outgoing secret on this call instead of at the
-	// end of the grace window. Intended for a compromised secret: deliveries
-	// still signed with the old value start failing immediately.
-	RevokePrevious bool `url:"revoke_previous,omitempty"`
+	// GracePeriodSeconds is how long the outgoing secret keeps verifying.
+	// Nil omits the query parameter (server default). Non-nil 0 revokes now.
+	GracePeriodSeconds *int `url:"grace_period_seconds,omitempty"`
 }
 
 // HostedAgentTriggerRotateSecretResponse is returned by RotateSecret.
@@ -410,9 +411,10 @@ func (s *HostedAgentTriggersServiceOp) Delete(ctx context.Context, triggerID str
 }
 
 // RotateSecret issues a new webhook secret (webhook triggers only).
-// By default the outgoing secret keeps verifying deliveries for a short
-// server-configured window, and PreviousSecretExpiresAt reports when it dies;
-// set opt.RevokePrevious to retire it on this call instead.
+// By default (nil options, or GracePeriodSeconds left nil) the outgoing secret
+// keeps verifying for the server default window (5 minutes) and
+// PreviousSecretExpiresAt reports when it dies. Pass GracePeriodSeconds pointing
+// at 0 to revoke it on this call, or at a positive value for a custom window.
 func (s *HostedAgentTriggersServiceOp) RotateSecret(ctx context.Context, triggerID string, opt *HostedAgentTriggerRotateSecretOptions) (*HostedAgentTriggerRotateSecretResponse, *Response, error) {
 	if triggerID == "" {
 		return nil, nil, errors.New("hosted agent triggers: trigger id is required")

--- a/hosted_agent_triggers_test.go
+++ b/hosted_agent_triggers_test.go
@@ -344,7 +344,7 @@ func TestHostedAgentTriggers_RotateSecret(t *testing.T) {
 
 	mux.HandleFunc("/v2/agents/triggers/trig-abc123/rotate-secret", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
-		assert.Empty(t, r.URL.Query().Get("revoke_previous"), "the default rotate must not ask for revocation")
+		assert.Empty(t, r.URL.Query().Get("grace_period_seconds"), "the default rotate must omit grace_period_seconds")
 		fmt.Fprint(w, `{"webhook_secret":"whsec_rotated","previous_secret_expires_at":"2026-07-01T12:05:00Z"}`)
 	})
 
@@ -357,17 +357,17 @@ func TestHostedAgentTriggers_RotateSecret(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
-// A non-nil options struct with RevokePrevious unset must be indistinguishable
-// on the wire from passing nil. This is what the `omitempty` tag buys, and
-// without it a caller building options programmatically would send
-// revoke_previous=false and depend on the server parsing it.
-func TestHostedAgentTriggers_RotateSecret_ExplicitFalseOmitsParam(t *testing.T) {
+// A non-nil options struct with GracePeriodSeconds unset must be indistinguishable
+// on the wire from passing nil. This is what the `omitempty` tag on the pointer
+// buys, and without it a caller building options programmatically would send
+// grace_period_seconds=0 and revoke by accident.
+func TestHostedAgentTriggers_RotateSecret_NilGraceOmitsParam(t *testing.T) {
 	setup()
 	defer teardown()
 
 	mux.HandleFunc("/v2/agents/triggers/trig-abc123/rotate-secret", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
-		assert.Empty(t, r.URL.RawQuery, "an unset RevokePrevious must put nothing on the wire")
+		assert.Empty(t, r.URL.RawQuery, "a nil GracePeriodSeconds must put nothing on the wire")
 		fmt.Fprint(w, `{"webhook_secret":"whsec_rotated","previous_secret_expires_at":"2026-07-01T12:05:00Z"}`)
 	})
 
@@ -385,22 +385,41 @@ func TestHostedAgentTriggers_RotateSecret_RequiresTriggerID(t *testing.T) {
 	require.Error(t, err, "an empty id would POST to the collection path instead of a trigger")
 }
 
-func TestHostedAgentTriggers_RotateSecret_RevokePrevious(t *testing.T) {
+func TestHostedAgentTriggers_RotateSecret_ZeroGraceRevokes(t *testing.T) {
 	setup()
 	defer teardown()
 
 	mux.HandleFunc("/v2/agents/triggers/trig-abc123/rotate-secret", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
-		assert.Equal(t, "true", r.URL.Query().Get("revoke_previous"))
+		assert.Equal(t, "0", r.URL.Query().Get("grace_period_seconds"))
 		fmt.Fprint(w, `{"webhook_secret":"whsec_rotated","previous_secret_revoked":true}`)
 	})
 
-	got, resp, err := client.HostedAgentTriggers.RotateSecret(ctx, "trig-abc123", &HostedAgentTriggerRotateSecretOptions{RevokePrevious: true})
+	zero := 0
+	got, resp, err := client.HostedAgentTriggers.RotateSecret(ctx, "trig-abc123", &HostedAgentTriggerRotateSecretOptions{GracePeriodSeconds: &zero})
 	require.NoError(t, err)
 	assert.Equal(t, "whsec_rotated", got.WebhookSecret)
 	assert.True(t, got.PreviousSecretRevoked)
 	assert.Nil(t, got.PreviousSecretExpiresAt, "there is no expiry to report when the old secret is already dead")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestHostedAgentTriggers_RotateSecret_CustomGrace(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/agents/triggers/trig-abc123/rotate-secret", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		assert.Equal(t, "90", r.URL.Query().Get("grace_period_seconds"))
+		fmt.Fprint(w, `{"webhook_secret":"whsec_rotated","previous_secret_expires_at":"2026-07-01T12:01:30Z"}`)
+	})
+
+	secs := 90
+	got, _, err := client.HostedAgentTriggers.RotateSecret(ctx, "trig-abc123", &HostedAgentTriggerRotateSecretOptions{GracePeriodSeconds: &secs})
+	require.NoError(t, err)
+	assert.Equal(t, "whsec_rotated", got.WebhookSecret)
+	require.NotNil(t, got.PreviousSecretExpiresAt)
+	assert.False(t, got.PreviousSecretRevoked)
 }
 
 // The API sets exactly one of previous_secret_expires_at and


### PR DESCRIPTION
## Summary

Replaces `RevokePrevious` with `GracePeriodSeconds *int` on `RotateSecret`, matching the server contract in cthulhu#172453.

| Call | Wire | Outcome |
|---|---|---|
| `nil` / unset | no query param | server 5m default |
| `&0` | `grace_period_seconds=0` | immediate revoke |
| `&N` | `grace_period_seconds=N` | custom window (server max 1h) |

`*int` is required so `0` is sent (a bare `int` with `omitempty` would drop it).

## Related

- Server: digitalocean/cthulhu#172453
- pydo / doctl follow-ups in parallel

## Test plan

- [x] `go test . -run HostedAgentTriggers_RotateSecret`
- [x] Wire assertions for omit / `0` / custom `90`

Made with [Cursor](https://cursor.com)