### PR TITLE
hosted agents: decode session create warnings (MARSOHS-1019)

### DIFF
--- a/hosted_agents.go
+++ b/hosted_agents.go
@@ -360,6 +360,10 @@ type HostedAgentSession struct {
 	// Returned on create/get/list; omitted for sessions created before config
 	// references were stored.
 	ConfigID string `json:"config_id,omitempty"`
+	// Warnings carries non-fatal create-time advisories from the server
+	// (manifest parse + policy fidelity). Populated on the create response
+	// only; omitted on get/list.
+	Warnings []string `json:"warnings,omitempty"`
 }
 
 // HostedAgentRun represents a single execution within a session.

--- a/hosted_agents_test.go
+++ b/hosted_agents_test.go
@@ -260,6 +260,24 @@ func TestHostedAgentSession_IgnoresServerTeamID(t *testing.T) {
 	assert.Equal(t, HostedAgentSessionStatusReady, session.Status)
 }
 
+func TestHostedAgentSession_DecodesWarnings(t *testing.T) {
+	const sessionJSON = `{
+		"session_id": "sess-warn",
+		"agent_kind": "AGENT_KIND_CODEX_CLI",
+		"status": "SESSION_STATUS_READY",
+		"created_at": "2026-08-13T21:01:32Z",
+		"last_event_at": "2026-08-13T21:04:50Z",
+		"warnings": [
+			"policy: bash rule command \"*\" with action ask cannot be enforced by Codex CLI; approval will fall back to coarse approvalPolicy"
+		]
+	}`
+
+	var session HostedAgentSession
+	require.NoError(t, json.Unmarshal([]byte(sessionJSON), &session))
+	require.Len(t, session.Warnings, 1)
+	assert.Contains(t, session.Warnings[0], "command \"*\"")
+}
+
 func TestHostedAgents_CreateSessionFromManifest(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
## Summary

- Add `Warnings []string` to `HostedAgentSession` so clients decode harness-api create-time advisories returned in the `warnings` JSON field on CreateSession responses.
- Mirrors the existing `HostedAgentConfig.Warnings` pattern; field is populated on create only and omitted on get/list.
- Adds `TestHostedAgentSession_DecodesWarnings` to verify JSON unmarshaling of policy fidelity warnings (e.g. bare-wildcard bash `command: "*"` with `action: ask` on Codex CLI).

## Context

Pairs with harness-api changes in [MARSOHS-1019](https://do-internal.atlassian.net/browse/MARSOHS-1019) that surface degraded policy rules as create-time session warnings. doctl will consume this field once godo is released/vendored.

## Test plan

- [x] `go test . -run TestHostedAgentSession_DecodesWarnings -count=1`
- [ ] After release, bump doctl godo pin and verify `doctl agents run` prints server warnings on stderr after session create

[MARSOHS-1019]: https://do-internal.atlassian.net/browse/MARSOHS-1019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ