### PR TITLE
feat: add OrcaRouter as a first-class OpenAI-compatible client

### DIFF
--- a/godo.go
+++ b/godo.go
@@ -356,14 +356,7 @@ func NewClient(httpClient *http.Client) *Client {
 	batchInferenceURL, _ := url.Parse(defaultBatchInferenceBaseURL)
 	c.BatchInference = &BatchInferenceServiceOp{client: c, baseURL: batchInferenceURL}
 	serverlessInferenceURL, _ := url.Parse(defaultServerlessInferenceBaseURL)
-	t := newInferenceTransport(c, serverlessInferenceURL)
-	c.Chat = &ChatService{Completions: &ChatCompletionService{inferenceTransport: t}}
-	c.Embeddings = &EmbeddingService{inferenceTransport: t}
-	c.ImageGenerations = &ImageGenerationService{inferenceTransport: t}
-	c.Messages = &MessageService{inferenceTransport: t}
-	c.Models = &ModelService{inferenceTransport: t}
-	c.Responses = &ResponseService{inferenceTransport: t}
-	c.AsyncInvocations = &AsyncInvocationService{inferenceTransport: t}
+	newInferenceServices(c, serverlessInferenceURL)
 
 	c.headers = make(map[string]string)
 

--- a/orcarouter.go
+++ b/orcarouter.go
@@ -1,0 +1,53 @@
+package godo
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"golang.org/x/oauth2"
+)
+
+const (
+	// defaultOrcaRouterBaseURL is the OpenAI-compatible gateway endpoint
+	// exposed by OrcaRouter.
+	defaultOrcaRouterBaseURL = "https://api.orcarouter.ai/"
+)
+
+// OrcaRouterClient is a client for OrcaRouter, an OpenAI-compatible AI gateway.
+// It embeds a *Client whose inference services (Chat, Messages, Models,
+// Embeddings, Responses, ...) are resolved against OrcaRouter's endpoint using
+// an OrcaRouter API key.
+//
+// See https://www.orcarouter.ai for more information.
+type OrcaRouterClient struct {
+	*Client
+}
+
+// NewOrcaRouterClient returns a client for OrcaRouter's OpenAI-compatible
+// gateway. apiKey is an OrcaRouter API key. The caller may pass additional
+// ClientOpt values, for example WithRetryAndBackoffs to enable automatic
+// retries or SetBaseURL to target a self-hosted OrcaRouter instance.
+func NewOrcaRouterClient(apiKey string, opts ...ClientOpt) (*OrcaRouterClient, error) {
+	cleanKey := strings.TrimSpace(apiKey)
+	if cleanKey == "" {
+		return nil, errors.New("orcarouter: api key is required")
+	}
+
+	ctx := context.Background()
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: cleanKey})
+	oauthClient := oauth2.NewClient(ctx, ts)
+
+	client, err := New(oauthClient, append([]ClientOpt{
+		SetBaseURL(defaultOrcaRouterBaseURL),
+	}, opts...)...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Point the shared OpenAI-compatible inference services at OrcaRouter's
+	// endpoint instead of DigitalOcean's Serverless Inference API.
+	newInferenceServices(client, client.BaseURL)
+
+	return &OrcaRouterClient{Client: client}, nil
+}

--- a/orcarouter_test.go
+++ b/orcarouter_test.go
@@ -1,0 +1,157 @@
+package godo
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNewOrcaRouterClient_Validation(t *testing.T) {
+	if _, err := NewOrcaRouterClient(""); err == nil {
+		t.Fatal("NewOrcaRouterClient with empty key: want error, got nil")
+	}
+	if _, err := NewOrcaRouterClient("   "); err == nil {
+		t.Fatal("NewOrcaRouterClient with blank key: want error, got nil")
+	}
+}
+
+func TestOrcaRouterClient_ChatCompletionsAndModels(t *testing.T) {
+	const (
+		apiKey = "orcarouter_api_key_xyz"
+		model  = "orcarouter/fusion"
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/chat/completions", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer "+apiKey {
+			http.Error(w, fmt.Sprintf("bad auth header %q", got), http.StatusUnauthorized)
+			return
+		}
+
+		var body ChatCompletionNewParams
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if body.Model != model {
+			http.Error(w, fmt.Sprintf("bad model %q", body.Model), http.StatusBadRequest)
+			return
+		}
+
+		if body.Stream != nil && *body.Stream {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, "data: %s\n\n", `{"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"}}]}`)
+			fmt.Fprintf(w, "data: %s\n\n", `{"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":" world"}}]}`)
+			fmt.Fprintf(w, "data: [DONE]\n\n")
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(ChatCompletion{
+			ID:     "chatcmpl-orc-123",
+			Object: "chat.completion",
+			Model:  model,
+			Choices: []ChatCompletionChoice{
+				{
+					Index:        0,
+					FinishReason: "stop",
+					Message: ChatCompletionMessage{
+						Role:    "assistant",
+						Content: PtrTo("Hello from OrcaRouter"),
+					},
+				},
+			},
+			Usage: &ChatCompletionUsage{
+				PromptTokens:     1,
+				CompletionTokens: 2,
+				TotalTokens:      3,
+			},
+		})
+	})
+
+	mux.HandleFunc("/v1/models", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer "+apiKey {
+			http.Error(w, fmt.Sprintf("bad auth header %q", got), http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(ModelList{
+			Object: "list",
+			Data: []InferenceModel{
+				{ID: "orcarouter/fusion", Object: "model", OwnedBy: "orcarouter"},
+			},
+		})
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client, err := NewOrcaRouterClient(apiKey, SetBaseURL(srv.URL))
+	if err != nil {
+		t.Fatalf("NewOrcaRouterClient: %v", err)
+	}
+
+	t.Run("non-streaming chat completion", func(t *testing.T) {
+		resp, _, err := client.Chat.Completions.New(context.Background(), &ChatCompletionNewParams{
+			Model: model,
+			Messages: []ChatCompletionMessage{
+				UserMessage("Say hi"),
+			},
+		})
+		if err != nil {
+			t.Fatalf("Chat.Completions.New: %v", err)
+		}
+		if resp.ID != "chatcmpl-orc-123" {
+			t.Fatalf("ID = %q, want chatcmpl-orc-123", resp.ID)
+		}
+		if got := resp.Choices[0].Message.Content; got == nil || *got != "Hello from OrcaRouter" {
+			t.Fatalf("Content = %v, want %q", got, "Hello from OrcaRouter")
+		}
+	})
+
+	t.Run("streaming chat completion", func(t *testing.T) {
+		stream, _, err := client.Chat.Completions.NewStreaming(context.Background(), &ChatCompletionNewParams{
+			Model: model,
+			Messages: []ChatCompletionMessage{
+				UserMessage("Say hi"),
+			},
+		})
+		if err != nil {
+			t.Fatalf("Chat.Completions.NewStreaming: %v", err)
+		}
+		defer stream.Close()
+
+		var got strings.Builder
+		for stream.Next() {
+			ev := stream.Current()
+			if len(ev.Choices) > 0 {
+				got.WriteString(ev.Choices[0].Delta.Content)
+			}
+		}
+		if err := stream.Err(); err != nil {
+			t.Fatalf("stream: %v", err)
+		}
+		if got.String() != "Hello world" {
+			t.Fatalf("streamed text = %q, want %q", got.String(), "Hello world")
+		}
+	})
+
+	t.Run("list models", func(t *testing.T) {
+		models, _, err := client.Models.List(context.Background())
+		if err != nil {
+			t.Fatalf("Models.List: %v", err)
+		}
+		if len(models.Data) != 1 || models.Data[0].ID != "orcarouter/fusion" {
+			t.Fatalf("unexpected models: %+v", models.Data)
+		}
+	})
+}

--- a/serverless_inference.go
+++ b/serverless_inference.go
@@ -32,6 +32,21 @@ func newInferenceTransport(client *Client, baseURL *url.URL) *inferenceTransport
 	return &inferenceTransport{client: client, baseURL: baseURL}
 }
 
+// newInferenceServices wires the shared OpenAI-compatible inference services
+// onto c with requests resolved against baseURL. It is used by NewClient for
+// DigitalOcean's Serverless Inference API and by NewOrcaRouterClient for
+// OrcaRouter's OpenAI-compatible gateway endpoint.
+func newInferenceServices(c *Client, baseURL *url.URL) {
+	t := newInferenceTransport(c, baseURL)
+	c.Chat = &ChatService{Completions: &ChatCompletionService{inferenceTransport: t}}
+	c.Embeddings = &EmbeddingService{inferenceTransport: t}
+	c.ImageGenerations = &ImageGenerationService{inferenceTransport: t}
+	c.Messages = &MessageService{inferenceTransport: t}
+	c.Models = &ModelService{inferenceTransport: t}
+	c.Responses = &ResponseService{inferenceTransport: t}
+	c.AsyncInvocations = &AsyncInvocationService{inferenceTransport: t}
+}
+
 // inferenceTransport is the shared request layer embedded by every inference service.
 type inferenceTransport struct {
 	client  *Client


### PR DESCRIPTION
Add `NewOrcaRouterClient`, a first-class client for OrcaRouter that lets godo users drive OrcaRouter's OpenAI-compatible gateway through the same `Chat`, `Messages`, `Models`, `Embeddings`, and `Responses` services they already use against the Serverless Inference API — without pointing a DigitalOcean client at an anonymous base URL.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a named client means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

This mirrors the existing `NewAgentInferenceClient` pattern: a standalone constructor that builds an authenticated `*Client` and points the shared inference services at OrcaRouter's endpoint. The inference-service wiring in `NewClient` is factored into `newInferenceServices` so both DigitalOcean's Serverless Inference API and OrcaRouter resolve through the same code path.

Changes:
- `orcarouter.go`: `OrcaRouterClient` + `NewOrcaRouterClient(apiKey string, opts ...ClientOpt)`; accepts the same `ClientOpt` values as the rest of godo (e.g. `WithRetryAndBackoffs`, `SetBaseURL` for self-hosted instances).
- `serverless_inference.go`: extract `newInferenceServices` helper.
- `godo.go`: `NewClient` uses the helper; no behavior change.
- `orcarouter_test.go`: httptest coverage for non-streaming/streaming chat completions and model listing.

Verified locally with `go build ./...`, `go vet ./...`, `go test ./...` (all green), plus a live `200` against OrcaRouter's real endpoint using `NewOrcaRouterClient`.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
